### PR TITLE
feat: initial implementation of hit condition breakpoints

### DIFF
--- a/.ci/common-validation.yml
+++ b/.ci/common-validation.yml
@@ -34,6 +34,7 @@ steps:
   timeoutInMinutes: 10
   condition: and(eq(${{ parameters.runTests }}, true), ne(variables['Agent.OS'], 'Darwin'))
   env:
+    IS_CI: '1'
     DISPLAY: ':99.0'
 
 - task: Gulp@0

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -2,25 +2,24 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { IUiLocation, SourceContainer, Source, uiToRawOffset, base1To0 } from './sources';
-import * as nls from 'vscode-nls';
+import { IUiLocation, SourceContainer, Source, base1To0 } from './sources';
 import Dap from '../dap/api';
 import Cdp from '../cdp/api';
 import { Thread, Script, ScriptWithSourceMapHandler } from './threads';
 import { IDisposable } from '../common/events';
 import { BreakpointsPredictor } from './breakpointPredictor';
 import * as urlUtils from '../common/urlUtils';
-import { rewriteLogPoint } from '../common/sourceUtils';
 import { BreakpointsStatisticsCalculator } from '../statistics/breakpointsStatistics';
 import { TelemetryEntityProperties } from '../telemetry/telemetryReporter';
 import { logger, assert } from '../common/logging/logger';
 import { LogTag } from '../common/logging';
-import { getDeferred, delay } from '../common/promiseUtil';
+import { delay } from '../common/promiseUtil';
 import { MapUsingProjection } from '../common/datastructure/mapUsingProjection';
-
-const localize = nls.loadMessageBundle();
-
-type LineColumn = { lineNumber: number; columnNumber: number }; // 1-based
+import { EntryBreakpoint } from './breakpoints/entryBreakpoint';
+import { Breakpoint } from './breakpoints/breakpointBase';
+import { UserDefinedBreakpoint } from './breakpoints/userDefinedBreakpoint';
+import { HitCondition } from './breakpoints/hitCondition';
+import { ProtocolError } from '../dap/errors';
 
 /**
  * Differential result used internally in setBreakpoints.
@@ -29,488 +28,18 @@ interface ISetBreakpointResult {
   /**
    * Breakpoints that previous existed which can be destroyed.
    */
-  unbound: Breakpoint[];
+  unbound: UserDefinedBreakpoint[];
   /**
    * Newly created breakpoints;
    */
-  new: Breakpoint[];
+  new: UserDefinedBreakpoint[];
   /**
    * All old and new breakpoints.
    */
