### PR TITLE
Fix angular in VS

### DIFF
--- a/src/adapter/breakpointPredictor.ts
+++ b/src/adapter/breakpointPredictor.ts
@@ -113,7 +113,7 @@ export class BreakpointsPredictor {
         const sourceUrl = urlUtils.maybeAbsolutePathToFileUrl(this.rootPath, url);
         const resolvedUrl = urlUtils.completeUrlEscapingRoot(baseUrl, sourceUrl);
         const resolvedPath = this.sourcePathResolver
-          ? this.sourcePathResolver.urlToAbsolutePath({ url: resolvedUrl, map })
+          ? await this.sourcePathResolver.urlToAbsolutePath({ url: resolvedUrl, map })
           : urlUtils.fileUrlToAbsolutePath(resolvedUrl);
 
         if (!resolvedPath) {

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -577,7 +577,10 @@ export class SourceContainer {
       let source = this._sourceMapSourcesByUrl.get(resolvedUrl);
       const isNew = !source;
       if (!source) {
-        const absolutePath = await this.sourcePathResolver.urlToAbsolutePath({ url: resolvedUrl, map });
+        const absolutePath = await this.sourcePathResolver.urlToAbsolutePath({
+          url: resolvedUrl,
+          map,
+        });
         logger.verbose(LogTag.RuntimeSourceCreate, 'Creating source from source map', {
           inputUrl: resolvedUrl,
           absolutePath,

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -459,14 +459,14 @@ export class SourceContainer {
     return output;
   }
 
-  addSource(
+  async addSource(
     url: string,
     contentGetter: ContentGetter,
     sourceMapUrl?: string,
     inlineSourceRange?: InlineScriptOffset,
     contentHash?: string,
-  ): Source {
-    const absolutePath = this.sourcePathResolver.urlToAbsolutePath({ url });
+  ): Promise<Source> {
+    const absolutePath = await this.sourcePathResolver.urlToAbsolutePath({ url });
     logger.verbose(LogTag.RuntimeSourceCreate, 'Creating source from url', {
       inputUrl: url,
       absolutePath,
@@ -577,7 +577,7 @@ export class SourceContainer {
       let source = this._sourceMapSourcesByUrl.get(resolvedUrl);
       const isNew = !source;
       if (!source) {
-        const absolutePath = this.sourcePathResolver.urlToAbsolutePath({ url: resolvedUrl, map });
+        const absolutePath = await this.sourcePathResolver.urlToAbsolutePath({ url: resolvedUrl, map });
         logger.verbose(LogTag.RuntimeSourceCreate, 'Creating source from source map', {
           inputUrl: resolvedUrl,
           absolutePath,

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -983,7 +983,7 @@ export class Thread implements IVariableStoreDelegate {
     }
   }
 
-  _onScriptParsed(event: Cdp.Debugger.ScriptParsedEvent) {
+  async _onScriptParsed(event: Cdp.Debugger.ScriptParsedEvent) {
     if (event.url) event.url = this._delegate.scriptUrlToUrl(event.url);
 
     let urlHashMap = this._scriptSources.get(event.url);
@@ -1014,7 +1014,7 @@ export class Thread implements IVariableStoreDelegate {
       }
 
       const hash = this._delegate.shouldCheckContentHash() ? event.hash : undefined;
-      source = this._sourceContainer.addSource(
+      source = await this._sourceContainer.addSource(
         event.url,
         contentGetter,
         resolvedSourceMapUrl,

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -46,6 +46,7 @@ export class Binder implements IDisposable {
   private _targetOrigin: any;
   private _launchParams?: AnyLaunchConfiguration;
   private _rawTelemetryReporter: RawTelemetryReporterToDap | undefined;
+  private _clientCapabilities: Dap.InitializeParams | undefined;
 
   constructor(
     delegate: IBinderDelegate,
@@ -75,6 +76,7 @@ export class Binder implements IDisposable {
     this._dap.then(dap => {
       this._rawTelemetryReporter = new RawTelemetryReporterToDap(dap);
       dap.on('initialize', async clientCapabilities => {
+        this._clientCapabilities = clientCapabilities;
         const capabilities = DebugAdapter.capabilities();
         if (clientCapabilities.clientID === 'vscode') {
           filterErrorsReportedToTelemetry();
@@ -187,6 +189,7 @@ export class Binder implements IDisposable {
         params,
         { cancellationToken, targetOrigin: this._targetOrigin, dap: await this._dap },
         this._rawTelemetryReporter!,
+        this._clientCapabilities!,
       );
     } catch (e) {
       if (e instanceof TaskCancelledError) {

--- a/src/common/fsUtils.ts
+++ b/src/common/fsUtils.ts
@@ -6,6 +6,8 @@ import * as fs from 'fs';
 import * as util from 'util';
 const readFileAsync = util.promisify(fs.readFile);
 
+export const fsModule = fs;
+
 export function stat(path: string): Promise<fs.Stats | undefined> {
   return new Promise(cb => {
     fs.stat(path, (err, stat) => {

--- a/src/common/sourcePathResolver.ts
+++ b/src/common/sourcePathResolver.ts
@@ -32,7 +32,7 @@ export interface ISourcePathResolver {
   /**
    * Attempts to convert a URL received from CDP to a local file path.
    */
-  urlToAbsolutePath(request: IUrlResolution): string | undefined;
+  urlToAbsolutePath(request: IUrlResolution): Promise<string | undefined>;
 
   /**
    * Attempts to convert an absolute path on disk to a URL for CDP.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -477,11 +477,7 @@ export const baseDefaults: IBaseConfiguration = {
   rootPath: '${workspaceFolder}',
   outFiles: ['${workspaceFolder}/**/*.js', '!**/node_modules/**'],
   // keep in sync with sourceMapPathOverrides in package.json
-  sourceMapPathOverrides: {
-    'webpack://?:*/*': '*',
-    'webpack:///./~/*': '${workspaceFolder}/node_modules/*',
-    'meteor://💻app/*': '${workspaceFolder}/*',
-  },
+  sourceMapPathOverrides: defaultSourceMapPathOverrides('${workspaceFolder}'),
   // Should always be determined upstream
   __workspaceFolder: '',
 };
@@ -565,6 +561,14 @@ export const nodeAttachConfigDefaults: INodeAttachConfiguration = {
   request: 'attach',
   processId: '',
 };
+
+export function defaultSourceMapPathOverrides(webRoot: string): { [key: string]: string; } {
+  return {
+    'webpack://?:*/*': '*',
+    'webpack:///./~/*': `${webRoot}/node_modules/*`,
+    'meteor://💻app/*': `${webRoot}/*`,
+  };
+}
 
 export function applyNodeDefaults(config: ResolvingNodeConfiguration): AnyNodeConfiguration {
   return config.request === 'attach'

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -562,7 +562,7 @@ export const nodeAttachConfigDefaults: INodeAttachConfiguration = {
   processId: '',
 };
 
-export function defaultSourceMapPathOverrides(webRoot: string): { [key: string]: string; } {
+export function defaultSourceMapPathOverrides(webRoot: string): { [key: string]: string } {
   return {
     'webpack://?:*/*': '*',
     'webpack:///./~/*': `${webRoot}/node_modules/*`,

--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -138,6 +138,7 @@ export class BrowserLauncher implements ILauncher {
     params: IChromeLaunchConfiguration,
     { dap, targetOrigin, cancellationToken }: ILaunchContext,
     rawTelemetryReporter: IRawTelemetryReporter,
+    clientCapabilities: Dap.InitializeParams,
   ): Promise<BrowserTarget | string> {
     let launched: launcher.ILaunchResult;
     try {
@@ -163,6 +164,7 @@ export class BrowserLauncher implements ILauncher {
       remoteRoot: null,
       webRoot: params.webRoot || params.rootPath,
       sourceMapOverrides: params.sourceMapPathOverrides,
+      clientID: clientCapabilities.clientID,
     });
     this._targetManager = await BrowserTargetManager.connect(
       launched.cdp,
@@ -229,12 +231,18 @@ export class BrowserLauncher implements ILauncher {
     params: AnyChromeConfiguration,
     context: ILaunchContext,
     telemetryReporter: RawTelemetryReporterToDap,
+    clientCapabilities: Dap.InitializeParams,
   ): Promise<ILaunchResult> {
     if (params.type !== Contributions.ChromeDebugType || params.request !== 'launch') {
       return { blockSessionTermination: false };
     }
 
-    const targetOrError = await this.prepareLaunch(params, context, telemetryReporter);
+    const targetOrError = await this.prepareLaunch(
+      params,
+      context,
+      telemetryReporter,
+      clientCapabilities,
+    );
     if (typeof targetOrError === 'string') return { error: targetOrError };
     await this.finishLaunch(targetOrError, params);
     return { blockSessionTermination: true };

--- a/src/targets/browser/browserPathResolver.ts
+++ b/src/targets/browser/browserPathResolver.ts
@@ -12,6 +12,7 @@ import { properResolve } from '../../common/pathUtils';
 interface IOptions extends ISourcePathResolverOptions {
   baseUrl?: string;
   webRoot?: string;
+  clientID: string | undefined;
 }
 
 export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> {
@@ -59,7 +60,11 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
 
       // Prefixing ../ClientApp is a workaround for a bug in ASP.NET debugging in VisualStudio because the wwwroot is not properly configured
       const clientAppPath = properResolve(webRoot, '..', 'ClientApp', unmappedPath);
-      if (!(await fsUtils.exists(webRootPath)) && (await fsUtils.exists(clientAppPath))) {
+      if (
+        this.options.clientID === 'visualstudio' &&
+        !(await fsUtils.exists(webRootPath)) &&
+        (await fsUtils.exists(clientAppPath))
+      ) {
         return clientAppPath;
       } else {
         return webRootPath;

--- a/src/targets/browser/browserPathResolver.ts
+++ b/src/targets/browser/browserPathResolver.ts
@@ -62,6 +62,7 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
       const clientAppPath = properResolve(webRoot, '..', 'ClientApp', unmappedPath);
       if (
         this.options.clientID === 'visualstudio' &&
+        url.startsWith('webpack:///') &&
         !(await fsUtils.exists(webRootPath)) &&
         (await fsUtils.exists(clientAppPath))
       ) {

--- a/src/targets/browser/browserPathResolver.ts
+++ b/src/targets/browser/browserPathResolver.ts
@@ -4,7 +4,7 @@
 
 import * as path from 'path';
 import * as utils from '../../common/urlUtils';
-import * as fs from 'fs';
+import * as fsUtils from '../../common/fsUtils';
 import { ISourcePathResolverOptions, SourcePathResolverBase } from '../sourcePathResolver';
 import { IUrlResolution } from '../../common/sourcePathResolver';
 import { properResolve } from '../../common/pathUtils';
@@ -35,7 +35,7 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
     return utils.completeUrlEscapingRoot(baseUrl, utils.platformPathToUrlPath(relative));
   }
 
-  urlToAbsolutePath({ url, map }: IUrlResolution): string | undefined {
+  async urlToAbsolutePath({ url, map }: IUrlResolution): Promise<string | undefined> {
     if (map && !this.shouldResolveSourceMap(map)) {
       return undefined;
     }
@@ -59,7 +59,7 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
 
       // Prefixing ../ClientApp is a workaround for a bug in ASP.NET debugging in VisualStudio because the wwwroot is not properly configured
       const clientAppPath = properResolve(webRoot, '..', 'ClientApp', unmappedPath);
-      if (!fs.existsSync(webRootPath) && fs.existsSync(clientAppPath)) {
+      if (!(await fsUtils.exists(webRootPath)) && (await fsUtils.exists(clientAppPath))) {
         return clientAppPath;
       } else {
         return webRootPath;

--- a/src/targets/node/nodeSourcePathResolver.ts
+++ b/src/targets/node/nodeSourcePathResolver.ts
@@ -13,7 +13,7 @@ interface IOptions extends ISourcePathResolverOptions {
 }
 
 export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
-  urlToAbsolutePath({ url, map }: IUrlResolution): string | undefined {
+  async urlToAbsolutePath({ url, map }: IUrlResolution): Promise<string | undefined> {
     if (map && !this.shouldResolveSourceMap(map)) {
       return undefined;
     }

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -37,7 +37,7 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
   protected readonly sourceMapOverrides = new SourceMapOverrides(this.options.sourceMapOverrides);
   constructor(protected readonly options: T) {}
 
-  public abstract urlToAbsolutePath(request: IUrlResolution): string | undefined;
+  public abstract urlToAbsolutePath(request: IUrlResolution): Promise<string | undefined>;
 
   public abstract absolutePathToUrl(absolutePath: string): string | undefined;
 

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -89,6 +89,7 @@ export interface ILauncher extends IDisposable {
     params: AnyLaunchConfiguration,
     context: ILaunchContext,
     rawTelemetryReporter: RawTelemetryReporterToDap,
+    clientCapabilities: Dap.InitializeParams,
   ): Promise<ILaunchResult>;
   terminate(): Promise<void>;
   disconnect(): Promise<void>;

--- a/src/test/browser/browserPathResolverTest.ts
+++ b/src/test/browser/browserPathResolverTest.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as fs from 'fs';
+import { stub, SinonStub } from 'sinon';
+import { expect } from 'chai';
+import { BrowserSourcePathResolver } from '../../targets/browser/browserPathResolver';
+import { fsModule } from '../../common/fsUtils';
+
+describe('browserPathResolver.urlToAbsolutePath', () => {
+  let fsExistStub: SinonStub<[fs.PathLike, (cb: boolean) => void], void>;
+  before(() => {
+    fsExistStub = stub(fsModule, 'exists').callsFake((path, cb) => {
+      switch (path) {
+        case 'C:\\Users\\user\\Source\\Repos\\Angular Project\\ClientApp\\src\\app\\app.component.html':
+          return cb(true);
+        case 'C:\\Users\\user\\Source\\Repos\\Angular Project\\wwwroot\\src\\app\\app.component.html':
+          return cb(false);
+        default:
+          throw Error('Unknown path');
+      }
+    });
+  });
+
+  [
+    ['visualstudio', 'ClientApp'],
+    ['vscode', 'wwwroot'],
+  ].forEach(([client, folder]) => {
+    it.only(`returns ${folder} for ${client} if the webroot path doesn't exist and the modified path does`, async () => {
+      const webRoot = 'C:\\Users\\user\\Source\\Repos\\Angular Project\\wwwroot';
+
+      const defaultSourceMapOverrides = {
+        'meteor://💻app/*': '/*',
+        'webpack://?:*/*': '*',
+        'webpack:///./~/*': '/node_modules/*',
+      };
+
+      const resolver = new BrowserSourcePathResolver({
+        webRoot,
+        clientID: client,
+        baseUrl: 'http://localhost:60318/',
+        sourceMapOverrides: defaultSourceMapOverrides,
+        localRoot: null,
+        remoteRoot: null,
+        resolveSourceMapLocations: null,
+      });
+
+      const url = 'webpack:///src/app/app.component.html';
+      const absolutePath = await resolver.urlToAbsolutePath({ url });
+
+      expect(absolutePath).to.equal(
+        `C:\\Users\\user\\Source\\Repos\\Angular Project\\${folder}\\src\\app\\app.component.html`,
+      );
+    });
+  });
+
+  after(() => {
+    fsExistStub.restore();
+  });
+});

--- a/src/test/browser/browserPathResolverTest.ts
+++ b/src/test/browser/browserPathResolverTest.ts
@@ -7,6 +7,7 @@ import { stub, SinonStub } from 'sinon';
 import { expect } from 'chai';
 import { BrowserSourcePathResolver } from '../../targets/browser/browserPathResolver';
 import { fsModule } from '../../common/fsUtils';
+import { defaultSourceMapPathOverrides } from '../../configuration';
 
 describe('browserPathResolver.urlToAbsolutePath', () => {
   let fsExistStub: SinonStub<[fs.PathLike, (cb: boolean) => void], void>;
@@ -27,20 +28,14 @@ describe('browserPathResolver.urlToAbsolutePath', () => {
     ['visualstudio', 'ClientApp'],
     ['vscode', 'wwwroot'],
   ].forEach(([client, folder]) => {
-    it.only(`returns ${folder} for ${client} if the webroot path doesn't exist and the modified path does`, async () => {
+    it(`returns ${folder} for ${client} if the webroot path doesn't exist and the modified path does`, async () => {
       const webRoot = 'C:\\Users\\user\\Source\\Repos\\Angular Project\\wwwroot';
-
-      const defaultSourceMapOverrides = {
-        'meteor://💻app/*': '/*',
-        'webpack://?:*/*': '*',
-        'webpack:///./~/*': '/node_modules/*',
-      };
 
       const resolver = new BrowserSourcePathResolver({
         webRoot,
         clientID: client,
         baseUrl: 'http://localhost:60318/',
-        sourceMapOverrides: defaultSourceMapOverrides,
+        sourceMapOverrides: defaultSourceMapPathOverrides(webRoot),
         localRoot: null,
         remoteRoot: null,
         resolveSourceMapLocations: null,

--- a/src/test/node/node-source-path-resolver.test.ts
+++ b/src/test/node/node-source-path-resolver.test.ts
@@ -17,41 +17,41 @@ describe('node source path resolver', () => {
       sourceMapOverrides: { 'webpack:///*': '*' },
     };
 
-    it('resolves absolute', () => {
+    it('resolves absolute', async () => {
       const r = new NodeSourcePathResolver(defaultOptions);
-      expect(r.urlToAbsolutePath({ url: 'file:///src/index.js' })).to.equal(
+      expect(await r.urlToAbsolutePath({ url: 'file:///src/index.js' })).to.equal(
         resolve('/src/index.js'),
       );
     });
 
-    it('normalizes roots (win -> posix) ', () => {
+    it('normalizes roots (win -> posix) ', async () => {
       const r = new NodeSourcePathResolver({
         ...defaultOptions,
         remoteRoot: 'C:\\Source',
         localRoot: '/dev/src',
       });
 
-      expect(r.urlToAbsolutePath({ url: 'file:///c:/source/foo/bar.js' })).to.equal(
+      expect(await r.urlToAbsolutePath({ url: 'file:///c:/source/foo/bar.js' })).to.equal(
         '/dev/src/foo/bar.js',
       );
     });
 
-    it('normalizes roots (posix -> win) ', () => {
+    it('normalizes roots (posix -> win) ', async () => {
       const r = new NodeSourcePathResolver({
         ...defaultOptions,
         remoteRoot: '/dev/src',
         localRoot: 'C:\\Source',
       });
 
-      expect(r.urlToAbsolutePath({ url: 'file:///dev/src/foo/bar.js' })).to.equal(
+      expect(await r.urlToAbsolutePath({ url: 'file:///dev/src/foo/bar.js' })).to.equal(
         'c:\\Source\\foo\\bar.js',
       );
     });
 
-    it('applies source map overrides', () => {
+    it('applies source map overrides', async () => {
       const r = new NodeSourcePathResolver(defaultOptions);
 
-      expect(r.urlToAbsolutePath({ url: 'webpack:///hello.js' })).to.equal(
+      expect(await r.urlToAbsolutePath({ url: 'webpack:///hello.js' })).to.equal(
         join(__dirname, 'hello.js'),
       );
     });
@@ -104,7 +104,7 @@ describe('node source path resolver', () => {
         const { locs, map, ok } = tcase;
         const caseSensitive = 'caseSensitive' in tcase && tcase.caseSensitive;
 
-        it(key, () => {
+        it(key, async () => {
           setCaseSensitivePaths(caseSensitive);
 
           const resolver = new NodeSourcePathResolver({
@@ -112,7 +112,7 @@ describe('node source path resolver', () => {
             resolveSourceMapLocations: locs,
           });
 
-          const result = resolver.urlToAbsolutePath({
+          const result = await resolver.urlToAbsolutePath({
             url: 'webpack:///hello.js',
             map: { metadata: { sourceMapUrl: map } } as any,
           });

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -66,6 +66,7 @@ export async function run(): Promise<void> {
   runner.addFile(join(__dirname, 'infra/infra'));
   runner.addFile(join(__dirname, 'breakpoints/breakpointsTest'));
   runner.addFile(join(__dirname, 'browser/framesTest'));
+  runner.addFile(join(__dirname, 'browser/browserPathResolverTest'));
   runner.addFile(join(__dirname, 'evaluate/evaluate'));
   runner.addFile(join(__dirname, 'sources/sourcesTest'));
   runner.addFile(join(__dirname, 'stacks/stacksTest'));


### PR DESCRIPTION
Due to some limitations we can't always figure out the right webRoot in VS for Angular projects. This fix worksaround that fact by trying both <webRoot> and <webRoot>/../ClientApp at the same time.

(This fix was ported from v1: https://github.com/microsoft/vscode-chrome-debug-core/blob/87d2c194179033e38d68308027c1d1dbbc43c454/src/sourceMaps/sourceMapUtils.ts#L118 )