### PR TITLE
feat(attach): separate BrowserAttacher from BrowserLauncher

### DIFF
--- a/src/adapterFactory.ts
+++ b/src/adapterFactory.ts
@@ -12,6 +12,7 @@ import DapConnection from './dap/connection';
 import { SessionManager } from './sessionManager';
 import { BrowserLauncher } from './targets/browser/browserLauncher';
 import { NodeLauncher } from './targets/node/nodeLauncher';
+import { BrowserAttacher } from './targets/browser/browserAttacher';
 
 export class Session implements vscode.Disposable {
   private _server: net.Server;
@@ -32,7 +33,8 @@ export class Session implements vscode.Disposable {
       if (binderDelegate) {
         const launchers = [
           new NodeLauncher(this._debugAdapter.sourceContainer.rootPath),
-          new BrowserLauncher(context.storagePath || context.extensionPath, this._debugAdapter.sourceContainer.rootPath)
+          new BrowserLauncher(context.storagePath || context.extensionPath, this._debugAdapter.sourceContainer.rootPath),
+          new BrowserAttacher(this._debugAdapter.sourceContainer.rootPath),
         ];
         this._binder = new Binder(binderDelegate, this._debugAdapter, launchers, debugSession.id);
       }

--- a/src/targets/browser/browserAttacher.ts
+++ b/src/targets/browser/browserAttacher.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import CdpConnection from '../../cdp/connection';
+import * as launcher from './launcher';
+import { BrowserTarget, BrowserTargetManager } from './browserTargets';
+import { Target, Launcher } from '../targets';
+import { BrowserSourcePathResolver } from './browserPathResolver';
+import { baseURL, LaunchParams } from './browserLaunchParams';
+
+export class BrowserAttacher implements Launcher {
+  private _rootPath: string | undefined;
+  private _attemptTimer: NodeJS.Timer | undefined;
+  private _connection: CdpConnection | undefined;
+  private _targetManager: BrowserTargetManager | undefined;
+  private _launchParams: LaunchParams | undefined;
+  private _targetOrigin: any;
+  private _disposables: vscode.Disposable[] = [];
+  private _onTerminatedEmitter = new vscode.EventEmitter<void>();
+  readonly onTerminated = this._onTerminatedEmitter.event;
+  private _onTargetListChangedEmitter = new vscode.EventEmitter<void>();
+  readonly onTargetListChanged = this._onTargetListChangedEmitter.event;
+
+  constructor(rootPath: string | undefined) {
+    this._rootPath = rootPath;
+  }
+
+  targetManager(): BrowserTargetManager | undefined {
+    return this._targetManager;
+  }
+
+  dispose() {
+    for (const disposable of this._disposables)
+      disposable.dispose();
+    this._disposables = [];
+    if (this._attemptTimer)
+      clearTimeout(this._attemptTimer);
+    if (this._targetManager)
+      this._targetManager.dispose();
+  }
+
+  async launch(params: any, targetOrigin: any): Promise<boolean> {
+    if (!('remoteDebuggingPort' in params))
+      return false;
+
+    this._launchParams = params;
+    this._targetOrigin = targetOrigin;
+    this._attemptToAttach();
+    return false;  // Do not block session on termination.
+  }
+
+  _scheduleAttach() {
+    this._attemptTimer = setTimeout(() => {
+      this._attemptTimer = undefined;
+      this._attemptToAttach();
+    }, 1000);
+  }
+
+  async _attemptToAttach() {
+    const params = this._launchParams!;
+    let connection: CdpConnection | undefined;
+    try {
+      connection = await launcher.attach({ browserURL: `http://localhost:${params.remoteDebuggingPort}` });
+    } catch (e) {
+    }
+    if (!connection) {
+      this._scheduleAttach();
+      return;
+    }
+
+    this._connection = connection;
+    connection.onDisconnected(() => {
+      this._connection = undefined;
+      if (this._targetManager) {
+        this._targetManager.dispose();
+        this._targetManager = undefined;
+        this._onTargetListChangedEmitter.fire();
+      }
+      if (this._launchParams)
+        this._scheduleAttach();
+    }, undefined, this._disposables);
+
+    const pathResolver = new BrowserSourcePathResolver(baseURL(params), params.webRoot || this._rootPath);
+    this._targetManager = await BrowserTargetManager.connect(connection, pathResolver, this._targetOrigin);
+    if (!this._targetManager)
+      return;
+
+    this._targetManager.serviceWorkerModel.onDidChange(() => this._onTargetListChangedEmitter.fire());
+    this._targetManager.frameModel.onFrameNavigated(() => this._onTargetListChangedEmitter.fire());
+    this._targetManager.onTargetAdded((target: BrowserTarget) => {
+      this._onTargetListChangedEmitter.fire();
+    });
+    this._targetManager.onTargetRemoved((target: BrowserTarget) => {
+      this._onTargetListChangedEmitter.fire();
+    });
+    this._targetManager.waitForMainTarget();
+  }
+
+  async terminate(): Promise<void> {
+    this._launchParams = undefined;
+    if (this._connection)
+      this._connection.close();
+  }
+
+  async disconnect(): Promise<void> {
+  }
+
+  async restart(): Promise<void> {
+  }
+
+  targetList(): Target[] {
+    const manager = this.targetManager();
+    return manager ? manager.targetList() : [];
+  }
+}

--- a/src/targets/browser/browserLaunchParams.ts
+++ b/src/targets/browser/browserLaunchParams.ts
@@ -2,9 +2,34 @@
 // Licensed under the MIT license.
 
 import Dap from "../../dap/api";
+import { URL } from "url";
 
 export interface LaunchParams extends Dap.LaunchParams {
   url?: string;
-  remoteDebuggingPort?: string,
+  remoteDebuggingPort?: string;
+  baseURL?: string;
   webRoot?: string;
 }
+
+export function baseURL(params: LaunchParams): URL | undefined {
+  if (params.baseURL) {
+    try {
+      return new URL(params.baseURL);
+    } catch (e) {
+    }
+  }
+
+  if (params.url) {
+    try {
+      const baseUrl = new URL(params.url);
+      baseUrl.pathname = '/';
+      baseUrl.search = '';
+      baseUrl.hash = '';
+      if (baseUrl.protocol === 'data:')
+        return undefined;
+      return baseUrl;
+    } catch (e) {
+    }
+  }
+}
+

--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -45,17 +45,14 @@ export class NodeLauncher implements Launcher {
     this._pathResolver = new NodeSourcePathResolver();
   }
 
-  canLaunch(params: any): boolean {
-    return 'command' in params;
-  }
-
-  async launch(params: any, targetOrigin: any): Promise<void> {
-    if (!this.canLaunch(params))
-      return;
+  async launch(params: any, targetOrigin: any): Promise<boolean> {
+    if (!('command' in params))
+      return false;
     this._launchParams = params as LaunchParams;
     this._targetOrigin = targetOrigin;
     await this._startServer();
     await this._relaunch();
+    return true;  // Block session on termination.
   }
 
   async _relaunch() {

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -32,8 +32,8 @@ export interface Target {
 }
 
 export interface Launcher extends Disposable {
-  canLaunch(params: any): boolean;
-  launch(params: any, targetOrigin: any): Promise<void>;
+  // If returns true, session should be blocked on the launcher termination.
+  launch(params: any, targetOrigin: any): Promise<boolean>;
   terminate(): Promise<void>;
   disconnect(): Promise<void>;
   restart(): Promise<void>;


### PR DESCRIPTION
BrowserAttacher keeps reattaching to specified remote debugging port
and does not assume ownership over the browser. Browser can be restarted
externally, e.g. using "restart session" button, and BrowserAttacher
will keep reattaching to it.