### PR TITLE
Send the thread 'exited' event after all other events

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -629,12 +629,14 @@ export class Thread implements IVariableStoreDelegate {
     for (const [debuggerId, thread] of Thread._allThreadsByDebuggerId) {
       if (thread === this) Thread._allThreadsByDebuggerId.delete(debuggerId);
     }
+
+    this._executionContextsCleared();
+
+    // Send 'exited' after all other thread-releated events
     this._dap.thread({
       reason: 'exited',
       threadId: this.id,
     });
-
-    this._executionContextsCleared();
   }
 
   rawLocation(


### PR DESCRIPTION
FIx #229