### PR TITLE
Send console output as plain text when possible

### DIFF
--- a/src/adapter/messageFormat.ts
+++ b/src/adapter/messageFormat.ts
@@ -63,7 +63,7 @@ export function formatMessage<T>(
   format: string,
   substitutions: ReadonlyArray<T>,
   formatters: Formatters<T>,
-): string {
+): { result: string; usedAllSubs: boolean } {
   const tokens = tokenizeFormatString(format, Array.from(formatters.keys()));
   const usedSubstitutionIndexes = new Set<number>();
   const defaultFormatter = formatters.get('');
@@ -97,13 +97,17 @@ export function formatMessage<T>(
 
   for (let i = 0; builder.checkBudget() && i < substitutions.length; ++i) {
     if (usedSubstitutionIndexes.has(i)) continue;
+    usedSubstitutionIndexes.add(i);
     if (format || i)
       // either we are second argument or we had format.
       builder.append(' ');
     builder.append(defaultFormatter(substitutions[i], builder.budget()));
   }
 
-  return builder.build();
+  return {
+    result: builder.build(),
+    usedAllSubs: usedSubstitutionIndexes.size === substitutions.length,
+  };
 }
 
 function escapeAnsiColor(colorString: string): number | undefined {

--- a/src/test/console/console-api-format-format-string.txt
+++ b/src/test/console/console-api-format-format-string.txt
@@ -5,24 +5,19 @@ Evaluating: 'console.info('Info')'
 stdout> Info
 
 Evaluating: 'console.warn('Warn')'
-console> > Warn
-console>     <anonymous> @ <eval>/VM<xx>:1:9
+console> Warn
 
 Evaluating: 'console.error('Error')'
-stderr> > Error
-stderr>     <anonymous> @ <eval>/VM<xx>:1:9
+stderr> Error
 
 Evaluating: 'console.assert(false, 'Assert')'
-stderr> > Assert
-stderr>     <anonymous> @ <eval>/VM<xx>:1:9
+stderr> Assert
 
 Evaluating: 'console.assert(false)'
-stderr> > Assertion failed
-stderr>     <anonymous> @ <eval>/VM<xx>:1:9
+stderr> Assertion failed
 
 Evaluating: 'console.trace('Trace')'
-stdout> > Trace
-stdout>     <anonymous> @ <eval>/VM<xx>:1:9
+stdout> Trace
 
 Evaluating: 'console.count('Counter')'
 stdout> Counter: 1

--- a/src/test/console/console-format-popular-types.txt
+++ b/src/test/console/console-format-popular-types.txt
@@ -23,8 +23,7 @@ Evaluating: 'console.log([str2])'
 stdout> > (1) ['test named "test"']
 
 Evaluating: 'console.log(error)'
-stdout> 
-Error
+stdout> Error
     at console-format:9:23
 
 Evaluating: 'console.log([error])'
@@ -33,8 +32,7 @@ stdout>
     at console-format:9:23]
 
 Evaluating: 'console.log(errorWithMessage)'
-stdout> 
-Error: my error message
+stdout> Error: my error message
     at console-format:10:34
 
 Evaluating: 'console.log([errorWithMessage])'
@@ -43,8 +41,7 @@ stdout>
     at console-format:10:34]
 
 Evaluating: 'console.log(errorWithMultilineMessage)'
-stdout> 
-Error: my multiline
+stdout> Error: my multiline
 error message
     at console-format:11:43
 


### PR DESCRIPTION
so that the client doesn't have to send a variables
request for every output. We will just use a variablesReference
when an object is logged, or when not all logged data gets
into the text representation
Fix #227