### PR TITLE
fix: allow omitting "program" from launch.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Or alternatively by self-hosting:
 
 1. Clone this repository and run `npm install`,
 2. Then either:
-   - Run `gulp build --nightly` to package a `.vsix` you can install manually, or
+   - Run `gulp package` to package a `.vsix` you can install manually, or
    - Run `npm run compile`, then open the repository in VS Code and select "Run Extension"
 3. Then you should be able to run and debug your programs without changing your launch config. If you can't, then please file an issue.
 

--- a/src/targets/node/subprocessProgramLauncher.ts
+++ b/src/targets/node/subprocessProgramLauncher.ts
@@ -23,11 +23,12 @@ export class SubprocessProgramLauncher implements IProgramLauncher {
     config: INodeLaunchConfiguration,
     context: ILaunchContext,
   ) {
-    const { executable, args, shell } = formatArguments(binary, [
-      ...config.runtimeArgs,
-      config.program,
-      ...config.args,
-    ]);
+    let execArgs = [...config.runtimeArgs, ...config.args];
+    if (config.program) {
+      execArgs = [...config.runtimeArgs, config.program, ...config.args];
+    }
+
+    const { executable, args, shell } = formatArguments(binary, execArgs);
 
     // Send an appoximation of the command we're running to
     // the terminal, for cosmetic purposes.


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-js-debug/issues/201

I also noticed `gulp build --nightly` does not seem to be a task; `gulp package` worked for me. 