### PR TITLE
feat: add code lens for npm scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4201,7 +4201,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4222,12 +4223,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4242,17 +4245,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4369,7 +4375,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4381,6 +4388,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4395,6 +4403,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4402,12 +4411,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4426,6 +4437,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4506,7 +4518,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4518,6 +4531,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4603,7 +4617,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4639,6 +4654,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4658,6 +4674,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4701,12 +4718,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6246,6 +6265,11 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "jsonc-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.0.tgz",
+      "integrity": "sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA=="
     },
     "jsprim": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "color": "^3.1.2",
     "glob-stream": "^6.1.0",
     "js-beautify": "^1.10.0",
+    "jsonc-parser": "^2.2.0",
     "long": "^4.0.0",
     "micromatch": "^4.0.2",
     "source-map": "^0.7.3",
@@ -143,6 +144,7 @@
   "main": "./src/extension.js",
   "enableProposedApi": true,
   "activationEvents": [
+    "onLanguage:json",
     "onDebugInitialConfigurations",
     "onDebugResolve:node",
     "onDebugResolve:extensionHost",

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
-import { Contributions } from '../common/contributionUtils';
+import { Contributions, IConfigurationTypes, Configuration } from '../common/contributionUtils';
 import {
   AnyLaunchConfiguration,
   ResolvingConfiguration,
@@ -33,6 +33,7 @@ type ConfigurationAttributes<T> = {
   [K in keyof Omit<T, OmittedKeysFromAttributes>]: JSONSchema6 &
     Described & {
       default: T[K];
+      enum?: Array<T[K]>;
     };
 };
 type Described =
@@ -166,7 +167,7 @@ const baseConfigurationAttributes: ConfigurationAttributes<IBaseConfiguration> =
     ],
   },
   outputCapture: {
-    enum: ['console', 'std'],
+    enum: [OutputSource.Console, OutputSource.Stdio],
     description: refString('node.launch.outputCapture.description'),
     default: OutputSource.Console,
   },
@@ -694,8 +695,25 @@ function buildDebuggers() {
   return walkObject(output, sortKeys);
 }
 
