### PR TITLE
feat: revamp completion

### DIFF
--- a/src/adapter/completions.ts
+++ b/src/adapter/completions.ts
@@ -7,108 +7,225 @@ import Dap from '../dap/api';
 import Cdp from '../cdp/api';
 import { StackFrame } from './stackTrace';
 import { positionToOffset } from '../common/sourceUtils';
+import { enumeratePropertiesTemplate } from './templates/enumerateProperties';
+
+/**
+ * Context in which a completion is being evaluated.
+ */
+export interface ICompletionContext {
+  cdp: Cdp.Api;
+  executionContextId: number | undefined;
+  stackFrame: StackFrame | undefined;
+}
+
+/**
+ * A completion expresson to be evaluated.
+ */
+export interface ICompletionExpression {
+  expression: string;
+  line: number;
+  column: number;
+}
+
+interface ICompletionWithSort extends Dap.CompletionItem {
+  sortText: string;
+}
+
+/**
+ * Completion kinds known to VS Code. This isn't formally restricted on the DAP.
+ * @see https://github.com/microsoft/vscode/blob/71eb6ad17eaf49a46fd176ca74a083001e17f7de/src/vs/editor/common/modes.ts#L329
+ */
+export const enum CompletionKind {
+  Method = 'method',
+  Function = 'function',
+  Constructor = 'constructor',
+  Field = 'field',
+  Variable = 'variable',
+  Class = 'class',
+  Struct = 'struct',
+  Interface = 'interface',
+  Module = 'module',
+  Property = 'property',
+  Event = 'event',
+  Operator = 'operator',
+  Unit = 'unit',
+  Value = 'value',
+  Constant = 'constant',
+  Enum = 'enum',
+  EnumMember = 'enumMember',
+  Keyword = 'keyword',
+  Snippet = 'snippet',
+  Text = 'text',
+  Color = 'color',
+  File = 'file',
+  Reference = 'reference',
+  Customcolor = 'customcolor',
+  Folder = 'folder',
+  Type = 'type',
+  TypeParameter = 'typeParameter',
+}
+
+/**
+ * Tries to infer the completion kind for the given TypeScript node.
+ */
+const inferCompletionKindForDeclaration = (node: ts.Declaration) => {
+  if (ts.isClassLike(node)) {
+    return CompletionKind.Class;
+  } else if (ts.isMethodDeclaration(node)) {
+    return CompletionKind.Method;
+  } else if (ts.isConstructorDeclaration(node)) {
+    return CompletionKind.Constructor;
+  } else if (ts.isPropertyDeclaration(node)) {
+    return CompletionKind.Property;
+  } else if (ts.isVariableDeclarationList(node)) {
+    return CompletionKind.Variable;
+  } else if (ts.isVariableDeclaration(node)) {
+    return node.initializer && ts.isFunctionLike(node.initializer)
+      ? CompletionKind.Function
+      : CompletionKind.Variable;
+  } else if (ts.isStringLiteral(node)) {
+    return CompletionKind.Text;
+  } else if (ts.isNumericLiteral(node) || ts.isBigIntLiteral(node)) {
+    return CompletionKind.Value;
+  } else if (ts.isInterfaceDeclaration(node)) {
+    return CompletionKind.Interface;
+  } else if (ts.isTypeAliasDeclaration(node)) {
+    return CompletionKind.Interface;
+  } else {
+    return undefined;
+  }
+};
 
 export async function completions(
-  cdp: Cdp.Api,
-  executionContextId: number | undefined,
-  stackFrame: StackFrame | undefined,
-  expression: string,
-  line: number,
-  column: number,
+  options: ICompletionContext & ICompletionExpression,
 ): Promise<Dap.CompletionItem[]> {
   const sourceFile = ts.createSourceFile(
     'test.js',
-    expression,
+    options.expression,
     ts.ScriptTarget.ESNext,
     /*setParentNodes */ true,
   );
 
-  // Find the last expression to autocomplete, in the form of "foo.bar.x|"
-  let prefix: string | undefined;
-  let toevaluate: string | undefined;
-  let quoteBefore = '';
-  let quoteAfter = '';
-  const offset = positionToOffset(expression, line, column);
-  const triggerCharacter = expression[offset - 1];
-  let length = 0;
+  const offset = positionToOffset(options.expression, options.line, options.column);
+  let candidate: () => Promise<ICompletionWithSort[]> = () => Promise.resolve([]);
 
-  function traverse(node: ts.Node) {
-    if (prefix !== undefined) return;
+  ts.forEachChild(sourceFile, function traverse(node: ts.Node) {
     if (node.pos < offset && offset <= node.end) {
-      switch (node.kind) {
-        case ts.SyntaxKind.Identifier: {
-          prefix = node.getText().substring(0, offset - node.getStart());
-          toevaluate = '';
-          break;
-        }
-        case ts.SyntaxKind.ElementAccessExpression: {
-          const ae = node as ts.ElementAccessExpression;
-          prefix = ae.argumentExpression
-            .getText()
-            .substring(0, offset - ae.argumentExpression.getStart());
-          if (prefix.startsWith(`'`) || prefix.startsWith(`"`)) {
-            quoteBefore = '[' + prefix[0];
-            quoteAfter = prefix[0] + ']';
-            prefix = prefix.substr(1);
-            length = prefix.length + 2;
-          } else if (triggerCharacter === `[`) {
-            quoteBefore = `['`;
-            quoteAfter = `']`;
-            length = 1;
-          }
-          toevaluate = ae.expression.getText();
-          break;
-        }
-        case ts.SyntaxKind.PropertyAccessExpression: {
-          const pe = node as ts.PropertyAccessExpression;
-          if (hasSideEffects(pe.expression)) break;
-          prefix = pe.name.getText().substring(0, offset - pe.name.getStart());
-          toevaluate = pe.expression.getText();
-          break;
-        }
+      if (ts.isIdentifier(node)) {
+        candidate = () => identifierCompleter(options, sourceFile, node, offset);
+      } else if (ts.isPropertyAccessExpression(node)) {
+        candidate = () => propertyAccessCompleter(options, node, offset);
+      } else if (ts.isElementAccessExpression(node)) {
+        candidate = () => elementAccessCompleter(options, node, offset);
       }
     }
-    if (prefix === undefined) ts.forEachChild(node, traverse);
-  }
 
-  traverse(sourceFile);
+    ts.forEachChild(node, traverse);
+  });
 
-  if (toevaluate && prefix)
-    return (
-      (await completePropertyAccess(cdp, executionContextId, stackFrame, toevaluate, prefix, {
-        length,
-        quoteBefore,
-        quoteAfter,
-      })) || []
-    );
-
-  // No object to autocomplete on, fallback to globals.
-  for (const global of ['self', 'global', 'this']) {
-    const items = await completePropertyAccess(
-      cdp,
-      executionContextId,
-      stackFrame,
-      global,
-      prefix || '',
-      {},
-    );
-    if (!items) continue;
-
-    if (stackFrame) {
-      // When evaluating on a call frame, also autocomplete with scope variables.
-      const names = new Set(items.map(item => item.label));
-      for (const completion of await stackFrame.completions()) {
-        if (names.has(completion.label)) continue;
-        names.add(completion.label);
-        items.push(completion);
-      }
-    }
-    return items;
-  }
-  return [];
+  return candidate().then(v => v.sort((a, b) => (a.sortText > b.sortText ? 1 : -1)));
 }
 
-type CompletionOptions = { quoteBefore?: string; quoteAfter?: string; length?: number };
+const isDeclarationStatement = (node: ts.Node): node is ts.DeclarationStatement => 'name' in node;
+
+/**
+ * Completer for a TS element access, via bracket syntax.
+ */
+const elementAccessCompleter = async (
+  options: ICompletionContext,
+  node: ts.ElementAccessExpression,
+  offset: number,
+) => {
+  if (!ts.isStringLiteralLike(node.argumentExpression)) {
+    // If this is not a string literal, either they're typing a number (where
+    // autocompletion would be quite silly) or a complex expression where
+    // trying to complete by property name is inappropriate.
+    return [];
+  }
+
+  const prefix = node.argumentExpression
+    .getText()
+    .slice(1, offset - node.argumentExpression.getStart());
+
+  const completions = await defaultCompletions(options, prefix);
+
+  // Filter out the array access, adjust replacement ranges
+  return completions
+    .filter(c => c.sortText !== '~~[')
+    .map(item => ({
+      ...item,
+      text: JSON.stringify(item.text ?? item.label) + ']',
+      start: node.argumentExpression.getStart(),
+      length: node.argumentExpression.getWidth() + 1,
+    }));
+};
+
+/**
+ * Completer for an arbitrary identifier.
+ */
+const identifierCompleter = async (
+  options: ICompletionContext,
+  source: ts.SourceFile,
+  node: ts.Identifier,
+  offset: number,
+) => {
+  // Walk through the expression and look for any locally-declared variables or identifiers.
+  const localIdentifiers: ICompletionWithSort[] = [];
+  ts.forEachChild(source, function transverse(node: ts.Node) {
+    if (!isDeclarationStatement(node)) {
+      ts.forEachChild(node, transverse);
+      return;
+    }
+
+    if (node.name && ts.isIdentifier(node.name)) {
+      localIdentifiers.push({
+        label: node.name.text,
+        type: inferCompletionKindForDeclaration(node),
+        sortText: node.name.text,
+      });
+    }
+  });
+
+  return [
+    ...localIdentifiers,
+    ...(await defaultCompletions(options, node.getText().substring(0, offset - node.getStart()))),
+  ];
+};
+
+/**
+ * Completes a property access on an object.
+ */
+const propertyAccessCompleter = async (
+  options: ICompletionContext,
+  node: ts.PropertyAccessExpression,
+  offset: number,
+): Promise<ICompletionWithSort[]> => {
+  if (hasSideEffects(node.expression)) {
+    return [];
+  }
+
+  const { result, isArray } = await completePropertyAccess(
+    options.cdp,
+    options.executionContextId,
+    options.stackFrame,
+    node.expression.getText(),
+    node.name.text.substring(0, offset - node.name.getStart()),
+  );
+
+  if (isArray) {
+    const start = node.name.getStart() - 1;
+    result.unshift({
+      label: '[index]',
+      text: '[',
+      type: 'property',
+      sortText: '~~[',
+      start,
+      length: 1,
+    });
+  }
+
+  return result;
+};
 
 async function completePropertyAccess(
   cdp: Cdp.Api,
@@ -116,36 +233,14 @@ async function completePropertyAccess(
   stackFrame: StackFrame | undefined,
   expression: string,
   prefix: string,
-  options: CompletionOptions,
-): Promise<Dap.CompletionItem[] | undefined> {
+  isInGlobalScope = false,
+): Promise<{ result: ICompletionWithSort[]; isArray: boolean }> {
   const params = {
-    expression: `
-      (() => {
-        const result = [];
-        const set = new Set();
-        let prefix = '~';
-        for (let object = ${expression}; object; object = object.__proto__) {
-          if (object instanceof Array)
-            return result;
-          prefix += '~';
-          const props = Object.getOwnPropertyNames(object).filter(l => l.startsWith('${prefix}') && !l.match(/\\d/));
-          for (const name of props) {
-            if (set.has(name))
-              continue;
-            set.add(name);
-            const d = Object.getOwnPropertyDescriptor(object, name);
-            const dType = typeof d.value;
-            let type = undefined;
-            if (dType === 'function')
-              type = 'function';
-            else
-              type = 'property';
-            result.push({label: name, sortText: prefix + name, type});
-          }
-        }
-        return result;
-      })();
-    `,
+    expression: enumeratePropertiesTemplate(
+      `(${expression})`,
+      JSON.stringify(prefix),
+      String(isInGlobalScope),
+    ),
     objectGroup: 'console',
     silent: true,
     includeCommandLineAPI: true,
@@ -156,13 +251,11 @@ async function completePropertyAccess(
   const response = callFrameId
     ? await cdp.Debugger.evaluateOnCallFrame({ ...params, callFrameId })
     : await cdp.Runtime.evaluate({ ...params, contextId: executionContextId });
-  if (!response || response.exceptionDetails) return;
+  if (!response || response.exceptionDetails) {
+    return { result: [], isArray: false };
+  }
 
-  return response.result.value.map((item: Dap.CompletionItem) => ({
-    ...item,
-    length: options.length ? options.length : undefined,
-    label: (options.quoteBefore || '') + item.label + (options.quoteAfter || ''),
-  }));
+  return response.result.value;
 }
 
 function hasSideEffects(node: ts.Node): boolean {
@@ -183,4 +276,42 @@ function hasSideEffects(node: ts.Node): boolean {
     ts.forEachChild(node, traverse);
   }
   return result;
+}
+
+/**
+ * Returns completion for globally scoped variables. Used for a fallback
+ * if we can't find anything more specific to complete.
+ */
+async function defaultCompletions(
+  options: ICompletionContext,
+  prefix = '',
+): Promise<ICompletionWithSort[]> {
+  for (const global of ['self', 'global', 'this']) {
+    const { result: items } = await completePropertyAccess(
+      options.cdp,
+      options.executionContextId,
+      options.stackFrame,
+      global,
+      prefix,
+      true,
+    );
+
+    if (!items.length) {
+      continue;
+    }
+
+    if (options.stackFrame) {
+      // When evaluating on a call frame, also autocomplete with scope variables.
+      const names = new Set(items.map(item => item.label));
+      for (const completion of await options.stackFrame.completions()) {
+        if (names.has(completion.label)) continue;
+        names.add(completion.label);
+        items.push(completion as ICompletionWithSort);
+      }
+    }
+
+    return items;
+  }
+
+  return [];
 }

--- a/src/adapter/templates/enumerateProperties.ts
+++ b/src/adapter/templates/enumerateProperties.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import Dap from '../../dap/api';
+import { templateFunction } from './index';
+import { CompletionKind } from '../completions';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Enumerates completion items of the property.
+ */
+export const enumeratePropertiesTemplate = templateFunction(
+  (expression: unknown, prefix: string, isGlobal: boolean) => {
+    const getCompletionKind = (name: string, dtype: string | undefined, value: unknown) => {
+      if (dtype !== 'function') {
+        return isGlobal ? CompletionKind.Variable : CompletionKind.Property;
+      }
+
+      // Say this value is a class if either it stringifies into a native ES6
+      // class declaration, or it's native that starts with a capital letter.
+      // No, there's not really a better way to do this.
+      // https://stackoverflow.com/questions/30758961/how-to-check-if-a-variable-is-an-es6-class-declaration
+      const stringified = String(value);
+      if (
+        stringified.startsWith('class ') ||
+        (stringified.includes('[native code]') && name[0].toUpperCase() === name[0])
+      ) {
+        return CompletionKind.Class;
+      }
+
+      return isGlobal ? CompletionKind.Function : CompletionKind.Method;
+    };
+
+    const result: Dap.CompletionItem[] = [];
+    const discovered = new Set<string>();
+    let sortPrefix = '~';
+
+    for (let object = expression; object != null; object = (object as any).__proto__) {
+      sortPrefix += '~';
+      const props = Object.getOwnPropertyNames(object).filter(
+        l => l.startsWith(prefix) && !l.match(/^\d+$/),
+      );
+
+      for (const name of props) {
+        if (discovered.has(name)) {
+          continue;
+        }
+
+        discovered.add(name);
+        const descriptor = Object.getOwnPropertyDescriptor(object, name);
+        result.push({
+          label: name,
+          sortText: sortPrefix + name,
+          type: getCompletionKind(name, typeof descriptor?.value, (object as any)[name]),
+        });
+      }
+
+      // After we go through the first level of properties and into the
+      // prototype chain, we'll never be in the global scope.
+      isGlobal = false;
+    }
+
+    return { result, isArray: expression instanceof Array };
+  },
+);

--- a/src/adapter/templates/getArrayProperties.ts
+++ b/src/adapter/templates/getArrayProperties.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { remoteFunction } from '.';
+
+/**
+ * Returns non-indexed properties of the array.
+ */
+export const getArrayProperties = remoteFunction(function(this: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = { __proto__: (this as any).__proto__ };
+  const names = Object.getOwnPropertyNames(this);
+  for (let i = 0; i < names.length; ++i) {
+    const name = names[i];
+    const numeric = ((name as unknown) as number) >>> 0;
+    // Array index check according to the ES5-15.4.
+    if (String(numeric >>> 0) === name && numeric >>> 0 !== 0xffffffff) {
+      continue;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(this, name);
+    if (descriptor) {
+      Object.defineProperty(result, name, descriptor);
+    }
+  }
+  return result;
+});

--- a/src/adapter/templates/getArraySlots.ts
+++ b/src/adapter/templates/getArraySlots.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { remoteFunction } from '.';
+
+/**
+ * Returns an object containing array property descriptors for the given
+ * range of array indices.
+ */
+export const getArraySlots = remoteFunction(function(
+  this: unknown[],
+  start: number,
+  count: number,
+) {
+  const result = {};
+  const from = start === -1 ? 0 : start;
+  const to = count === -1 ? this.length : start + count;
+  for (let i = from; i < to && i < this.length; ++i) {
+    const descriptor = Object.getOwnPropertyDescriptor(this, i);
+    if (descriptor) {
+      Object.defineProperty(result, i, descriptor);
+    }
+  }
+
+  return result;
+});

--- a/src/adapter/templates/index.ts
+++ b/src/adapter/templates/index.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as ts from 'typescript';
+
+/**
+ * Creates a template for the given function that replaces its arguments
+ * and generates a string to be executed where it takes expressions to be
+ * interpolated in place of arguments.  It assumes there's no shadowing
+ * going on and that the template does not reference things outside its scope.
+ *
+ * This is not pretty, but presented as an alternative to writing a bunch of
+ * raw JavaScript functions in strings.
+ *
+ * Example:
+ *
+ * ```js
+ * const multiply = (a, b) => {
+ *   return a * b;
+ * };
+ * const template = templateFunction(multiply);
+ * console.log(multiple('42', 'foo()));
+ * ```
+ *
+ * Outputs:
+ *
+ * ```
+ * (() => {
+ *   let __arg0 = 42;
+ *   let __arg1 = foo();
+ *   return __arg0 * __arg1;
+ * })();
+ * ```
+ */
+export function templateFunction<A>(fn: (a: A) => void): (a: string) => string;
+export function templateFunction<A, B>(fn: (a: A, b: B) => void): (a: string, b: string) => string;
+export function templateFunction<A, B, C>(
+  fn: (a: A, b: B, c: C) => void,
+): (a: string, b: string, c: string) => string;
+export function templateFunction<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+): (...args: string[]) => string {
+  const stringified = '' + fn;
+  const sourceFile = ts.createSourceFile('test.js', stringified, ts.ScriptTarget.ESNext, true);
+
+  // 1. Find the function.
+  let decl: ts.FunctionLike | undefined;
+  ts.forEachChild(sourceFile, function traverse(node) {
+    if (ts.isFunctionLike(node)) {
+      decl = node;
+    } else {
+      ts.forEachChild(node, traverse);
+    }
+  });
+
+  if (!decl || !('body' in decl) || !decl.body) {
+    throw new Error(`Could not find function declaration for ${fn}`);
+  }
+
+  // 2. Get parameter names.
+  const params = decl.parameters.map(p => {
+    if (!ts.isIdentifier(p.name)) {
+      throw new Error('Parameter must be identifier');
+    }
+
+    return p.name.text;
+  });
+
+  // 3. Gather usages of the parameter in the source.
+  const replacements: { start: number; end: number; param: number }[] = [];
+  ts.forEachChild(decl.body, function traverse(node) {
+    if (ts.isIdentifier(node) && params.includes(node.text)) {
+      replacements.push({
+        start: node.getStart(),
+        end: node.getEnd(),
+        param: params.indexOf(node.text),
+      });
+    }
+
+    ts.forEachChild(node, traverse);
+  });
+
+  replacements.sort((a, b) => b.end - a.end);
+
+  // 4. Sort usages and slice up the function appropriately, wraping in an IIFE.
+  const parts: string[] = [];
+  let lastIndex = decl.body.getEnd() - 1;
+  for (const replacement of replacements) {
+    parts.push(stringified.slice(replacement.end, lastIndex));
+    parts.push(`__args${replacement.param}`);
+    lastIndex = replacement.start;
+  }
+
+  parts.push(stringified.slice(decl.body.getStart() + 1, lastIndex));
+  const body = parts.reverse().join('');
+
+  return (...args) => `(() => {
+    ${args.map((a, i) => `let __args${i} = ${a}`).join('; ')};
+    ${body}
+  })();`;
+}

--- a/src/adapter/templates/previewThis.ts
+++ b/src/adapter/templates/previewThis.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { remoteFunction } from '.';
+
+/**
+ * Returns a preview of the current context.
+ */
+export const previewThis = remoteFunction(function(this: unknown) {
+  return this;
+});

--- a/src/adapter/templates/toStringForClipboard.ts
+++ b/src/adapter/templates/toStringForClipboard.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { remoteFunction } from '.';
+
+/**
+ * Stringifies the current object for the clipboard.
+ */
+export const toStringForClipboard = remoteFunction(function(
+  this: unknown,
+  subtype: string | undefined,
+) {
+  if (subtype === 'node')
+    // a DOM node, but we don't have those typings here.
+    return (this as { outerHTML: string }).outerHTML;
+  if (subtype && typeof this === 'undefined') return subtype + '';
+  try {
+    return JSON.stringify(this, null, '  ');
+  } catch (e) {
+    return '' + this;
+  }
+});

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -290,14 +290,14 @@ export class Thread implements IVariableStoreDelegate {
     )
       return { targets: contexts };
     const line = params.line === undefined ? 0 : params.line - 1;
-    const targets = await completions.completions(
-      this._cdp,
-      this._selectedContext ? this._selectedContext.description.id : undefined,
+    const targets = await completions.completions({
+      cdp: this._cdp,
+      executionContextId: this._selectedContext ? this._selectedContext.description.id : undefined,
       stackFrame,
-      params.text,
+      expression: params.text,
       line,
-      params.column,
-    );
+      column: params.column,
+    });
     if (
       params.line === 1 &&
       params.column === params.text.length + 1 &&

--- a/src/test/completion/completion.test.ts
+++ b/src/test/completion/completion.test.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { itIntegrates } from '../testIntegrationUtils';
+import { expect } from 'chai';
+import Dap from '../../dap/api';
+
+describe('completion', () => {
+  const tcases: [string, Dap.CompletionItem[]][] = [
+    ['ar|', [{ label: 'arr', sortText: '~~arr', type: 'variable' }]],
+    [
+      'arr.|',
+      [
+        {
+          label: '[index]',
+          text: '[',
+          type: 'property',
+          sortText: '~~[',
+          length: 1,
+          start: 3,
+        },
+        {
+          label: 'length',
+          sortText: '~~length',
+          type: 'property',
+        },
+        {
+          label: 'concat',
+          sortText: '~~~concat',
+          type: 'method',
+        },
+      ],
+    ],
+    ['arr[|', []],
+    [
+      'arr[0].|',
+      [
+        {
+          label: 'length',
+          sortText: '~~length',
+          type: 'property',
+        },
+        {
+          label: 'anchor',
+          sortText: '~~~anchor',
+          type: 'method',
+        },
+        {
+          label: 'big',
+          sortText: '~~~big',
+          type: 'method',
+        },
+      ],
+    ],
+    ['arr[2].|', []],
+    [
+      'obj.|',
+      [
+        {
+          label: 'bar',
+          sortText: '~~bar',
+          type: 'property',
+        },
+        {
+          label: 'baz',
+          sortText: '~~baz',
+          type: 'method',
+        },
+        {
+          label: 'foo',
+          sortText: '~~foo',
+          type: 'property',
+        },
+      ],
+    ],
+    ['ob|', [{ label: 'obj', sortText: '~~obj', type: 'variable' }]],
+    ['arr[myStr|', [{ label: 'myString', sortText: '~~myString', type: 'variable' }]],
+    ['const replVar = 42; replV|', [{ label: 'replVar', sortText: 'replVar', type: 'variable' }]],
+    ['MyCoolCl|', [{ label: 'MyCoolClass', sortText: '~~MyCoolClass', type: 'class' }]],
+    ['Strin|', [{ label: 'String', sortText: '~~String', type: 'class' }]],
+    ['myNeatFun|', [{ label: 'myNeatFunction', sortText: '~~myNeatFunction', type: 'function' }]],
+  ];
+
+  itIntegrates('completion', async ({ r }) => {
+    const p = await r.launchAndLoad(`
+      <script>
+        var arr = ['', {}, null];
+        var obj = { foo: '', bar: 42, baz() {} };
+        var myString = '';
+        var MyCoolClass = class MyCoolClass {} // need to be hoisted manually
+        function myNeatFunction() {}
+      </script>
+    `);
+
+    for (const [completion, expected] of tcases) {
+      const index = completion.indexOf('|');
+      const actual = await p.dap.completions({
+        text: completion.slice(0, index) + completion.slice(index + 1),
+        column: index + 1,
+      });
+
+      expect(actual.targets.slice(0, 3)).to.deep.equal(
+        expected,
+        `bad result evaluating ${completion}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Completion previously was pretty basic. This does more work to get it
better data and correct type...

1. I made a "template function" helper. It's very scary, but in the
   debug adapter we heavily rely on sending non-trivial chunks of JS
   over to the adapter, and being able to write these in TypeScript with
   all the associated checking and linter is, in my opinion, preferable.
2. Did some work on the property walker (template) function to have it
   try to infer class types, properties, etc. correctly. Previously it
   only ever emitted `property` and `function`.
3. Better detection and handling of element kinds, particularly handling
   arrays correctly, which we didn't really do before.
4. Allow referencing locals declared elsewhere in the REPL expression,
   useful for writing more complex statements.

Fixes https://github.com/microsoft/vscode/issues/87123
Fixes https://github.com/microsoft/vscode-js-debug/issues/190
Fixes https://github.com/microsoft/vscode-js-debug/issues/186