### PR TITLE
fix: cache source maps to speed up setting

### DIFF
--- a/src/adapter/breakpointPredictor.ts
+++ b/src/adapter/breakpointPredictor.ts
@@ -5,7 +5,6 @@
 import * as path from 'path';
 import Dap from '../dap/api';
 import * as urlUtils from '../common/urlUtils';
-import * as sourceUtils from '../common/sourceUtils';
 import { InlineScriptOffset, ISourcePathResolver } from '../common/sourcePathResolver';
 import { uiToRawOffset } from './sources';
 import { ISourceMapRepository } from '../common/sourceMaps/sourceMapRepository';
@@ -17,6 +16,7 @@ import { logger } from '../common/logging/logger';
 import { LogTag } from '../common/logging';
 import { AnyLaunchConfiguration } from '../configuration';
 import { EventEmitter } from '../common/events';
+import { SourceMapCache } from './sourceMapCache';
 
 // TODO: kNodeScriptOffset and every "+/-1" here are incorrect. We should use "defaultScriptOffset".
 const kNodeScriptOffset: InlineScriptOffset = { lineOffset: 0, columnOffset: 62 };
@@ -54,6 +54,7 @@ export class BreakpointsPredictor {
     private readonly rootPath: string,
     launchConfig: AnyLaunchConfiguration,
     private readonly repo: ISourceMapRepository,
+    private readonly sourceMapCache: SourceMapCache,
     private readonly sourcePathResolver: ISourcePathResolver | undefined,
     private readonly cache: BreakpointPredictionCache | undefined,
   ) {
@@ -101,7 +102,7 @@ export class BreakpointsPredictor {
         return;
       }
 
-      const map = await sourceUtils.loadSourceMap(metadata);
+      const map = await this.sourceMapCache.load(metadata);
       if (!map) {
         return;
       }
@@ -172,7 +173,7 @@ export class BreakpointsPredictor {
         return;
       }
 
-      const map = await sourceUtils.loadSourceMap(metadata);
+      const map = await this.sourceMapCache.load(metadata);
       if (!map) {
         continue;
       }

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -21,6 +21,7 @@ import { BreakpointsPredictor, BreakpointPredictionCache } from './breakpointPre
 import { CorrelatedCache } from '../common/sourceMaps/mtimeCorrelatedCache';
 import { join } from 'path';
 import { IDeferred, getDeferred } from '../common/promiseUtil';
+import { SourceMapCache } from './sourceMapCache';
 
 const localize = nls.loadMessageBundle();
 
@@ -79,14 +80,24 @@ export class DebugAdapter {
     const bpCache: BreakpointPredictionCache | undefined = launchConfig.__workspaceCachePath
       ? new CorrelatedCache(join(launchConfig.__workspaceCachePath, 'bp-predict.json'))
       : undefined;
+    const sourceMapCache = new SourceMapCache();
+    this._disposables.push(sourceMapCache);
     const bpPredictor = rootPath
-      ? new BreakpointsPredictor(rootPath, launchConfig, sourceMapRepo, sourcePathResolver, bpCache)
+      ? new BreakpointsPredictor(
+          rootPath,
+          launchConfig,
+          sourceMapRepo,
+          sourceMapCache,
+          sourcePathResolver,
+          bpCache,
+        )
       : undefined;
 
     bpPredictor?.onLongParse(() => dap.longPrediction({}));
 
     this.sourceContainer = new SourceContainer(
       this.dap,
+      sourceMapCache,
       rootPath,
       sourcePathResolver,
       sourceMapRepo,

--- a/src/adapter/sourceMapCache.ts
+++ b/src/adapter/sourceMapCache.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ISourceMapMetadata, SourceMap } from '../common/sourceMaps/sourceMap';
+import { loadSourceMap } from '../common/sourceUtils';
+import { IDisposable } from '../common/disposable';
+
+/**
+ * A cache of source maps shared between the Thread and Predictor to avoid
+ * duplicate loading.
+ */
+export class SourceMapCache implements IDisposable {
+  private readonly loadedMaps = new Map<string, Promise<SourceMap | undefined>>();
+
+  /**
+   * Loads the provided source map.
+   */
+  public load(metadata: ISourceMapMetadata): Promise<SourceMap | undefined> {
+    const existing = this.loadedMaps.get(metadata.sourceMapUrl);
+    if (existing) {
+      return existing;
+    }
+
+    const created = loadSourceMap(metadata);
+    this.loadedMaps.set(metadata.sourceMapUrl, created);
+    return created;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public dispose() {
+    for (const map of this.loadedMaps.values()) {
+      map.then(m => m?.destroy());
+    }
+
+    this.loadedMaps.clear();
+  }
+}

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -17,6 +17,7 @@ import { SourceMap } from '../common/sourceMaps/sourceMap';
 import { ISourceMapRepository } from '../common/sourceMaps/sourceMapRepository';
 import { MapUsingProjection } from '../common/datastructure/mapUsingProjection';
 import { assert } from '../common/logging/logger';
+import { SourceMapCache } from './sourceMapCache';
 
 const localize = nls.loadMessageBundle();
 
@@ -277,6 +278,7 @@ export class SourceContainer {
 
   constructor(
     dap: Dap.Api,
+    private readonly sourceMapCache: SourceMapCache,
     public readonly rootPath: string | undefined,
     public readonly sourcePathResolver: ISourcePathResolver,
     public readonly localSourceMaps: ISourceMapRepository,
@@ -502,7 +504,7 @@ export class SourceContainer {
     this._sourceMaps.set(sourceMapUrl, sourceMap);
 
     // will log any errors internally:
-    const loaded = await sourceUtils.loadSourceMap({ sourceMapUrl });
+    const loaded = await this.sourceMapCache.load({ sourceMapUrl });
     if (loaded) {
       sourceMap.map = loaded;
     } else {


### PR DESCRIPTION
The old debug adapter took about ~100ms to set a breakpoint. The new one
was taking ~300ms. It turns out the first time you try to resolve a
breakpoint location with a parsed sourcemap, it takes roughly ~200ms,
and roughly ~0ms after that point. We weren't caching sourcemaps,
reparsing them every time we set a breakpoint. The math adds up :)

Fixes #178