### PR TITLE
Normalize commands in Windows

### DIFF
--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -76,7 +76,8 @@ export class NodeLauncher implements Launcher {
 
   /** Normalize the command line */
   private _normalizeCommandLine(unnormalizedCommand: string): string {
-    const tokens = unnormalizedCommand.split(' ');
+    // We trim the left spaces to make sure we normalize the first word of the command
+    const tokens = unnormalizedCommand.trimLeft().split(' ');
     tokens[0] = path.normalize(tokens[0]);
     return tokens.join(' ');
   }


### PR DESCRIPTION
Commands such as:
"command": "node_modules/.bin/serve -p 5002",

Don't work on windows.

This new code normalizes it to "command": "node_modules\.bin\serve -p 5002",

So it'll work...