### PR TITLE
fix: ensure bp set completes before updates or pauses

### DIFF
--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -246,10 +246,10 @@ export class DebugAdapter {
     return callback(this._thread);
   }
 
-  _refreshStackTrace() {
+  async _refreshStackTrace() {
     if (!this._thread) return;
     const details = this._thread.pausedDetails();
-    if (details) this._thread.refreshStackTrace();
+    if (details) await this._thread.refreshStackTrace();
   }
 
   _threadNotAvailableError(): Dap.Error {
@@ -328,7 +328,7 @@ export class DebugAdapter {
         localize('error.cannotPrettyPrint', 'Unable to pretty print'),
       );
 
-    this._refreshStackTrace();
+    await this._refreshStackTrace();
     if (params.line) {
       const originalUiLocation: IUiLocation = {
         source,

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -475,16 +475,18 @@ export class Thread implements IVariableStoreDelegate {
     });
   }
 
-  refreshStackTrace() {
-    if (this._pausedDetails) {
-      const event = this._pausedDetailsEvent.get(this._pausedDetails);
-      if (event) {
-        this._pausedDetails = this._createPausedDetails(event);
-      }
-
-      this._onThreadResumed();
-      this._onThreadPaused(this._pausedDetails);
+  async refreshStackTrace() {
+    if (!this._pausedDetails) {
+      return;
     }
+
+    const event = this._pausedDetailsEvent.get(this._pausedDetails);
+    if (event) {
+      this._pausedDetails = this._createPausedDetails(event);
+    }
+
+    this._onThreadResumed();
+    await this._onThreadPaused(this._pausedDetails);
   }
 
   // It is important to produce debug console output in the same order as it happens
@@ -599,7 +601,7 @@ export class Thread implements IVariableStoreDelegate {
     this._pausedDetailsEvent.set(this._pausedDetails, event);
     this._pausedVariables = new VariableStore(this._cdp, this);
     scheduledPauseOnAsyncCall = undefined;
-    this._onThreadPaused(this._pausedDetails);
+    await this._onThreadPaused(this._pausedDetails);
   }
 
   _onResumed() {

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -45,6 +45,7 @@ export interface IPausedDetails {
   reason: PausedReason;
   description: string;
   stackTrace: StackTrace;
+  hitBreakpoints?: string[];
   text?: string;
   exception?: Cdp.Runtime.RemoteObject;
 }
@@ -809,6 +810,7 @@ export class Thread implements IVariableStoreDelegate {
           return {
             thread: this,
             stackTrace,
+            hitBreakpoints: event.hitBreakpoints,
             reason: 'breakpoint',
             description: localize('pause.breakpoint', 'Paused on breakpoint'),
           };
@@ -1157,8 +1159,24 @@ export class Thread implements IVariableStoreDelegate {
     slot(output);
   }
 
-  _onThreadPaused(details: IPausedDetails) {
+  async _onThreadPaused(details: IPausedDetails) {
     this._expectedPauseReason = undefined;
+
+    // If we hit breakpoints, try to make sure they all get resolved before we
+    // send the event to the UI. This should generally only happen if the UI
+    // bulk-set breakpoints and some resolve faster than others, since we expect
+    // the CDP in turn will tell *us* they're resolved before hitting them.
+    if (details.hitBreakpoints) {
+      await Promise.race([
+        delay(1000),
+        Promise.all(
+          details.hitBreakpoints.map(bp =>
+            this._breakpointManager._resolvedBreakpoints.get(bp)?.untilSetCompleted(),
+          ),
+        ),
+      ]);
+    }
+
     this._dap.stopped({
       reason: details.reason,
       description: details.description,

--- a/src/common/promiseUtil.ts
+++ b/src/common/promiseUtil.ts
@@ -7,6 +7,7 @@ export const delay = (duration: number) =>
 export interface IDeferred<T> {
   resolve: (result: T) => void;
   reject: (err: Error) => void;
+  hasSettled(): boolean;
   promise: Promise<T>;
 }
 
@@ -17,11 +18,24 @@ export function getDeferred<T>(): IDeferred<T> {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   let reject: IDeferred<T>['reject'] = null!;
 
+  let settled = false;
+
   // Promise constructor is called synchronously
   const promise = new Promise<T>((_resolve, _reject) => {
-    resolve = _resolve;
-    reject = _reject;
+    resolve = (value: T) => {
+      settled = true;
+      _resolve(value);
+    };
+    reject = (error: Error) => {
+      settled = true;
+      _reject(error);
+    };
   });
 
-  return { resolve, reject, promise };
+  return {
+    resolve,
+    reject,
+    promise,
+    hasSettled: () => settled,
+  };
 }

--- a/src/statistics/breakpointsStatistics.ts
+++ b/src/statistics/breakpointsStatistics.ts
@@ -18,14 +18,13 @@ export class BreakpointsStatisticsCalculator {
   private readonly _statisticsById = new Map<number, BreakpointStatistic>();
 
   public registerBreakpoints(manyBreakpoints: Dap.Breakpoint[]): void {
-    manyBreakpoints
-      .filter(breakpoint => breakpoint.id !== undefined)
-      .forEach(breakpoint => {
+    manyBreakpoints.forEach(breakpoint => {
+      breakpoint.id !== undefined &&
         this._statisticsById.set(
-          breakpoint.id!,
+          breakpoint.id,
           new BreakpointStatistic(breakpoint.verified, false),
         );
-      });
+    });
   }
 
   public registerResolvedBreakpoint(breakpointId: number) {

--- a/src/test/breakpoints/breakpoints-launched-source-map-set-compiled-2.txt
+++ b/src/test/breakpoints/breakpoints-launched-source-map-set-compiled-2.txt
@@ -1,16 +1,13 @@
 Breakpoint resolved: {
-    breakpoint : {
-        column : 5
-        id : <number>
-        line : 36
-        source : {
-            name : bundle.js
-            path : ${workspaceFolder}/web/browserify/bundle.js
-            sourceReference : <number>
-        }
-        verified : true
+    column : 5
+    id : <number>
+    line : 36
+    source : {
+        name : bundle.js
+        path : ${workspaceFolder}/web/browserify/bundle.js
+        sourceReference : <number>
     }
-    reason : changed
+    verified : true
 }
 {
     allThreadsStopped : false

--- a/src/test/breakpoints/breakpoints-launched-source-map-set-compiled.txt
+++ b/src/test/breakpoints/breakpoints-launched-source-map-set-compiled.txt
@@ -1,16 +1,13 @@
 Breakpoint resolved: {
-    breakpoint : {
-        column : 5
-        id : <number>
-        line : 36
-        source : {
-            name : bundle.js
-            path : ${workspaceFolder}/web/browserify/bundle.js
-            sourceReference : <number>
-        }
-        verified : true
+    column : 5
+    id : <number>
+    line : 36
+    source : {
+        name : bundle.js
+        path : ${workspaceFolder}/web/browserify/bundle.js
+        sourceReference : <number>
     }
-    reason : changed
+    verified : true
 }
 {
     allThreadsStopped : false

--- a/src/test/breakpoints/breakpointsTest.ts
+++ b/src/test/breakpoints/breakpointsTest.ts
@@ -5,6 +5,7 @@
 import { TestP } from '../test';
 import Dap from '../../dap/api';
 import { itIntegrates } from '../testIntegrationUtils';
+import { expect } from 'chai';
 
 describe('breakpoints', () => {
   async function waitForPause(p: TestP, cb?: () => Promise<void>) {
@@ -194,8 +195,8 @@ describe('breakpoints', () => {
       const source: Dap.Source = {
         path: p.workspacePath('web/browserify/module2.ts'),
       };
-      p.dap.setBreakpoints({ source, breakpoints: [{ line: 3 }] });
-      await p.dap.once('breakpoint', event => event.breakpoint.verified);
+      const resolved = await p.dap.setBreakpoints({ source, breakpoints: [{ line: 3 }] });
+      expect(resolved.breakpoints[0].verified).to.be.true;
       p.cdp.Runtime.evaluate({
         expression: 'window.callBack(window.pause);\n//# sourceURL=test.js',
       });
@@ -227,10 +228,9 @@ describe('breakpoints', () => {
       const source: Dap.Source = {
         path: p.workspacePath('web/browserify/bundle.js'),
       };
-      p.dap.setBreakpoints({ source, breakpoints: [{ line: 36 }] });
-      const resolved = await p.dap.once('breakpoint', event => !!event.breakpoint.verified);
-      delete resolved.breakpoint.source!.sources;
-      p.log(resolved, 'Breakpoint resolved: ');
+      const resolved = await p.dap.setBreakpoints({ source, breakpoints: [{ line: 36 }] });
+      delete resolved.breakpoints[0].source!.sources;
+      p.log(resolved.breakpoints[0], 'Breakpoint resolved: ');
       p.cdp.Runtime.evaluate({
         expression: 'window.callBack(window.pause);\n//# sourceURL=test.js',
       });
@@ -253,10 +253,9 @@ describe('breakpoints', () => {
       const source: Dap.Source = {
         path: p.workspacePath('web/browserify/bundle.js'),
       };
-      p.dap.setBreakpoints({ source, breakpoints: [{ line: 36 }] });
-      const resolved = await p.dap.once('breakpoint', event => !!event.breakpoint.verified);
-      delete resolved.breakpoint.source!.sources;
-      p.log(resolved, 'Breakpoint resolved: ');
+      const resolved = await p.dap.setBreakpoints({ source, breakpoints: [{ line: 36 }] });
+      delete resolved.breakpoints[0].source!.sources;
+      p.log(resolved.breakpoints[0], 'Breakpoint resolved: ');
       p.cdp.Runtime.evaluate({
         expression: 'window.callBack(window.pause);\n//# sourceURL=test.js',
       });


### PR DESCRIPTION
This is a followup to #169 and the discussion in #162. We now store
a deferred 'set complete' on the breakpoint, which we resolve in a
after returning the set response over DAP. We then guard updates around
this promise and skip sending them if we haven't sent the initial
`setBreakpoints` response yet (the response will contain their full
state with any updates that came in).

Also, if we see that we pause on a breakpoint that we haven't sent
back yet, we'll wait a moment for it to try to be set. I don't _think_
this will ever be hit in VS Code, since it sends all breakpoint
updates individually after the initial configuration, but it's there
regardless and seems to work well.