### PR TITLE
fix: absolute path handling in source map

### DIFF
--- a/src/targets/browser/browserPathResolver.ts
+++ b/src/targets/browser/browserPathResolver.ts
@@ -7,7 +7,7 @@ import * as utils from '../../common/urlUtils';
 import * as fsUtils from '../../common/fsUtils';
 import { ISourcePathResolverOptions, SourcePathResolverBase } from '../sourcePathResolver';
 import { IUrlResolution } from '../../common/sourcePathResolver';
-import { properResolve } from '../../common/pathUtils';
+import { properResolve, fixDriveLetterAndSlashes } from '../../common/pathUtils';
 
 interface IOptions extends ISourcePathResolverOptions {
   baseUrl?: string;
@@ -47,8 +47,8 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
     }
 
     const { baseUrl, webRoot } = this.options;
-    const absolutePath = utils.fileUrlToAbsolutePath(url);
-    if (absolutePath) return absolutePath;
+    const absolutePath = utils.isAbsolute(url) ? url : utils.fileUrlToAbsolutePath(url);
+    if (absolutePath) return fixDriveLetterAndSlashes(absolutePath);
 
     if (!webRoot) {
       return '';

--- a/src/test/breakpoints/breakpoints-configure-absolute-paths-in-source-maps.txt
+++ b/src/test/breakpoints/breakpoints-configure-absolute-paths-in-source-maps.txt
@@ -1,0 +1,23 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+bar @ ${workspaceFolder}/web/browserify/module2.ts:3:2
+3../module1 @ ${workspaceFolder}/web/browserify/pause.ts:4:3
+o @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
+r @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
+<anonymous> @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
+{
+    allThreadsStopped : false
+    description : Paused on debugger statement
+    reason : pause
+    threadId : <number>
+}
+foo @ ${workspaceFolder}/web/browserify/module1.ts:3:2
+bar @ ${workspaceFolder}/web/browserify/module2.ts:3:2
+3../module1 @ ${workspaceFolder}/web/browserify/pause.ts:4:3
+o @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
+r @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
+<anonymous> @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1


### PR DESCRIPTION
We previously allowed source map file URIs, but not full absolute paths. It appears that create-react-app on Windows specifically creates sourcemaps containing absolute paths (with forward slashes instead of back slashes). This PR adds handling and a test case for those.

Fixes https://github.com/microsoft/vscode-js-debug/issues/215