-  list: Breakpoint[];
-}
-
-/**
- * State of the IBreakpointCdpReference.
- */
-const enum CdpReferenceState {
-  // We're still working on the initial 'set breakpoint' request for this.
-  Pending,
-  // CDP has resolved this breakpoint to a source location locations.
-  Applied,
-}
-
-type AnyCdpBreakpointArgs =
-  | Cdp.Debugger.SetBreakpointByUrlParams
-  | Cdp.Debugger.SetBreakpointParams;
-
-const isSetByUrl = (
-  params: AnyCdpBreakpointArgs,
-): params is Cdp.Debugger.SetBreakpointByUrlParams => !('location' in params);
-const isSetByLocation = (
-  params: AnyCdpBreakpointArgs,
-): params is Cdp.Debugger.SetBreakpointParams => 'location' in params;
-
-const breakpointIsForUrl = (params: Cdp.Debugger.SetBreakpointByUrlParams, url: string) =>
-  (params.url && url === params.url) || params.urlRegex === urlUtils.urlToRegex(url);
-
-/**
- * We're currently working on sending the breakpoint to CDP.
- */
-interface IBreakpointCdpReferencePending {
-  state: CdpReferenceState.Pending;
-  // If deadletter is true, it indicates we want to invalidate this breakpoint;
-  // this will cause it to be unset as soon as it is applied.
-  deadletter: boolean;
-  // Promise that resolves to the 'applied' state once applied, or void if an
-  // error or deadletter occurred.
-  done: Promise<IBreakpointCdpReferenceApplied | void>;
-  // Arguments used to set the breakpoint.
-  args: AnyCdpBreakpointArgs;
-}
-
-/**
- * The breakpoint has been acknowledged by CDP and mapped to one or more locations.
- */
-interface IBreakpointCdpReferenceApplied {
-  state: CdpReferenceState.Applied;
-  // ID of the breakpoint on CDP.
-  cdpId: Cdp.Debugger.BreakpointId;
-  // Locations where CDP told us the breakpoint has bound.
-  locations: ReadonlyArray<Cdp.Debugger.Location>;
-  // Arguments used to set the breakpoint.
-  args: AnyCdpBreakpointArgs;
-  // A list of UI locations whether this breakpoint was resolved.
-  uiLocations: IUiLocation[];
-}
-
-/**
- * An entry in the Breakpoint class that references a breakpoint in CDP/the
- * debug target. A single "Breakpoint" class might resolve to
- * multiple source locations, so there is a list of these.
- */
-type BreakpointCdpReference = IBreakpointCdpReferencePending | IBreakpointCdpReferenceApplied;
-
-const isApplied = (bp: BreakpointCdpReference): bp is IBreakpointCdpReferenceApplied =>
-  bp.state === CdpReferenceState.Applied;
-
-export class Breakpoint {
-  private _manager: BreakpointManager;
-  _source: Dap.Source;
-  private _condition?: string;
-
-  /**
-   * A list of the CDP breakpoints that have been set from this one.
-   */
-  private _cdpBreakpoints: BreakpointCdpReference[] = [];
-
-  /**
-   * A deferred that resolves once the breakpoint 'set' response has been
-   * returned to the UI. We should wait for this to finish before sending any
-   * notifications about breakpoint changes.
-   */
-  private _completedSet = getDeferred<void>();
-
-  /**
-   * Gets all CDP breakpoint IDs under which this breakpoint currently exists.
-   */
-  public get cdpIds() {
-    return this._cdpBreakpoints.filter(isApplied).map(bp => bp.cdpId);
-  }
-
-  /**
-   * The position in the UI this breakpoint was placed at.
-   */
-  public readonly originalPosition: LineColumn;
-
-  constructor(
-    manager: BreakpointManager,
-    public readonly dapId: number,
-    source: Dap.Source,
-    params: Dap.SourceBreakpoint,
-  ) {
-    this._manager = manager;
-    this.dapId = dapId;
-    this._source = source;
-    this.originalPosition = { lineNumber: params.line, columnNumber: params.column || 1 };
-    if (params.logMessage)
-      this._condition = rewriteLogPoint(params.logMessage) + `\n//# sourceURL=${kLogPointUrl}`;
-    if (params.condition)
-      this._condition = this._condition
-        ? `(${params.condition}) && ${this._condition}`
-        : params.condition;
-  }
-
-  /**
-   * Returns a promise that resolves once the breakpoint 'set' response
-   */
-  public untilSetCompleted() {
-    return this._completedSet.promise;
-  }
-
-  /**
-   * Marks the breakpoint 'set' as having finished.
-   */
-  public markSetCompleted() {
-    this._completedSet.resolve();
-  }
-
-  /**
-   * Returns a DAP representation of the breakpoint. If the breakpoint is
-   * resolved, this will be fulfilled with the complete source location.
-   */
-  public async toDap(): Promise<Dap.Breakpoint> {
-    const location = this.getResolvedUiLocation();
-    if (location) {
-      return {
-        id: this.dapId,
-        verified: true,
-        source: await location.source.toDap(),
-        line: location.lineNumber,
-        column: location.columnNumber,
-      };
-    }
-
-    return {
-      id: this.dapId,
-      verified: false,
-      message: localize('breakpoint.provisionalBreakpoint', `Unbound breakpoint`), // TODO: Put a useful message here
-    };
-  }
-
-  /**
-   * Gets the location whether this breakpoint is resolved, if any.
-   */
-  private getResolvedUiLocation() {
-    for (const bp of this._cdpBreakpoints) {
-      if (bp.state === CdpReferenceState.Applied && bp.uiLocations.length) {
-        return bp.uiLocations[0];
-      }
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Called the breakpoint manager to notify that the breakpoint is resolved,
-   * used for statistics and notifying the UI.
-   */
-  private async notifyResolved(): Promise<void> {
-    const location = this.getResolvedUiLocation();
-    if (location) {
-      await this._manager.notifyBreakpointResolved(
-        this.dapId,
-        location,
-        this._completedSet.hasSettled(),
-      );
-    }
-  }
-
-  async set(thread: Thread): Promise<void> {
-    const promises: Promise<void>[] = [
-      // For breakpoints set before launch, we don't know whether they are in a compiled or
-      // a source map source. To make them work, we always set by url to not miss compiled.
-      // Additionally, if we have two sources with the same url, but different path (or no path),
-      // this will make breakpoint work in all of them.
-      this._setByPath(thread, this.originalPosition),
-
-      // Also use predicted locations if available.
-      this._setPredicted(thread),
-    ];
-
-    const source = this._manager._sourceContainer.source(this._source);
-    if (source) {
-      const uiLocations = this._manager._sourceContainer.currentSiblingUiLocations({
-        lineNumber: this.originalPosition.lineNumber,
-        columnNumber: this.originalPosition.columnNumber,
-        source,
-      });
-      promises.push(...uiLocations.map(uiLocation => this._setByUiLocation(thread, uiLocation)));
-    }
-
-    await Promise.all(promises);
-    await this.notifyResolved();
-  }
-
-  /**
-   * Updates the breakpoint's locations in the UI. Should be called whenever
-   * a breakpoint set completes or a breakpointResolved event is received.
-   */
-  public async updateUiLocations(
-    thread: Thread,
-    cdpId: Cdp.Debugger.BreakpointId,
-    resolvedLocations: Cdp.Debugger.Location[],
-  ) {
-    const uiLocation = (
-      await Promise.all(
-        resolvedLocations.map(l => thread.rawLocationToUiLocation(thread.rawLocation(l))),
-      )
-    ).find(l => !!l);
-
-    if (!uiLocation) {
-      return;
-    }
-
-    const source = this._manager._sourceContainer.source(this._source);
-    if (!source) {
-      return;
-    }
-
-    const hadPreviousLocation = !!this.getResolvedUiLocation();
-    for (const bp of this._cdpBreakpoints) {
-      if (bp.state === CdpReferenceState.Applied && bp.cdpId === cdpId) {
-        bp.uiLocations = bp.uiLocations.concat(
-          this._manager._sourceContainer.currentSiblingUiLocations(uiLocation, source),
-        );
-      }
-    }
-
-    if (!hadPreviousLocation) {
-      this.notifyResolved();
-    }
-  }
-
-  public async updateForSourceMap(thread: Thread, script: Script) {
-    const source = this._manager._sourceContainer.source(this._source);
-    if (!source) {
-      return [];
-    }
-
-    // Find all locations for this breakpoint in the new script.
-    const uiLocations = this._manager._sourceContainer.currentSiblingUiLocations(
-      {
-        lineNumber: this.originalPosition.lineNumber,
-        columnNumber: this.originalPosition.columnNumber,
-        source,
-      },
-      script.source,
-    );
-
-    if (!uiLocations.length) {
-      return [];
-    }
-
-    const promises: Promise<void>[] = [];
-    for (const uiLocation of uiLocations) {
-      promises.push(this._setByScriptId(thread, script, uiLocation));
-    }
-
-    // If we get a source map that references this script exact URL, then
-    // remove any URL-set breakpoints because they are probably not correct.
-    // This oft happens with Node.js loaders which rewrite sources on the fly.
-    for (const bp of this._cdpBreakpoints) {
-      if (isSetByUrl(bp.args) && breakpointIsForUrl(bp.args, source.url())) {
-        logger.verbose(LogTag.RuntimeSourceMap, 'Adjusted breakpoint due to overlaid sourcemap', {
-          url: source.url(),
-        });
-        promises.push(this.removeCdpBreakpoint(bp));
-      }
-    }
-
-    await Promise.all(promises);
-
-    return uiLocations;
-  }
-
-  async _setPredicted(thread: Thread): Promise<void> {
-    if (!this._source.path || !this._manager._breakpointsPredictor) return;
-    const workspaceLocations = this._manager._breakpointsPredictor.predictedResolvedLocations({
-      absolutePath: this._source.path,
-      lineNumber: this.originalPosition.lineNumber,
-      columnNumber: this.originalPosition.columnNumber,
-    });
-    const promises: Promise<void>[] = [];
-    for (const workspaceLocation of workspaceLocations) {
-      const url = this._manager._sourceContainer.sourcePathResolver.absolutePathToUrl(
-        workspaceLocation.absolutePath,
-      );
-      if (url) promises.push(this._setByUrl(thread, url, workspaceLocation));
-    }
-    await Promise.all(promises);
-  }
-
-  async _setByUiLocation(thread: Thread, uiLocation: IUiLocation): Promise<void> {
-    const promises: Promise<void>[] = [];
-    const scripts = thread.scriptsFromSource(uiLocation.source);
-    for (const script of scripts) promises.push(this._setByScriptId(thread, script, uiLocation));
-    await Promise.all(promises);
-  }
-
-  async _setByPath(thread: Thread, lineColumn: LineColumn): Promise<void> {
-    const sourceByPath = this._manager._sourceContainer.source({ path: this._source.path });
-
-    // If the source has been mapped in-place, don't set anything by path,
-    // we'll depend only on the mapped locations.
-    if (sourceByPath?._compiledToSourceUrl) {
-      const mappedInPlace = [...sourceByPath._compiledToSourceUrl.keys()].some(
-        s => s.absolutePath() === this._source.path,
-      );
-
-      if (mappedInPlace) {
-        return;
-      }
-    }
-    const source = this._manager._sourceContainer.source(this._source);
-
-    const url = source
-      ? source.url()
-      : this._source.path
-      ? this._manager._sourceContainer.sourcePathResolver.absolutePathToUrl(this._source.path)
-      : undefined;
-    if (!url) return;
-    await this._setByUrl(thread, url, lineColumn);
-  }
-
-  /**
-   * Returns whether a breakpoint has been set on the given line and column
-   * at the provided URL already. This is used to deduplicate breakpoint
-   * requests--as URLs do not refer explicitly to a single script, there's
-   * not an intrinsic deduplication that happens before this point.
-   */
-  private hasSetOnLocation(urlRegex: string, lineColumn: LineColumn): boolean {
-    return this._cdpBreakpoints.some(
-      bp =>
-        isSetByUrl(bp.args) &&
-        bp.args.urlRegex === urlRegex &&
-        bp.args.lineNumber === lineColumn.lineNumber &&
-        bp.args.columnNumber === lineColumn.columnNumber,
-    );
-  }
-
-  private async _setByUrl(thread: Thread, url: string, lineColumn: LineColumn): Promise<void> {
-    const urlRegex = urlUtils.urlToRegex(url);
-    lineColumn = base1To0(uiToRawOffset(lineColumn, thread.defaultScriptOffset()));
-    if (this.hasSetOnLocation(urlRegex, lineColumn)) {
-      return;
-    }
-
-    return this._setAny(thread, {
-      urlRegex,
-      condition: this._condition,
-      ...lineColumn,
-    });
-  }
-
-  private async _setByScriptId(
-    thread: Thread,
-    script: Script,
-    lineColumn: LineColumn,
-  ): Promise<void> {
-    lineColumn = base1To0(uiToRawOffset(lineColumn, thread.defaultScriptOffset()));
-    if (script.url && this.hasSetOnLocation(urlUtils.urlToRegex(script.url), lineColumn)) {
-      return;
-    }
-
-    return this._setAny(thread, { location: { scriptId: script.scriptId, ...lineColumn } });
-  }
-
-  /**
-   * Sets a breakpoint on the thread using the given set of arguments
-   * to Debugger.setBreakpoint or Debugger.setBreakpointByUrl.
-   */
-  private async _setAny(thread: Thread, args: AnyCdpBreakpointArgs) {
-    const state: Partial<IBreakpointCdpReferencePending> = {
-      state: CdpReferenceState.Pending,
-      args,
-      deadletter: false,
-    };
-
-    state.done = (async () => {
-      const result = isSetByLocation(args)
-        ? await thread.cdp().Debugger.setBreakpoint(args)
-        : await thread.cdp().Debugger.setBreakpointByUrl(args);
-      if (!result) {
-        return;
-      }
-
-      if (state.deadletter) {
-        await thread.cdp().Debugger.removeBreakpoint({ breakpointId: result.breakpointId });
-        return;
-      }
-
-      const locations = 'actualLocation' in result ? [result.actualLocation] : result.locations;
-      this._manager._resolvedBreakpoints.set(result.breakpointId, this);
-
-      // Note that we add the record after calling breakpointResolved()
-      // to avoid duplicating locations.
-      const next: IBreakpointCdpReferenceApplied = {
-        state: CdpReferenceState.Applied,
-        cdpId: result.breakpointId,
-        args,
-        locations,
-        uiLocations: [],
-      };
-      this._cdpBreakpoints = this._cdpBreakpoints.map(r => (r === state ? next : r));
-
-      this.updateUiLocations(thread, result.breakpointId, locations);
-      return next;
-    })();
-
-    this._cdpBreakpoints.push(state as IBreakpointCdpReferencePending);
-    await state.done;
-  }
-
-  async remove(): Promise<void> {
-    const promises: Promise<unknown>[] = this._cdpBreakpoints.map(bp =>
-      this.removeCdpBreakpoint(bp, false),
-    );
-    this._cdpBreakpoints = [];
-    await Promise.all(promises);
-  }
-
-  /**
-   * Removes a CDP breakpoint attached to this one. Deadletters it if it
-   * hasn't been applied yet, deletes it immediately otherwise.
-   */
-  private async removeCdpBreakpoint(breakpoint: BreakpointCdpReference, notify = true) {
-    const previousLocation = this.getResolvedUiLocation();
-    this._cdpBreakpoints = this._cdpBreakpoints.filter(bp => bp !== breakpoint);
-    if (breakpoint.state === CdpReferenceState.Pending) {
-      breakpoint.deadletter = true;
-      await breakpoint.done;
-    } else {
-      this._manager._resolvedBreakpoints.delete(breakpoint.cdpId);
-      await this._manager._thread
-        ?.cdp()
-        .Debugger.removeBreakpoint({ breakpointId: breakpoint.cdpId });
-    }
-
-    if (notify && previousLocation !== this.getResolvedUiLocation()) {
-      this.notifyResolved();
-    }
-  }
-
-  /**
-   * Compares this breakpoint with the other. String comparison-style return:
-   *  - a negative number if this breakpoint is before the other one
-   *  - zero if they're the same location
-   *  - a positive number if this breakpoint is after the other one
-   */
-  public compare(other: Breakpoint) {
-    const lca = this.originalPosition;
-    const lcb = other.originalPosition;
-    return lca.lineNumber !== lcb.lineNumber
-      ? lca.lineNumber - lcb.lineNumber
-      : lca.columnNumber - lcb.columnNumber;
-  }
+  list: UserDefinedBreakpoint[];
 }
 
 export class BreakpointManager {
-  private _byPath: Map<string, Breakpoint[]> = new MapUsingProjection(
-    urlUtils.lowerCaseInsensitivePath,
-  );
-  private _byRef: Map<number, Breakpoint[]> = new Map();
-
   _dap: Dap.Api;
   _sourceContainer: SourceContainer;
   _thread: Thread | undefined;
@@ -523,9 +52,21 @@ export class BreakpointManager {
   private _breakpointsStatisticsCalculator = new BreakpointsStatisticsCalculator();
 
   /**
+   * User-defined breakpoints by path on disk.
+   */
+  private _byPath: Map<string, UserDefinedBreakpoint[]> = new MapUsingProjection(
+    urlUtils.lowerCaseInsensitivePath,
+  );
+
+  /**
+   * User-defined breakpoints by `sourceReference`.
+   */
+  private _byRef: Map<number, UserDefinedBreakpoint[]> = new Map();
+
+  /**
    * Mapping of source paths to entrypoint breakpoint IDs we set there.
    */
-  private readonly moduleEntryBreakpoints: Map<string, Breakpoint> = new MapUsingProjection(
+  private readonly moduleEntryBreakpoints: Map<string, EntryBreakpoint> = new MapUsingProjection(
     urlUtils.lowerCaseInsensitivePath,
   );
 
@@ -570,7 +111,7 @@ export class BreakpointManager {
    */
   public tryResolveModuleEntryBreakpoint(breakpointId: Cdp.Debugger.BreakpointId) {
     for (const bp of this.moduleEntryBreakpoints.values()) {
-      if (bp.cdpIds.includes(breakpointId)) {
+      if (bp.cdpIds.has(breakpointId)) {
         // we intentionally don't remove the record from the map; it's kept as
         // an indicator that it did exist and was hit, so that if further
         // breakpoints are set in the file it doesn't get re-applied.
@@ -763,14 +304,34 @@ export class BreakpointManager {
 
     // Creates new breakpoints for the parameters, unsetting any previous
     // breakpoints that don't still exist in the params.
-    const mergeInto = (previous: Breakpoint[]): ISetBreakpointResult => {
+    const mergeInto = (previous: UserDefinedBreakpoint[]): ISetBreakpointResult => {
       const result: ISetBreakpointResult = { unbound: previous.slice(), new: [], list: [] };
       if (!params.breakpoints) {
         return result;
       }
 
       for (let index = 0; index < params.breakpoints.length; index++) {
-        const created = new Breakpoint(this, ids[index], params.source, params.breakpoints[index]);
+        const bpParams = params.breakpoints[index];
+
+        let hitCondition: HitCondition | undefined;
+        try {
+          if (bpParams.hitCondition) {
+            hitCondition = HitCondition.parse(bpParams.hitCondition);
+          }
+        } catch (e) {
+          if (e instanceof ProtocolError) {
+            this._dap.output({ category: 'stderr', output: e.message });
+            continue;
+          }
+        }
+
+        const created = new UserDefinedBreakpoint(
+          this,
+          ids[index],
+          params.source,
+          params.breakpoints[index],
+          hitCondition,
+        );
         const existingIndex = result.unbound.findIndex(p => p.compare(created) === 0);
         if (existingIndex === -1) {
           result.new.push(created);
@@ -844,14 +405,34 @@ export class BreakpointManager {
     }
   }
 
-  public notifyBreakpointHit(hitBreakpointIds: string[]): void {
-    hitBreakpointIds.forEach(breakpointId => {
+  /**
+   * Function that should be called when breakpoints are hit.
+   */
+  public onBreakpointHit(hitBreakpointIds: ReadonlyArray<Cdp.Debugger.BreakpointId>) {
+    // We do two things here--notify that we hit BPs for statistical purposes,
+    // and see if we should automatically continue based on hit conditions. To
+    // automatically continue, we need *no* breakpoints to want to continue and
+    // at least one breakpoint who wants to continue. See {@link HitCondition}
+    // for more details here.
+    let votesForPause = 0;
+    let votesForContinue = 0;
+
+    for (const breakpointId of hitBreakpointIds) {
       const breakpoint = this._resolvedBreakpoints.get(breakpointId);
-      if (breakpoint) {
-        const id = breakpoint.dapId;
-        this._breakpointsStatisticsCalculator.registerBreakpointHit(id);
+      if (!breakpoint || !(breakpoint instanceof UserDefinedBreakpoint)) {
+        continue;
       }
-    });
+
+      const id = breakpoint.dapId;
+      this._breakpointsStatisticsCalculator.registerBreakpointHit(id);
+      if (breakpoint.testHitCondition()) {
+        votesForContinue++;
+      } else {
+        votesForPause++;
+      }
+    }
+
+    return { remainPaused: votesForPause === 0 || votesForContinue > 0 };
   }
 
   public statisticsForTelemetry(): TelemetryEntityProperties {
@@ -867,7 +448,7 @@ export class BreakpointManager {
       return;
     }
 
-    const bp = new Breakpoint(this, 0, source, { line: 1 });
+    const bp = new EntryBreakpoint(this, source);
     this.moduleEntryBreakpoints.set(source.path, bp);
     this._setBreakpoint(bp, thread);
   }

--- a/src/adapter/breakpoints/breakpointBase.ts
+++ b/src/adapter/breakpoints/breakpointBase.ts
@@ -344,12 +344,12 @@ export abstract class Breakpoint {
     script: Script,
     lineColumn: LineColumn,
   ): Promise<void> {
-    lineColumn = base1To0(uiToRawOffset(lineColumn, thread.defaultScriptOffset()));
-    if (script.url && this.hasSetOnLocation(urlToRegex(script.url), lineColumn)) {
-      return;
-    }
-
-    return this._setAny(thread, { location: { scriptId: script.scriptId, ...lineColumn } });
+    return this._setAny(thread, {
+      location: {
+        scriptId: script.scriptId,
+        ...base1To0(uiToRawOffset(lineColumn, thread.defaultScriptOffset())),
+      },
+    });
   }
 
   /**

--- a/src/adapter/breakpoints/breakpointBase.ts
+++ b/src/adapter/breakpoints/breakpointBase.ts
@@ -1,0 +1,416 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { BreakpointManager } from '../breakpoints';
+import Dap from '../../dap/api';
+import { Thread, Script } from '../threads';
+import Cdp from '../../cdp/api';
+import { logger } from '../../common/logging/logger';
+import { LogTag } from '../../common/logging';
+import { IUiLocation, base1To0, uiToRawOffset } from '../sources';
+import { urlToRegex } from '../../common/urlUtils';
+
+type LineColumn = { lineNumber: number; columnNumber: number }; // 1-based
+
+/**
+ * State of the IBreakpointCdpReference.
+ */
+export const enum CdpReferenceState {
+  // We're still working on the initial 'set breakpoint' request for this.
+  Pending,
+  // CDP has resolved this breakpoint to a source location locations.
+  Applied,
+}
+
+type AnyCdpBreakpointArgs =
+  | Cdp.Debugger.SetBreakpointByUrlParams
+  | Cdp.Debugger.SetBreakpointParams;
+
+const isSetByUrl = (
+  params: AnyCdpBreakpointArgs,
+): params is Cdp.Debugger.SetBreakpointByUrlParams => !('location' in params);
+const isSetByLocation = (
+  params: AnyCdpBreakpointArgs,
+): params is Cdp.Debugger.SetBreakpointParams => 'location' in params;
+
+const breakpointIsForUrl = (params: Cdp.Debugger.SetBreakpointByUrlParams, url: string) =>
+  (params.url && url === params.url) || params.urlRegex === urlToRegex(url);
+
+/**
+ * We're currently working on sending the breakpoint to CDP.
+ */
+export interface IBreakpointCdpReferencePending {
+  state: CdpReferenceState.Pending;
+  // If deadletter is true, it indicates we want to invalidate this breakpoint;
+  // this will cause it to be unset as soon as it is applied.
+  deadletter: boolean;
+  // Promise that resolves to the 'applied' state once applied, or void if an
+  // error or deadletter occurred.
+  done: Promise<IBreakpointCdpReferenceApplied | void>;
+  // Arguments used to set the breakpoint.
+  args: AnyCdpBreakpointArgs;
+}
+
+/**
+ * The breakpoint has been acknowledged by CDP and mapped to one or more locations.
+ */
+export interface IBreakpointCdpReferenceApplied {
+  state: CdpReferenceState.Applied;
+  // ID of the breakpoint on CDP.
+  cdpId: Cdp.Debugger.BreakpointId;
+  // Locations where CDP told us the breakpoint has bound.
+  locations: ReadonlyArray<Cdp.Debugger.Location>;
+  // Arguments used to set the breakpoint.
+  args: AnyCdpBreakpointArgs;
+  // A list of UI locations whether this breakpoint was resolved.
+  uiLocations: IUiLocation[];
+}
+
+/**
+ * An entry in the Breakpoint class that references a breakpoint in CDP/the
+ * debug target. A single "Breakpoint" class might resolve to
+ * multiple source locations, so there is a list of these.
+ */
+export type BreakpointCdpReference =
+  | IBreakpointCdpReferencePending
+  | Readonly<IBreakpointCdpReferenceApplied>;
+
+export abstract class Breakpoint {
+  /**
+   * Gets all CDP breakpoint IDs under which this breakpoint currently exists.
+   */
+  public get cdpIds(): ReadonlySet<string> {
+    return this._cdpIds;
+  }
+
+  /**
+   * A list of the CDP breakpoints that have been set from this one. Note that
+   * this can be set, only through {@link Breakpoint#updateCdpRefs}
+   */
+  protected readonly cdpBreakpoints: ReadonlyArray<BreakpointCdpReference> = [];
+
+  private _cdpIds = new Set<string>();
+
+  /**
+   * @param manager - Associated breakpoint manager
+   * @param originalPosition - The position in the UI this breakpoint was placed at
+   * @param _source - Source in which this breakpoint is placed
+   */
+  constructor(
+    protected readonly _manager: BreakpointManager,
+    public readonly _source: Dap.Source,
+    public readonly originalPosition: LineColumn,
+  ) {}
+
+  /**
+   * Sets the breakpoint in the provided thread.
+   */
+  public async set(thread: Thread): Promise<void> {
+    const promises: Promise<void>[] = [
+      // For breakpoints set before launch, we don't know whether they are in a compiled or
+      // a source map source. To make them work, we always set by url to not miss compiled.
+      // Additionally, if we have two sources with the same url, but different path (or no path),
+      // this will make breakpoint work in all of them.
+      this._setByPath(thread, this.originalPosition),
+
+      // Also use predicted locations if available.
+      this._setPredicted(thread),
+    ];
+
+    const source = this._manager._sourceContainer.source(this._source);
+    if (source) {
+      const uiLocations = this._manager._sourceContainer.currentSiblingUiLocations({
+        lineNumber: this.originalPosition.lineNumber,
+        columnNumber: this.originalPosition.columnNumber,
+        source,
+      });
+      promises.push(...uiLocations.map(uiLocation => this._setByUiLocation(thread, uiLocation)));
+    }
+
+    await Promise.all(promises);
+  }
+
+  /**
+   * Updates the breakpoint's locations in the UI. Should be called whenever
+   * a breakpoint set completes or a breakpointResolved event is received.
+   */
+  public async updateUiLocations(
+    thread: Thread,
+    cdpId: Cdp.Debugger.BreakpointId,
+    resolvedLocations: Cdp.Debugger.Location[],
+  ) {
+    const uiLocation = (
+      await Promise.all(
+        resolvedLocations.map(l => thread.rawLocationToUiLocation(thread.rawLocation(l))),
+      )
+    ).find(l => !!l);
+
+    if (!uiLocation) {
+      return;
+    }
+
+    const source = this._manager._sourceContainer.source(this._source);
+    if (!source) {
+      return;
+    }
+
+    this.updateCdpRefs(list =>
+      list.map(bp =>
+        bp.state === CdpReferenceState.Applied && bp.cdpId === cdpId
+          ? {
+              ...bp,
+              uiLocations: [
+                ...bp.uiLocations,
+                ...this._manager._sourceContainer.currentSiblingUiLocations(uiLocation, source),
+              ],
+            }
+          : bp,
+      ),
+    );
+  }
+
+  /**
+   * Compares this breakpoint with the other. String comparison-style return:
+   *  - a negative number if this breakpoint is before the other one
+   *  - zero if they're the same location
+   *  - a positive number if this breakpoint is after the other one
+   */
+  public compare(other: Breakpoint) {
+    const lca = this.originalPosition;
+    const lcb = other.originalPosition;
+    return lca.lineNumber !== lcb.lineNumber
+      ? lca.lineNumber - lcb.lineNumber
+      : lca.columnNumber - lcb.columnNumber;
+  }
+
+  public async remove(): Promise<void> {
+    const promises: Promise<unknown>[] = this.cdpBreakpoints.map(bp =>
+      this.removeCdpBreakpoint(bp),
+    );
+    await Promise.all(promises);
+  }
+
+  public async updateForSourceMap(thread: Thread, script: Script) {
+    const source = this._manager._sourceContainer.source(this._source);
+    if (!source) {
+      return [];
+    }
+
+    // Find all locations for this breakpoint in the new script.
+    const uiLocations = this._manager._sourceContainer.currentSiblingUiLocations(
+      {
+        lineNumber: this.originalPosition.lineNumber,
+        columnNumber: this.originalPosition.columnNumber,
+        source,
+      },
+      script.source,
+    );
+
+    if (!uiLocations.length) {
+      return [];
+    }
+
+    const promises: Promise<void>[] = [];
+    for (const uiLocation of uiLocations) {
+      promises.push(this._setByScriptId(thread, script, uiLocation));
+    }
+
+    // If we get a source map that references this script exact URL, then
+    // remove any URL-set breakpoints because they are probably not correct.
+    // This oft happens with Node.js loaders which rewrite sources on the fly.
+    for (const bp of this.cdpBreakpoints) {
+      if (isSetByUrl(bp.args) && breakpointIsForUrl(bp.args, source.url())) {
+        logger.verbose(LogTag.RuntimeSourceMap, 'Adjusted breakpoint due to overlaid sourcemap', {
+          url: source.url(),
+        });
+        promises.push(this.removeCdpBreakpoint(bp));
+      }
+    }
+
+    await Promise.all(promises);
+
+    return uiLocations;
+  }
+
+  /**
+   * Gets the condition under which this breakpoint should be hit.
+   */
+  protected getBreakCondition(): string | undefined {
+    return undefined;
+  }
+
+  /**
+   * Updates the list of CDP breakpoint references. Used to provide lifecycle
+   * hooks to consumers and internal caches.
+   */
+  protected updateCdpRefs(
+    mutator: (l: ReadonlyArray<BreakpointCdpReference>) => ReadonlyArray<BreakpointCdpReference>,
+  ) {
+    const cast = (this as unknown) as { cdpBreakpoints: ReadonlyArray<BreakpointCdpReference> };
+    cast.cdpBreakpoints = mutator(this.cdpBreakpoints);
+
+    const nextIdSet = new Set<string>();
+    for (const bp of this.cdpBreakpoints) {
+      if (bp.state === CdpReferenceState.Applied) {
+        nextIdSet.add(bp.cdpId);
+      }
+    }
+
+    this._cdpIds = nextIdSet;
+  }
+
+  private async _setPredicted(thread: Thread): Promise<void> {
+    if (!this._source.path || !this._manager._breakpointsPredictor) return;
+    const workspaceLocations = this._manager._breakpointsPredictor.predictedResolvedLocations({
+      absolutePath: this._source.path,
+      lineNumber: this.originalPosition.lineNumber,
+      columnNumber: this.originalPosition.columnNumber,
+    });
+    const promises: Promise<void>[] = [];
+    for (const workspaceLocation of workspaceLocations) {
+      const url = this._manager._sourceContainer.sourcePathResolver.absolutePathToUrl(
+        workspaceLocation.absolutePath,
+      );
+      if (url) promises.push(this._setByUrl(thread, url, workspaceLocation));
+    }
+    await Promise.all(promises);
+  }
+
+  private async _setByUiLocation(thread: Thread, uiLocation: IUiLocation): Promise<void> {
+    const promises: Promise<void>[] = [];
+    const scripts = thread.scriptsFromSource(uiLocation.source);
+    for (const script of scripts) promises.push(this._setByScriptId(thread, script, uiLocation));
+    await Promise.all(promises);
+  }
+
+  private async _setByPath(thread: Thread, lineColumn: LineColumn): Promise<void> {
+    const sourceByPath = this._manager._sourceContainer.source({ path: this._source.path });
+
+    // If the source has been mapped in-place, don't set anything by path,
+    // we'll depend only on the mapped locations.
+    if (sourceByPath?._compiledToSourceUrl) {
+      const mappedInPlace = [...sourceByPath._compiledToSourceUrl.keys()].some(
+        s => s.absolutePath() === this._source.path,
+      );
+
+      if (mappedInPlace) {
+        return;
+      }
+    }
+    const source = this._manager._sourceContainer.source(this._source);
+
+    const url = source
+      ? source.url()
+      : this._source.path
+      ? this._manager._sourceContainer.sourcePathResolver.absolutePathToUrl(this._source.path)
+      : undefined;
+    if (!url) return;
+    await this._setByUrl(thread, url, lineColumn);
+  }
+
+  /**
+   * Returns whether a breakpoint has been set on the given line and column
+   * at the provided URL already. This is used to deduplicate breakpoint
+   * requests--as URLs do not refer explicitly to a single script, there's
+   * not an intrinsic deduplication that happens before this point.
+   */
+  private hasSetOnLocation(urlRegex: string, lineColumn: LineColumn): boolean {
+    return this.cdpBreakpoints.some(
+      bp =>
+        isSetByUrl(bp.args) &&
+        bp.args.urlRegex === urlRegex &&
+        bp.args.lineNumber === lineColumn.lineNumber &&
+        bp.args.columnNumber === lineColumn.columnNumber,
+    );
+  }
+
+  private async _setByUrl(thread: Thread, url: string, lineColumn: LineColumn): Promise<void> {
+    const urlRegex = urlToRegex(url);
+    lineColumn = base1To0(uiToRawOffset(lineColumn, thread.defaultScriptOffset()));
+    if (this.hasSetOnLocation(urlRegex, lineColumn)) {
+      return;
+    }
+
+    return this._setAny(thread, {
+      urlRegex,
+      condition: this.getBreakCondition(),
+      ...lineColumn,
+    });
+  }
+
+  private async _setByScriptId(
+    thread: Thread,
+    script: Script,
+    lineColumn: LineColumn,
+  ): Promise<void> {
+    lineColumn = base1To0(uiToRawOffset(lineColumn, thread.defaultScriptOffset()));
+    if (script.url && this.hasSetOnLocation(urlToRegex(script.url), lineColumn)) {
+      return;
+    }
+
+    return this._setAny(thread, { location: { scriptId: script.scriptId, ...lineColumn } });
+  }
+
+  /**
+   * Sets a breakpoint on the thread using the given set of arguments
+   * to Debugger.setBreakpoint or Debugger.setBreakpointByUrl.
+   */
+  private async _setAny(thread: Thread, args: AnyCdpBreakpointArgs) {
+    const state: Partial<IBreakpointCdpReferencePending> = {
+      state: CdpReferenceState.Pending,
+      args,
+      deadletter: false,
+    };
+
+    state.done = (async () => {
+      const result = isSetByLocation(args)
+        ? await thread.cdp().Debugger.setBreakpoint(args)
+        : await thread.cdp().Debugger.setBreakpointByUrl(args);
+      if (!result) {
+        return;
+      }
+
+      if (state.deadletter) {
+        await thread.cdp().Debugger.removeBreakpoint({ breakpointId: result.breakpointId });
+        return;
+      }
+
+      const locations = 'actualLocation' in result ? [result.actualLocation] : result.locations;
+      this._manager._resolvedBreakpoints.set(result.breakpointId, this);
+
+      // Note that we add the record after calling breakpointResolved()
+      // to avoid duplicating locations.
+      const next: IBreakpointCdpReferenceApplied = {
+        state: CdpReferenceState.Applied,
+        cdpId: result.breakpointId,
+        args,
+        locations,
+        uiLocations: [],
+      };
+      this.updateCdpRefs(list => list.map(r => (r === state ? next : r)));
+      this.updateUiLocations(thread, result.breakpointId, locations);
+      return next;
+    })();
+
+    this.updateCdpRefs(list => [...list, state as IBreakpointCdpReferencePending]);
+    await state.done;
+  }
+
+  /**
+   * Removes a CDP breakpoint attached to this one. Deadletters it if it
+   * hasn't been applied yet, deletes it immediately otherwise.
+   */
+  private async removeCdpBreakpoint(breakpoint: BreakpointCdpReference) {
+    this.updateCdpRefs(bps => bps.filter(bp => bp !== breakpoint));
+    if (breakpoint.state === CdpReferenceState.Pending) {
+      breakpoint.deadletter = true;
+      await breakpoint.done;
+    } else {
+      this._manager._resolvedBreakpoints.delete(breakpoint.cdpId);
+      await this._manager._thread
+        ?.cdp()
+        .Debugger.removeBreakpoint({ breakpointId: breakpoint.cdpId });
+    }
+  }
+}

--- a/src/adapter/breakpoints/entryBreakpoint.ts
+++ b/src/adapter/breakpoints/entryBreakpoint.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Breakpoint } from './breakpointBase';
+import { BreakpointManager } from '../breakpoints';
+import Dap from '../../dap/api';
+
+/**
+ * A breakpoint set automatically on module entry.
+ */
+export class EntryBreakpoint extends Breakpoint {
+  constructor(manager: BreakpointManager, source: Dap.Source) {
+    super(manager, source, { lineNumber: 1, columnNumber: 1 });
+  }
+}

--- a/src/adapter/breakpoints/hitCondition.ts
+++ b/src/adapter/breakpoints/hitCondition.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ProtocolError, invalidHitCondition } from '../../dap/errors';
+
+/**
+ * Regex used to match hit conditions. It matches the operator in group 1 and
+ * the constant in group 2.
+ */
+const hitConditionRe = /^(>|>=|={1,3}|<|<=|%)?\s*([0-9]+)$/;
+
+/**
+ * A hit condition breakpoint encapsulates the handling of breakpoints hit on
+ * a certain "nth" times we pause on them. For instance, a user could define
+ * a hit condition breakpoint to pause the second time we reach it.
+ *
+ * This is used and exposed by the {@link Breakpoint} class.
+ */
+export class HitCondition {
+  private hits = 0;
+
+  protected constructor(private readonly predicate: (n: number) => boolean) {}
+
+  /**
+   * Indicates that the breakpoint was hit, and returns whether the debugger
+   * should remain paused.
+   */
+  public test() {
+    return this.predicate(++this.hits);
+  }
+
+  /**
+   * Parses the hit condition expression, like "> 42", into a {@link HitCondition}.
+   * @throws {ProtocolError} if the expression is invalid
+   */
+  public static parse(expression: string) {
+    const parts = hitConditionRe.exec(expression);
+    if (!parts) {
+      throw new ProtocolError(invalidHitCondition(expression));
+    }
+
+    const [, op, value] = parts;
+    const expr =
+      op === '%' ? `return (numHits % ${value}) === 0;` : `return numHits ${op} ${value};`;
+
+    return new HitCondition(new Function('numHits', expr) as (n: number) => boolean);
+  }
+}

--- a/src/adapter/breakpoints/userDefinedBreakpoint.ts
+++ b/src/adapter/breakpoints/userDefinedBreakpoint.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { CdpReferenceState, Breakpoint, BreakpointCdpReference } from './breakpointBase';
+import * as nls from 'vscode-nls';
+import { BreakpointManager, kLogPointUrl } from '../breakpoints';
+import Dap from '../../dap/api';
+import { rewriteLogPoint } from '../../common/sourceUtils';
+import { getDeferred } from '../../common/promiseUtil';
+import { HitCondition } from './hitCondition';
+import { Thread } from '../threads';
+import Cdp from '../../cdp/api';
+
+const localize = nls.loadMessageBundle();
+
+export class UserDefinedBreakpoint extends Breakpoint {
+  /**
+   * A deferred that resolves once the breakpoint 'set' response has been
+   * returned to the UI. We should wait for this to finish before sending any
+   * notifications about breakpoint changes.
+   */
+  private readonly completedSet = getDeferred<void>();
+
+  /**
+   * @param hitCondition - Hit condition for this breakpoint. See
+   * {@link HitCondition} for more information.
+   */
+  constructor(
+    manager: BreakpointManager,
+    public readonly dapId: number,
+    source: Dap.Source,
+    private readonly dapParams: Dap.SourceBreakpoint,
+    private readonly hitCondition?: HitCondition,
+  ) {
+    super(manager, source, { lineNumber: dapParams.line, columnNumber: dapParams.column || 1 });
+  }
+
+  /**
+   * Returns a promise that resolves once the breakpoint 'set' response
+   */
+  public untilSetCompleted() {
+    return this.completedSet.promise;
+  }
+
+  /**
+   * Marks the breakpoint 'set' as having finished.
+   */
+  public markSetCompleted() {
+    this.completedSet.resolve();
+  }
+
+  /**
+   * Returns whether the debugger should remain paused on this breakpoint
+   * according to the hit condition.
+   */
+  public testHitCondition() {
+    return this.hitCondition?.test() ?? true;
+  }
+
+  /**
+   * Returns a DAP representation of the breakpoint. If the breakpoint is
+   * resolved, this will be fulfilled with the complete source location.
+   */
+  public async toDap(): Promise<Dap.Breakpoint> {
+    const location = this.getResolvedUiLocation();
+    if (location) {
+      return {
+        id: this.dapId,
+        verified: true,
+        source: await location.source.toDap(),
+        line: location.lineNumber,
+        column: location.columnNumber,
+      };
+    }
+
+    return {
+      id: this.dapId,
+      verified: false,
+      message: localize('breakpoint.provisionalBreakpoint', `Unbound breakpoint`), // TODO: Put a useful message here
+    };
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async updateUiLocations(
+    thread: Thread,
+    cdpId: Cdp.Debugger.BreakpointId,
+    resolvedLocations: Cdp.Debugger.Location[],
+  ) {
+    const hadPreviousLocation = !!this.getResolvedUiLocation();
+    await super.updateUiLocations(thread, cdpId, resolvedLocations);
+    if (!hadPreviousLocation) {
+      this.notifyResolved();
+    }
+  }
+
+  /**
+   * @override
+   */
+  protected getBreakCondition() {
+    const { logMessage, condition } = this.dapParams;
+
+    const expressions: string[] = [];
+    if (logMessage) {
+      expressions.push(rewriteLogPoint(logMessage) + `\n//# sourceURL=${kLogPointUrl}`);
+    }
+
+    if (condition) {
+      expressions.push(condition);
+    }
+
+    return expressions.length ? expressions.join(' && ') : undefined;
+  }
+
+  /**
+   * @override
+   */
+  protected updateCdpRefs(
+    mutator: (l: ReadonlyArray<BreakpointCdpReference>) => ReadonlyArray<BreakpointCdpReference>,
+  ) {
+    const previousLocation = this.getResolvedUiLocation();
+    super.updateCdpRefs(mutator);
+
+    if (this.getResolvedUiLocation() !== previousLocation) {
+      this.notifyResolved();
+    }
+  }
+
+  /**
+   * Gets the location whether this breakpoint is resolved, if any.
+   */
+  private getResolvedUiLocation() {
+    for (const bp of this.cdpBreakpoints) {
+      if (bp.state === CdpReferenceState.Applied && bp.uiLocations.length) {
+        return bp.uiLocations[0];
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Called the breakpoint manager to notify that the breakpoint is resolved,
+   * used for statistics and notifying the UI.
+   */
+  private async notifyResolved(): Promise<void> {
+    const location = this.getResolvedUiLocation();
+    if (location) {
+      await this._manager.notifyBreakpointResolved(
+        this.dapId,
+        location,
+        this.completedSet.hasSettled(),
+      );
+    }
+  }
+}

--- a/src/dap/errors.ts
+++ b/src/dap/errors.ts
@@ -16,6 +16,7 @@ export const enum ErrorCodes {
   CannotLoadEnvironmentVariables,
   CannotFindNodeBinary,
   NodeBinaryOutOfDate,
+  InvalidHitCondition,
 }
 
 export function reportToConsole(dap: Dap.Api, error: string) {
@@ -107,6 +108,16 @@ export const nodeBinaryOutOfDate = (readVersion: string, attemptedPath: string) 
       readVersion,
     ),
     ErrorCodes.NodeBinaryOutOfDate,
+  );
+
+export const invalidHitCondition = (expression: string) =>
+  createUserError(
+    localize(
+      'invalidHitCondition',
+      'Invalid hit condition "{0}". Expected an expression like "> 42" or "== 2".',
+      expression,
+    ),
+    ErrorCodes.InvalidHitCondition,
   );
 
 export class ProtocolError extends Error {

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -102,7 +102,7 @@ export class NodeTarget implements ITarget {
   }
 
   defaultScriptOffset(): InlineScriptOffset {
-    return { lineOffset: 0, columnOffset: 62 };
+    return { lineOffset: 0, columnOffset: 0 };
   }
 
   skipFiles(): ScriptSkipper | undefined {

--- a/src/test/breakpoints/breakpoints-first-line-breaks-if-requested.txt
+++ b/src/test/breakpoints/breakpoints-first-line-breaks-if-requested.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${workspaceFolder}/simpleNode/index.js:1:1

--- a/src/test/breakpoints/breakpoints-first-line-does-not-break-if-not-requested.txt
+++ b/src/test/breakpoints/breakpoints-first-line-does-not-break-if-not-requested.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${workspaceFolder}/simpleNode/index.js:2:1

--- a/src/test/breakpoints/breakpoints-hot-transpiled-adjusts-breakpoints.txt
+++ b/src/test/breakpoints/breakpoints-hot-transpiled-adjusts-breakpoints.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+triple @ ${workspaceFolder}/tsNode/double.ts:5:2

--- a/src/test/breakpoints/breakpoints-hot-transpiled-breaks-on-first-line.txt
+++ b/src/test/breakpoints/breakpoints-hot-transpiled-breaks-on-first-line.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${workspaceFolder}/tsNode/double.ts:4:1

--- a/src/test/breakpoints/breakpoints-hot-transpiled-does-not-adjust-already-correct.txt
+++ b/src/test/breakpoints/breakpoints-hot-transpiled-does-not-adjust-already-correct.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+double @ ${workspaceFolder}/tsNode/double.ts:15:2

--- a/src/test/breakpoints/breakpointsTest.ts
+++ b/src/test/breakpoints/breakpointsTest.ts
@@ -363,19 +363,83 @@ describe('breakpoints', () => {
     });
   });
 
-  itIntegrates('handles hot-transpiled modules', async ({ r }) => {
-    await r.initialize;
+  describe('first line', () => {
+    itIntegrates('breaks if requested', async ({ r }) => {
+      await r.initialize;
 
-    const cwd = join(testWorkspace, 'tsNode');
-    const handle = await r.runScript(join(cwd, 'index.js'));
-    await handle.dap.setBreakpoints({
-      source: { path: join(cwd, 'double.ts') },
-      breakpoints: [{ line: 12, column: 1 }],
+      const cwd = join(testWorkspace, 'simpleNode');
+      const handle = await r.runScript(join(cwd, 'index.js'));
+      await handle.dap.setBreakpoints({
+        source: { path: join(cwd, 'index.js') },
+        breakpoints: [{ line: 1, column: 1 }],
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      handle.assertLog({ substring: true });
     });
 
-    handle.load();
-    await waitForPause(handle);
-    handle.assertLog({ substring: true });
+    itIntegrates('does not break if not requested', async ({ r }) => {
+      await r.initialize;
+
+      const cwd = join(testWorkspace, 'simpleNode');
+      const handle = await r.runScript(join(cwd, 'index.js'));
+      await handle.dap.setBreakpoints({
+        source: { path: join(cwd, 'index.js') },
+        breakpoints: [{ line: 2, column: 1 }],
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      handle.assertLog({ substring: true });
+    });
+  });
+
+  describe('hot-transpiled', () => {
+    itIntegrates('breaks on first line', async ({ r }) => {
+      await r.initialize;
+
+      const cwd = join(testWorkspace, 'tsNode');
+      const handle = await r.runScript(join(cwd, 'index.js'));
+      await handle.dap.setBreakpoints({
+        source: { path: join(cwd, 'double.ts') },
+        breakpoints: [{ line: 1, column: 1 }],
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      handle.assertLog({ substring: true });
+    });
+
+    itIntegrates('adjusts breakpoints', async ({ r }) => {
+      await r.initialize;
+
+      const cwd = join(testWorkspace, 'tsNode');
+      const handle = await r.runScript(join(cwd, 'index.js'));
+      await handle.dap.setBreakpoints({
+        source: { path: join(cwd, 'double.ts') },
+        breakpoints: [{ line: 5, column: 1 }],
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      handle.assertLog({ substring: true });
+    });
+
+    itIntegrates('does not adjust already correct', async ({ r }) => {
+      await r.initialize;
+
+      const cwd = join(testWorkspace, 'tsNode');
+      const handle = await r.runScript(join(cwd, 'index.js'));
+      await handle.dap.setBreakpoints({
+        source: { path: join(cwd, 'double.ts') },
+        breakpoints: [{ line: 15, column: 1 }],
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      handle.assertLog({ substring: true });
+    });
   });
 
   itIntegrates('restart frame', async ({ r }) => {

--- a/src/test/node/node-runtime-attaching-attaches-children-of-child-processes.txt
+++ b/src/test/node/node-runtime-attaching-attaches-children-of-child-processes.txt
@@ -4,4 +4,4 @@
     reason : pause
     threadId : <number>
 }
-foo @ ${fixturesDir}/child.js:1:1
+foo @ ${fixturesDir}/child.js:1:19

--- a/src/test/node/node-runtime-attaching-attaches-to-existing-processes.txt
+++ b/src/test/node/node-runtime-attaching-attaches-to-existing-processes.txt
@@ -4,6 +4,4 @@
     reason : pause
     threadId : <number>
 }
-<anonymous> @ ${fixturesDir}/test.js:1:1
-listOnTimeout @ internal/timers.js:531:17
-processTimers @ internal/timers.js:475:7
+<anonymous> @ ${fixturesDir}/test.js:1:21

--- a/src/test/node/node-runtime-attaching-retries-attachment.txt
+++ b/src/test/node/node-runtime-attaching-retries-attachment.txt
@@ -4,4 +4,4 @@
     reason : pause
     threadId : <number>
 }
-<anonymous> @ ${fixturesDir}/test.js:1:1
+<anonymous> @ ${fixturesDir}/test.js:1:21

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -58,7 +58,9 @@ export async function run(): Promise<void> {
   runner.useColors(true);
 
   // todo: retry failing tests https://github.com/microsoft/vscode-pwa/issues/28
-  // runner.retries(2);
+  if (process.env.IS_CI) {
+    runner.retries(2);
+  }
 
   runner.addFile(join(__dirname, 'testIntegrationUtils'));
   runner.addFile(join(__dirname, 'infra/infra'));

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -58,7 +58,7 @@ export async function run(): Promise<void> {
   runner.useColors(true);
 
   // todo: retry failing tests https://github.com/microsoft/vscode-pwa/issues/28
-  runner.retries(2);
+  // runner.retries(2);
 
   runner.addFile(join(__dirname, 'testIntegrationUtils'));
   runner.addFile(join(__dirname, 'infra/infra'));

--- a/testWorkspace/simpleNode/index.js
+++ b/testWorkspace/simpleNode/index.js
@@ -1,0 +1,2 @@
+console.log('hello world');
+console.log('goodbye world');

--- a/testWorkspace/tsNode/double.ts
+++ b/testWorkspace/tsNode/double.ts
@@ -1,6 +1,9 @@
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
+export function triple(n: number) {
+  return n * 3; // this line matches, so BP won't be adjusted
+}
 
 export interface ISomeStuffToMakeLinesNotMatch {
   some: true;
@@ -9,5 +12,5 @@ export interface ISomeStuffToMakeLinesNotMatch {
 }
 
 export function double(n: number) {
-  return n * 2;
+  return n * 2; // this line is a different # in the compiled source
 }

--- a/testWorkspace/tsNode/index.js
+++ b/testWorkspace/tsNode/index.js
@@ -1,5 +1,6 @@
 require('ts-node').register({ transpileModule: true })
 
-const { double } = require('./double.ts');
+const { double, triple } = require('./double.ts');
 
+console.log(triple(3));
 console.log(double(21));


### PR DESCRIPTION
> **Note:** this is stacked on #174. That PR should be fast-forwards-merged first, and then this should be changed to point at master.

First of all, apologies for the churn. While this change is relatively
simple, I realized that hit condition breakpoints further diverges the
user-defined breakpoints and the managed 'entrypoint' breakpoints (as
of #174), where we don't have hit conditions or DAP representations.

Therefore, there's now a base "Breakpoint" class which implements the
purely CDP-side of things, which a `UserDefinedBreakpoint` extends with
metadata around DAP, and the `EntryBreakpoint` extends in a minimal way.
After doing the split there was almost no changes the existing code
around the breakpoints, which is good evidence that we are indeed
dealing with two different types of things!

That done, there's a new `HitBreakpoint` class whose parsing logic is
copied from the existing debug adapters. The UserDefinedBreakpoint
optionally includes a HitBreakpoint, and we check on these when we hit
a location to see whether we should automatically continue, or not.

This works in my quick manual tests. Haven't had a chance to write unit
tests for this, but I wanted to get it in PR before I head out for the
holidays.