### PR TITLE
feat(node): use simple command line instead of executable and args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,12 +126,6 @@
 			"integrity": "sha512-xRas+PW/fM/MoonB+Pawg48bGTjCqJsFUFwZpH/q2oW80AMHGDAUTUqySBnqeQ18e/SNi7NOCf3ZkYOzKm3Pqw==",
 			"dev": true
 		},
-		"@types/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-ZrJDWpvg75LTGX4XwuneY9s6bF3OeZcGTpoGh3zDV9ytzcHMFsRrMIaLBRJZQMBoGyKs6unBQfVdrLZiYfb1zQ==",
-			"dev": true
-		},
 		"@types/ws": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
@@ -839,11 +833,6 @@
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
 			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-		},
 		"js-beautify": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.0.tgz",
@@ -1507,14 +1496,6 @@
 				"tunnel": "0.0.4",
 				"typed-rest-client": "^0.9.0",
 				"underscore": "^1.8.3"
-			}
-		},
-		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"requires": {
-				"isexe": "^2.0.0"
 			}
 		},
 		"wrappy": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "js-beautify": "^1.10.0",
     "source-map": "^0.7.3",
     "vscode-nls": "^4.1.1",
-    "which": "^1.3.1",
     "ws": "^7.0.1"
   },
   "devDependencies": {
@@ -51,7 +50,6 @@
     "@types/js-beautify": "^1.8.1",
     "@types/node": "^8.9.3",
     "@types/vscode": "^1.30.0",
-    "@types/which": "^1.3.1",
     "@types/ws": "^6.0.1",
     "express": "^4.17.1",
     "tslint": "5.11.0",
@@ -288,17 +286,13 @@
                 "type": "string",
                 "description": "Path to source files"
               },
-              "runtimeExecutable": {
+              "command": {
                 "type": "string",
-                "description": "Path to runtime"
+                "description": "Command line to run"
               },
               "cwd": {
                 "type": "string",
                 "description": "Current working directory"
-              },
-              "args": {
-                "type": "array",
-                "description": "Program arguments"
               },
               "env": {
                 "type": "object",

--- a/src/adapterFactory.ts
+++ b/src/adapterFactory.ts
@@ -79,7 +79,7 @@ export class AdapterFactory implements vscode.DebugAdapterDescriptorFactory {
         rootPath = session.workspaceFolder.uri.path;
       const adapter = new DebugAdapter(connection.dap());
       this._sessions.set(session.id, { session, server, adapter });
-      if (session.configuration['runtimeExecutable'])
+      if (session.configuration['command'])
         new NodeDelegate(adapter, rootPath);
       if (session.configuration['url'])
         new BrowserDelegate(adapter, this._context.storagePath || this._context.extensionPath, rootPath);

--- a/src/node/watchdog.ts
+++ b/src/node/watchdog.ts
@@ -62,7 +62,7 @@ process.on('exit', () => {
     if (object.method === 'Target.detachFromTarget') {
       debugLog('DETACH FROM TARGET');
       if (target)
-        target.close()
+        target.close();
       else
         debugLog('DETACH WITHOUT ATTACH');
       target = undefined;


### PR DESCRIPTION
drive-by: fixing onexit node cleanups