+const configurationSchema: ConfigurationAttributes<IConfigurationTypes> = {
+  [Configuration.NpmScriptLens]: {
+    enum: ['top', 'all', 'never'],
+    default: 'top',
+    description: refString('configuration.npmScriptLensLocation'),
+  },
+  [Configuration.WarnOnLongPrediction]: {
+    type: 'boolean',
+    default: true,
+    description: refString('configuration.warnOnLongPrediction'),
+  },
+};
+
 process.stdout.write(
   JSON.stringify({
     debuggers: buildDebuggers(),
+    configuration: {
+      title: 'JavaScript Debugger',
+      properties: configurationSchema,
+    },
   }),
 );

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -157,8 +157,6 @@ const strings = {
   'node.timeout.description':
     'Retry for this number of milliseconds to connect to Node.js. Default is 10000 ms.',
 
-  'configuration.warnOnLongPrediction':
-    'Whether a loading prompt should be shown if breakpoint prediction takes a while.',
   'longPredictionWarning.message':
     "It's taking a while to configure your breakpoints. You can speed this up by updating the 'outFiles' in your launch.json.",
   'longPredictionWarning.open': 'Open launch.json',
@@ -172,8 +170,12 @@ const strings = {
     'An array of glob patterns for files to skip when debugging. The pattern `<node_internals>/**` matches all internal Node.js modules.',
   'smartStep.description':
     'Automatically step through generated code that cannot be mapped back to the original source.',
-
   'errors.timeout': '{0}: timeout after {1}ms',
+
+  'configuration.warnOnLongPrediction':
+    'Whether a loading prompt should be shown if breakpoint prediction takes a while.',
+  'configuration.npmScriptLensLocation':
+    'Where a "Run" and "Debug" code lens should be shown in your npm scripts. It may be on "all", scripts, on "top" of the script section, or "never".',
 };
 
 export default strings;

--- a/src/common/contributionUtils.ts
+++ b/src/common/contributionUtils.ts
@@ -2,6 +2,8 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { WorkspaceConfiguration } from 'vscode';
+
 export const enum Contributions {
   PrettyPrintCommand = 'extension.NAMESPACE(node-debug).prettyPrint',
   ToggleSkippingCommand = 'extension.NAMESPACE(node-debug).toggleSkippingFile',
@@ -20,6 +22,34 @@ export const enum Contributions {
   ChromeDebugType = 'NAMESPACE(chrome)',
 
   BrowserBreakpointsView = 'jsBrowserBreakpoints',
-  ConfigSection = 'debug.javascript',
-  WarnOnLongPredictionConfig = 'warnOnLongPrediction',
 }
+
+export const enum Configuration {
+  NpmScriptLens = 'debug.javascript.codelens.npmScripts',
+  WarnOnLongPrediction = 'debug.javascript.warnOnLongPrediction',
+}
+
+/**
+ * Type map for {@link Configuration} properties.
+ */
+export interface IConfigurationTypes {
+  [Configuration.NpmScriptLens]: 'all' | 'top' | 'never';
+  [Configuration.WarnOnLongPrediction]: boolean;
+}
+
+/**
+ * Typed guard for reading a contributed config.
+ */
+export const readConfig = <K extends keyof IConfigurationTypes>(
+  config: WorkspaceConfiguration,
+  key: K,
+) => config.get<IConfigurationTypes[K]>(key);
+
+/**
+ * Typed guard for updating a contributed config.
+ */
+export const writeConfig = <K extends keyof IConfigurationTypes>(
+  config: WorkspaceConfiguration,
+  key: K,
+  value: IConfigurationTypes[K],
+) => config.update(key, value);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { TerminalDebugConfigurationProvider } from './terminalDebugConfiguration
 import { debugNpmScript } from './ui/debugNpmScript';
 import { registerCustomBreakpointsUI } from './ui/customBreakpointsUI';
 import { registerLongBreakpointUI } from './ui/longPredictionUI';
+import { registerNpmScriptLens } from './ui/npmScriptLens';
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -81,6 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
   registerCustomBreakpointsUI(context, debugSessionTracker);
   registerPrettyPrintActions(context, debugSessionTracker);
   registerDebugScriptActions(context);
+  registerNpmScriptLens(context);
 }
 
 export function deactivate() {

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -61,7 +61,7 @@ export class NodeTarget implements ITarget, IThreadDelegate {
     else this._targetName = `[${targetInfo.targetId}]`;
 
     cdp.Target.on('targetDestroyed', () => this.connection.close());
-    connection.onDisconnected(_ => this._disconnected());
+    connection.onDisconnected(() => this._disconnected());
   }
 
   id(): string {

--- a/src/telemetry/opsReportBatch.ts
+++ b/src/telemetry/opsReportBatch.ts
@@ -92,19 +92,19 @@ export class OpsReportBatcher {
   }
 }
 
-function extractAllPropertyNames(objects: object[]): string[] {
+function extractAllPropertyNames<T>(objects: T[]): (keyof T)[] {
   return _.uniq(_.flatten(objects.map(object => Object.keys(object))));
 }
 
-function aggregateIntoSingleObject(
-  objectsToAggregate: object[],
+function aggregateIntoSingleObject<T>(
+  objectsToAggregate: T[],
 ): { [propertyName: string]: unknown[] } {
   const manyPropertyNames = extractAllPropertyNames(objectsToAggregate);
   return _.fromPairs(
-    manyPropertyNames.map((propertyName: string) => {
+    manyPropertyNames.map(propertyName => {
       return [
         propertyName,
-        objectsToAggregate.map((objectToAggregate: any) => objectToAggregate[propertyName]),
+        objectsToAggregate.map(objectToAggregate => objectToAggregate[propertyName]),
       ];
     }),
   );

--- a/src/ui/debugNpmScript.ts
+++ b/src/ui/debugNpmScript.ts
@@ -20,9 +20,10 @@ type ScriptPickItem = vscode.QuickPickItem & { script: IScript };
 
 /**
  * Opens a quickpick and them subsequently debugs a configured npm script.
+ * @param inFolder - Optionally scopes lookups to the given workspace folder
  */
-export async function debugNpmScript() {
-  const scripts = await findScripts();
+export async function debugNpmScript(inFolder?: vscode.WorkspaceFolder) {
+  const scripts = await findScripts(inFolder);
   if (!scripts) {
     return; // cancelled
   }
@@ -39,7 +40,7 @@ export async function debugNpmScript() {
 
   quickPick.onDidAccept(() => {
     const { script } = quickPick.selectedItems[0];
-    vscode.debug.startDebugging(vscode.workspace.workspaceFolders![0], {
+    vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], {
       type: Contributions.TerminalDebugType,
       name: quickPick.selectedItems[0].label,
       request: 'launch',
@@ -64,8 +65,8 @@ const updateEditCandidate = (existing: IEditCandidate, updated: IEditCandidate) 
 /**
  * Finds configured npm scripts in the workspace.
  */
-async function findScripts(): Promise<IScript[] | void> {
-  const folders = vscode.workspace.workspaceFolders;
+async function findScripts(inFolder?: vscode.WorkspaceFolder): Promise<IScript[] | void> {
+  const folders = inFolder ? [inFolder] : vscode.workspace.workspaceFolders;
 
   // 1. If there are no open folders, show an error and abort.
   if (!folders || folders.length === 0) {

--- a/src/ui/debugScriptUI.ts
+++ b/src/ui/debugScriptUI.ts
@@ -7,12 +7,16 @@ import { Contributions } from '../common/contributionUtils';
 
 export function registerDebugScriptActions(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand(Contributions.CreateDebuggerTerminal, async e => {
-      vscode.debug.startDebugging(vscode.workspace.workspaceFolders![0], {
-        type: Contributions.TerminalDebugType,
-        name: 'Debugger Terminal',
-        request: 'launch',
-      });
-    }),
+    vscode.commands.registerCommand(
+      Contributions.CreateDebuggerTerminal,
+      async (command?: string, workspaceFolder = vscode.workspace.workspaceFolders?.[0]) => {
+        vscode.debug.startDebugging(workspaceFolder, {
+          type: Contributions.TerminalDebugType,
+          name: 'Debugger Terminal',
+          request: 'launch',
+          command,
+        });
+      },
+    ),
   );
 }

--- a/src/ui/longPredictionUI.ts
+++ b/src/ui/longPredictionUI.ts
@@ -4,15 +4,14 @@
 
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { Contributions } from '../common/contributionUtils';
+import { Configuration, readConfig, writeConfig } from '../common/contributionUtils';
 import { join } from 'path';
 
 const localize = nls.loadMessageBundle();
 
 async function promptLongBreakpoint(workspaceFolder?: vscode.WorkspaceFolder) {
-  const extConfig = vscode.workspace.getConfiguration(Contributions.ConfigSection);
-  const shouldWarn = extConfig.get<boolean>(Contributions.WarnOnLongPredictionConfig);
-  if (shouldWarn === false) {
+  const config = vscode.workspace.getConfiguration();
+  if (!readConfig(config, Configuration.WarnOnLongPrediction)) {
     return;
   }
 
@@ -25,7 +24,7 @@ async function promptLongBreakpoint(workspaceFolder?: vscode.WorkspaceFolder) {
   const result = await vscode.window.showWarningMessage(message, dontShow, openLaunch);
 
   if (result === dontShow) {
-    await extConfig.update(Contributions.WarnOnLongPredictionConfig, false);
+    await writeConfig(config, Configuration.WarnOnLongPrediction, false);
     return;
   }
 

--- a/src/ui/npmScriptLens.ts
+++ b/src/ui/npmScriptLens.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import {
+  TextDocument,
+  CodeLens,
+  CodeLensProvider,
+  Range,
+  workspace,
+  languages,
+  ExtensionContext,
+  ProviderResult,
+  Position,
+  EventEmitter,
+} from 'vscode';
+import { readConfig, Contributions, Configuration } from '../common/contributionUtils';
+import { JSONVisitor, visit } from 'jsonc-parser';
+import { IDisposable } from '../common/disposable';
+
+const getFreshLensLocation = () =>
+  readConfig(workspace.getConfiguration(), Configuration.NpmScriptLens);
+
+/**
+ * Npm script lens provider implementation. Can show a "Debug" text above any
+ * npm script, or the npm scripts section.
+ */
+class NpmScriptLenProvider implements CodeLensProvider, IDisposable {
+  private lensLocation = getFreshLensLocation();
+  private changeEmitter = new EventEmitter<void>();
+  private subscriptions: IDisposable[] = [];
+
+  /**
+   * @inheritdoc
+   */
+  public onDidChangeCodeLenses = this.changeEmitter.event;
+
+  constructor() {
+    this.subscriptions.push(
+      workspace.onDidChangeConfiguration(evt => {
+        if (evt.affectsConfiguration(Configuration.NpmScriptLens)) {
+          this.lensLocation = getFreshLensLocation();
+          this.changeEmitter.fire();
+        }
+      }),
+    );
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public provideCodeLenses(document: TextDocument): ProviderResult<CodeLens[]> {
+    if (this.lensLocation === 'never') {
+      return [];
+    }
+
+    const tokens = this.tokenizeScripts(document);
+    if (!tokens) {
+      return [];
+    }
+
+    const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
+    if (this.lensLocation === 'top') {
+      return [
+        new CodeLens(new Range(tokens.scriptStart, tokens.scriptStart), {
+          title: 'Debug',
+          command: Contributions.DebugNpmScript,
+          arguments: [workspaceFolder],
+        }),
+      ];
+    }
+
+    if (this.lensLocation === 'all') {
+      return tokens.scripts.map(
+        ({ value, position }) =>
+          new CodeLens(new Range(position, position), {
+            title: 'Debug',
+            command: Contributions.CreateDebuggerTerminal,
+            arguments: [value, workspaceFolder],
+          }),
+      );
+    }
+
+    return [];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public dispose() {
+    this.subscriptions.forEach(s => s.dispose());
+  }
+
+  /**
+   * Returns position data about the "scripts" section of the current JSON
+   * document.
+   */
+  private tokenizeScripts(document: TextDocument) {
+    let scriptStart: Position | undefined;
+    let inScripts = false;
+    let buildingScript: { name: string; position: Position } | void;
+    const text = document.getText();
+    const getPos = (offset: number) => {
+      const line = text.slice(0, offset).match(/\n/g)?.length ?? 0;
+      const character = offset - Math.max(0, text.lastIndexOf('\n', offset));
+      return new Position(line, character);
+    };
+
+    const scripts: { name: string; value: string; position: Position }[] = [];
+
+    const visitor: JSONVisitor = {
+      onError() {
+        // no-op
+      },
+      onObjectEnd() {
+        if (inScripts) {
+          inScripts = false;
+        }
+      },
+      onLiteralValue(value: unknown) {
+        if (buildingScript && typeof value === 'string') {
+          scripts.push({ ...buildingScript, value });
+          buildingScript = undefined;
+        }
+      },
+      onObjectProperty(property: string, offset: number) {
+        if (property === 'scripts') {
+          inScripts = true;
+          scriptStart = getPos(offset);
+        } else if (inScripts) {
+          buildingScript = { name: property, position: getPos(offset) };
+        }
+      },
+    };
+
+    visit(text, visitor);
+
+    return scriptStart !== undefined ? { scriptStart, scripts } : undefined;
+  }
+}
+
+export const registerNpmScriptLens = (context: ExtensionContext) => {
+  const provider = new NpmScriptLenProvider();
+
+  context.subscriptions.push(provider);
+  context.subscriptions.push(
+    languages.registerCodeLensProvider(
+      {
+        language: 'json',
+        pattern: '**/package.json',
+      },
+      provider,
+    ),
+  );
+};


### PR DESCRIPTION
Fixes #196. Adds a code lens to debug an npm script. This adapter
currently doesn't support `nodebug` very well, and there are changes
coming to the terminal in #199, so I didn't implement a "Run" action
yet, but that should be straightforward once those are resolved.

By default the code lens appears atop the "script" section of the
package.json from where it opens a quick-pick, but it can also be
shown above individual scripts or hidden.

This also includes a slight modification to the contrib generator for
configuration to add some type safety.

![Kapture 2020-01-08 at 11 30 49](https://user-images.githubusercontent.com/2230985/72009252-5ed06980-320a-11ea-915d-856cc622852a.gif)

