### PR TITLE
fix: stopOnEntry not working with omitted program

### DIFF
--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -381,7 +381,7 @@ const nodeLaunchConfig: IDebugger<INodeLaunchConfiguration> = {
       default: '',
     },
     stopOnEntry: {
-      type: 'boolean',
+      type: ['boolean', 'string'],
       description: refString('node.stopOnEntry.description'),
       default: true,
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -241,12 +241,15 @@ export interface INodeLaunchConfiguration extends INodeBaseConfiguration {
   /**
    * Program to use to launch the debugger.
    */
-  program: string;
+  program?: string;
 
   /**
-   * Automatically stop program after launch.
+   * Automatically stop program after launch. It can be set to a boolean, or
+   * the absolute filepath to stop in. Setting a path for stopOnEntry should
+   * only be needed in esoteric scenarios where it cannot be inferred
+   * from the run args.
    */
-  stopOnEntry: boolean;
+  stopOnEntry: boolean | string;
 
   /**
    * Where to launch the debug target.

--- a/src/targets/node/terminalProgramLauncher.ts
+++ b/src/targets/node/terminalProgramLauncher.ts
@@ -31,7 +31,9 @@ export class TerminalProgramLauncher implements IProgramLauncher {
       kind: config.console === 'integratedTerminal' ? 'integrated' : 'external',
       title: localize('node.console.title', 'Node Debug Console'),
       cwd: config.cwd,
-      args: [binary, ...config.runtimeArgs, config.program, ...config.args],
+      args: config.program
+        ? [binary, ...config.runtimeArgs, config.program, ...config.args]
+        : [binary, ...config.runtimeArgs, ...config.args],
       env: removeNulls(config.env),
     };
 

--- a/src/test/node/node-runtime-stoponentry-launches-and-infers-entry-from-args.txt
+++ b/src/test/node/node-runtime-stoponentry-launches-and-infers-entry-from-args.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${fixturesDir}/test.js:1:1

--- a/src/test/node/node-runtime-stoponentry-sets-an-explicit-stop-on-entry-point.txt
+++ b/src/test/node/node-runtime-stoponentry-sets-an-explicit-stop-on-entry-point.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${fixturesDir}/test.js:1:1

--- a/src/test/node/node-runtime-stoponentry-stops-with-a-program-provided.txt
+++ b/src/test/node/node-runtime-stoponentry-stops-with-a-program-provided.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${fixturesDir}/test.js:1:1

--- a/src/test/node/node-runtime.test.ts
+++ b/src/test/node/node-runtime.test.ts
@@ -88,6 +88,47 @@ describe('node runtime', () => {
     });
   });
 
+  describe('stopOnEntry', () => {
+    beforeEach(() =>
+      createFileTree(testFixturesDir, { 'test.js': '', 'bar.js': 'require("./test")' }),
+    );
+
+    itIntegrates('stops with a program provided', async ({ r }) => {
+      const handle = await r.runScript('test.js', {
+        cwd: testFixturesDir,
+        stopOnEntry: true,
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      r.assertLog({ substring: true });
+    });
+
+    itIntegrates('launches and infers entry from args', async ({ r }) => {
+      const handle = await r.runScript('test.js', {
+        cwd: testFixturesDir,
+        args: ['--max-old-space-size=1024', 'test.js', '--not-a-file'],
+        program: undefined,
+        stopOnEntry: true,
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      r.assertLog({ substring: true });
+    });
+
+    itIntegrates('sets an explicit stop on entry point', async ({ r }) => {
+      const handle = await r.runScript('bar.js', {
+        cwd: testFixturesDir,
+        stopOnEntry: join(testFixturesDir, 'test.js'),
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      r.assertLog({ substring: true });
+    });
+  });
+
   describe('attaching', () => {
     let child: ChildProcess | undefined;
 


### PR DESCRIPTION
Fixes #201

As referenced in the comment, this isn't the ideal approach because it
was stolen from us by having a bootloader script. It should work for
most people, though, and I also allowed people to set a custom file path
in "stopOnEntry" in case the heuristics don't work (for instance, if
they start a Node program through a shell script where the path is not
present on the command line).