### PR TITLE
feat: tag events correctly for gdpr

### DIFF
--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -10,7 +10,6 @@ import { IDisposable } from '../common/events';
 import { BreakpointsPredictor } from './breakpointPredictor';
 import * as urlUtils from '../common/urlUtils';
 import { BreakpointsStatisticsCalculator } from '../statistics/breakpointsStatistics';
-import { TelemetryEntityProperties } from '../telemetry/telemetryReporter';
 import { logger, assert } from '../common/logging/logger';
 import { LogTag } from '../common/logging';
 import { delay } from '../common/promiseUtil';
@@ -453,7 +452,7 @@ export class BreakpointManager {
     }
   }
 
-  public statisticsForTelemetry(): TelemetryEntityProperties {
+  public statisticsForTelemetry() {
     return this._breakpointsStatisticsCalculator.statistics();
   }
 

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -14,7 +14,7 @@ import { BreakpointManager, generateBreakpointIds } from './breakpoints';
 import { Cdp } from '../cdp/api';
 import { ISourcePathResolver } from '../common/sourcePathResolver';
 import { AnyLaunchConfiguration } from '../configuration';
-import { IRawTelemetryReporter } from '../telemetry/telemetryReporter';
+import { TelemetryReporter } from '../telemetry/telemetryReporter';
 import { CodeSearchSourceMapRepository } from '../common/sourceMaps/codeSearchSourceMapRepository';
 import { BreakpointsPredictor, BreakpointPredictionCache } from './breakpointPredictor';
 import { CorrelatedCache } from '../common/sourceMaps/mtimeCorrelatedCache';
@@ -47,7 +47,7 @@ export class DebugAdapter {
     sourcePathResolver: ISourcePathResolver,
     private readonly asyncStackPolicy: IAsyncStackPolicy,
     private readonly launchConfig: AnyLaunchConfiguration,
-    private readonly _rawTelemetryReporter: IRawTelemetryReporter,
+    private readonly _rawTelemetryReporter: TelemetryReporter,
   ) {
     this._configurationDoneDeferred = getDeferred();
     this.dap = dap;
@@ -114,9 +114,9 @@ export class DebugAdapter {
       bpPredictor,
     );
 
-    this._rawTelemetryReporter.flush.event(() => {
+    this._rawTelemetryReporter.onFlush(() => {
       this._rawTelemetryReporter.report(
-        'breakpointsStatistics',
+        'breakpointStats',
         this.breakpointManager.statisticsForTelemetry(),
       );
     });

--- a/src/dap/flatSessionConnection.ts
+++ b/src/dap/flatSessionConnection.ts
@@ -4,9 +4,7 @@
 
 import DapConnection, { Message } from './connection';
 import { EventEmitter, IDisposable } from '../common/events';
-import { HighResolutionTime } from '../utils/performance';
 import { TelemetryReporter } from '../telemetry/telemetryReporter';
-import { assert } from '../common/logging/logger';
 
 /**
  * An extension of the DAP connection class which publishes all messages which are received
@@ -16,21 +14,14 @@ export class MessageEmitterConnection extends DapConnection {
   public readonly onMessage = this._messageEventEmitter.event;
   public readonly initialized = new EventEmitter<TelemetryReporter>();
 
-  public get telemetryReporter(): TelemetryReporter | undefined {
-    return this._telemetryReporter;
-  }
-
-  async _onMessage(msg: Message, receivedTime: HighResolutionTime) {
+  async _onMessage(msg: Message, receivedTime: bigint) {
     msg.__receivedTime = receivedTime;
     this._messageEventEmitter.fire(msg);
   }
 
   public init(inStream: NodeJS.ReadableStream, outStream: NodeJS.WritableStream) {
     super.init(inStream, outStream);
-
-    if (assert(this._telemetryReporter, 'Expected telemetry reporter to have been set')) {
-      this.initialized.fire(this._telemetryReporter);
-    }
+    this.initialized.fire(this.telemetryReporter);
   }
 }
 
@@ -43,19 +34,15 @@ export class ChildConnection extends DapConnection {
   private _messageSubscription: IDisposable;
 
   constructor(
+    telemetryReporter: TelemetryReporter,
     private readonly parentConnection: MessageEmitterConnection,
     private readonly sessionId: string | undefined,
   ) {
-    super();
-    this._telemetryReporter = parentConnection.telemetryReporter;
-
-    parentConnection.initialized.event(telemetryReporter => {
-      this._telemetryReporter = telemetryReporter;
-    });
+    super(telemetryReporter);
 
     this._messageSubscription = parentConnection.onMessage(msg => {
       if (msg.sessionId === this.sessionId) {
-        super._onMessage(msg, msg.__receivedTime || [0, 0]);
+        super._onMessage(msg, msg.__receivedTime || BigInt(0));
       }
     });
 

--- a/src/debugServer.ts
+++ b/src/debugServer.ts
@@ -23,6 +23,7 @@ import { ExtensionHostAttacher } from './targets/node/extensionHostAttacher';
 import * as nls from 'vscode-nls';
 import { NodePathProvider } from './targets/node/nodePathProvider';
 import { TargetOrigin } from './targets/targetOrigin';
+import { TelemetryReporter } from './telemetry/telemetryReporter';
 
 const localize = nls.loadMessageBundle();
 
@@ -124,8 +125,15 @@ export function startDebugServer(port: number): Promise<IDisposable> {
           },
         };
 
-        const connection = new DapConnection();
-        new Binder(binderDelegate, connection, launchers, new TargetOrigin('targetOrigin'));
+        const telemetry = new TelemetryReporter();
+        const connection = new DapConnection(telemetry);
+        new Binder(
+          binderDelegate,
+          connection,
+          launchers,
+          telemetry,
+          new TargetOrigin('targetOrigin'),
+        );
         const configurator = new Configurator(connection.dap());
 
         connection.init(socket, socket);

--- a/src/targets/browser/browserAttacher.ts
+++ b/src/targets/browser/browserAttacher.ts
@@ -12,7 +12,7 @@ import { BrowserSourcePathResolver } from './browserPathResolver';
 import { baseURL } from './browserLaunchParams';
 import { AnyLaunchConfiguration, IChromeAttachConfiguration } from '../../configuration';
 import { Contributions } from '../../common/contributionUtils';
-import { RawTelemetryReporterToDap } from '../../telemetry/telemetryReporter';
+import { TelemetryReporter } from '../../telemetry/telemetryReporter';
 import { createTargetFilterForConfig } from '../../common/urlUtils';
 import { delay } from '../../common/promiseUtil';
 import { CancellationToken } from 'vscode';
@@ -47,8 +47,7 @@ export class BrowserAttacher implements ILauncher {
 
   async launch(
     params: AnyLaunchConfiguration,
-    { targetOrigin, cancellationToken }: ILaunchContext,
-    rawTelemetryReporter: RawTelemetryReporterToDap,
+    { targetOrigin, cancellationToken, telemetryReporter }: ILaunchContext,
     clientCapabilities: Dap.InitializeParams,
   ): Promise<ILaunchResult> {
     if (params.type !== Contributions.ChromeDebugType || params.request !== 'attach') {
@@ -59,7 +58,7 @@ export class BrowserAttacher implements ILauncher {
     this._targetOrigin = targetOrigin;
 
     const error = await this._attemptToAttach(
-      rawTelemetryReporter,
+      telemetryReporter,
       clientCapabilities,
       cancellationToken,
     );
@@ -67,7 +66,7 @@ export class BrowserAttacher implements ILauncher {
   }
 
   _scheduleAttach(
-    rawTelemetryReporter: RawTelemetryReporterToDap,
+    rawTelemetryReporter: TelemetryReporter,
     clientCapabilities: Dap.InitializeParams,
   ) {
     this._attemptTimer = setTimeout(() => {
@@ -77,7 +76,7 @@ export class BrowserAttacher implements ILauncher {
   }
 
   async _attemptToAttach(
-    rawTelemetryReporter: RawTelemetryReporterToDap,
+    rawTelemetryReporter: TelemetryReporter,
     clientCapabilities: Dap.InitializeParams,
     cancellationToken: CancellationToken,
   ) {
@@ -154,7 +153,7 @@ export class BrowserAttacher implements ILauncher {
   }
 
   private async acquireConnectionForBrowser(
-    rawTelemetryReporter: RawTelemetryReporterToDap,
+    rawTelemetryReporter: TelemetryReporter,
     params: IChromeAttachConfiguration,
     cancellationToken: CancellationToken,
   ) {

--- a/src/targets/browser/launcher.ts
+++ b/src/targets/browser/launcher.ts
@@ -11,10 +11,7 @@ import CdpConnection from '../../cdp/connection';
 import { PipeTransport, WebSocketTransport, ITransport } from '../../cdp/transport';
 import { Readable, Writable } from 'stream';
 import { EnvironmentVars } from '../../common/environmentVars';
-import {
-  RawTelemetryReporterToDap,
-  IRawTelemetryReporter,
-} from '../../telemetry/telemetryReporter';
+import { TelemetryReporter } from '../../telemetry/telemetryReporter';
 import { CancellationToken } from 'vscode';
 import { TaskCancelledError } from '../../common/cancellation';
 import { IDisposable } from '../../common/disposable';
@@ -76,7 +73,7 @@ export interface ILaunchResult {
 export async function launch(
   dap: Dap.Api,
   executablePath: string,
-  rawTelemetryReporter: IRawTelemetryReporter,
+  telemetryReporter: TelemetryReporter,
   clientCapabilities: IDapInitializeParamsWithExtensions,
   cancellationToken: CancellationToken,
   options: ILaunchOptions | undefined = {},
@@ -171,7 +168,7 @@ export async function launch(
       transport = await WebSocketTransport.create(endpoint, cancellationToken);
     }
 
-    const cdp = new CdpConnection(transport, rawTelemetryReporter);
+    const cdp = new CdpConnection(transport, telemetryReporter);
     exitListener = async () => {
       await cdp.rootSession().Browser.close({});
       if (browserProcess.pid) {
@@ -205,7 +202,7 @@ interface IAttachOptions {
 export async function attach(
   options: IAttachOptions,
   cancellationToken: CancellationToken,
-  rawTelemetryReporter: RawTelemetryReporterToDap,
+  telemetryReporter: TelemetryReporter,
 ): Promise<CdpConnection> {
   const { browserWSEndpoint, browserURL } = options;
 
@@ -214,11 +211,11 @@ export async function attach(
       browserWSEndpoint,
       cancellationToken,
     );
-    return new CdpConnection(connectionTransport, rawTelemetryReporter);
+    return new CdpConnection(connectionTransport, telemetryReporter);
   } else if (browserURL) {
     const connectionURL = await retryGetWSEndpoint(browserURL, cancellationToken);
     const connectionTransport = await WebSocketTransport.create(connectionURL, cancellationToken);
-    return new CdpConnection(connectionTransport, rawTelemetryReporter);
+    return new CdpConnection(connectionTransport, telemetryReporter);
   }
   throw new Error('Either browserURL or browserWSEndpoint needs to be specified');
 }

--- a/src/targets/node/nodeAttacherBase.ts
+++ b/src/targets/node/nodeAttacherBase.ts
@@ -90,8 +90,15 @@ export abstract class NodeAttacherBase<T extends AnyNodeConfiguration> extends N
       return;
     }
 
-    this.program.gotTelemetery(telemetry.result.value);
-    return telemetry.result.value;
+    const result = telemetry.result.value as IProcessTelemetry;
+
+    run.context.telemetryReporter.report('nodeRuntime', {
+      version: result.nodeVersion,
+      arch: result.architecture,
+    });
+    this.program.gotTelemetery(result);
+
+    return result;
   }
 }
 

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -8,7 +8,7 @@ import { InlineScriptOffset, ISourcePathResolver } from '../common/sourcePathRes
 import { AnyLaunchConfiguration } from '../configuration';
 import { ScriptSkipper } from '../adapter/scriptSkipper';
 import Dap from '../dap/api';
-import { RawTelemetryReporterToDap } from '../telemetry/telemetryReporter';
+import { TelemetryReporter } from '../telemetry/telemetryReporter';
 import { CancellationToken } from 'vscode';
 import { ITargetOrigin } from './targetOrigin';
 
@@ -55,6 +55,7 @@ export interface ILaunchContext {
   dap: Dap.Api;
   cancellationToken: CancellationToken;
   targetOrigin: ITargetOrigin;
+  telemetryReporter: TelemetryReporter;
 }
 
 export interface ILaunchResult {
@@ -82,14 +83,13 @@ export interface IStopMetadata {
   /**
    * Restart parameters.
    */
-  restart?: any;
+  restart?: Dap.AttachParams['__restart'];
 }
 
 export interface ILauncher extends IDisposable {
   launch(
     params: AnyLaunchConfiguration,
     context: ILaunchContext,
-    rawTelemetryReporter: RawTelemetryReporterToDap,
     clientCapabilities: Dap.InitializeParams,
   ): Promise<ILaunchResult>;
   terminate(): Promise<void>;

--- a/src/telemetry/classification.ts
+++ b/src/telemetry/classification.ts
@@ -1,0 +1,241 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import Dap from '../dap/api';
+
+/******************************************************************************
+ * GDPR tooling definitions
+ *****************************************************************************/
+
+export interface IPropertyData {
+  classification:
+    | 'SystemMetaData'
+    | 'CallstackOrException'
+    | 'CustomerContent'
+    | 'EndUserPseudonymizedInformation'
+    | 'Unclassified';
+  purpose: 'PerformanceAndHealth' | 'FeatureInsight' | 'BusinessInsight';
+  endpoint?: string;
+  isMeasurement?: boolean;
+}
+
+interface IGDPRProperty {
+  readonly [name: string]: IPropertyData | undefined | IGDPRProperty;
+}
+
+type ClassifiedEvent<T extends IGDPRProperty> = { [K in keyof T]?: unknown };
+
+type StrictPropertyCheck<
+  TEvent,
+  TClassifiedEvent,
+  TError
+> = keyof TEvent extends keyof TClassifiedEvent
+  ? keyof TClassifiedEvent extends keyof TEvent
+    ? TEvent
+    : TError
+  : TError;
+
+/******************************************************************************
+ * Classifications
+ *****************************************************************************/
+
+export interface IGlobalProperties {
+  version: string;
+}
+
+interface IGlobalClassification {
+  nodeVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  browser: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+}
+
+export interface IGlobalMetrics {
+  nodeVersion?: string;
+  browser?: string;
+}
+
+interface IRPCOperationClassification {
+  performance: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
+}
+
+export interface IRPCMetrics {
+  operation: string;
+  totalTime: number;
+  max: number;
+  avg: number;
+  stddev: number;
+  count: number;
+  failed: number;
+  errors: Error[];
+}
+
+export interface IRPCOperation {
+  performance: ReadonlyArray<IRPCMetrics>;
+}
+
+interface IErrorClassification {
+  exceptionType: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
+  error: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
+}
+
+export interface IErrorMetrics {
+  exceptionType: 'uncaughtException' | 'unhandledRejection';
+  error: unknown;
+}
+
+interface IBreakpointClassification {
+  set: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  verified: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  hit: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+}
+
+export interface IBreakpointMetrics {
+  set: number;
+  verified: number;
+  hit: number;
+}
+
+interface IBrowserVersionClassification {
+  targetCRDPVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  targetRevision: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  targetUserAgent: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  targetV8: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  targetProject: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  targetVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  targetProduct: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+}
+
+export interface IBrowserVersionMetrics {
+  targetCRDPVersion: string;
+  targetRevision: string;
+  targetUserAgent: string;
+  targetV8: string;
+  targetProject: string;
+  targetVersion: string;
+  targetProduct: string;
+}
+
+interface INodeRuntimeClassification {
+  version: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  arch: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+}
+
+export interface INodeRuntimeMetrics {
+  version: string;
+  arch: string;
+}
+
+interface ILaunchClassification {
+  type: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  request: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  parameters: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  nodeVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  adapterVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+  os: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+}
+
+export interface ILaunchMetrics {
+  type: string;
+  os: string;
+  nodeVersion: string;
+  adapterVersion: string;
+  request: string;
+  parameters: object;
+}
+
+/******************************************************************************
+ * Implementations
+ *****************************************************************************/
+
+/**
+ * Creates typed, classified logging functions. Takes a callback that's
+ * invoked when any of the logging functions are called.
+ */
+export const createLoggers = (sendEvent: (event: Dap.OutputEventParams) => void) => {
+  const globalMetrics: Partial<IGlobalMetrics> = {};
+
+  /**
+   * Warning! The naming of this method is required to be exactly `publicLog2`
+   * for the GDPR tooling to automatically detect.
+   */
+  function publicLog2<
+    E extends ClassifiedEvent<T> = never,
+    T extends { [_ in keyof T]: IPropertyData | IGDPRProperty | undefined } = never
+  >(
+    name: string,
+    props: StrictPropertyCheck<
+      E,
+      ClassifiedEvent<T>,
+      'Type of classified event does not match event properties'
+    >,
+  ) {
+    return sendEvent({
+      category: 'telemetry',
+      output: name,
+      data: props,
+    });
+  }
+
+  const dapOperation = (metrics: IRPCOperation) =>
+    publicLog2<IGlobalMetrics & IRPCOperation, IRPCOperationClassification & IGlobalClassification>(
+      'js-debug/dap/operation',
+      { ...globalMetrics, ...metrics },
+    );
+
+  const cdpOperation = (metrics: IRPCOperation) =>
+    publicLog2<IGlobalMetrics & IRPCOperation, IRPCOperationClassification & IGlobalClassification>(
+      'js-debug/cdp/operation',
+      { ...globalMetrics, ...metrics },
+    );
+
+  const error = (metrics: IErrorMetrics) =>
+    publicLog2<IGlobalMetrics & IErrorMetrics, IErrorClassification & IGlobalClassification>(
+      'js-debug/error',
+      { ...globalMetrics, ...metrics },
+    );
+
+  const browserVersion = (metrics: IBrowserVersionMetrics) => {
+    globalMetrics.browser =
+      (metrics.targetProject || metrics.targetProject) + '/' + metrics.targetVersion;
+
+    publicLog2<
+      IGlobalMetrics & IBrowserVersionMetrics,
+      IBrowserVersionClassification & IGlobalClassification
+    >('js-debug/browserVersion', { ...globalMetrics, ...metrics });
+  };
+
+  const breakpointStats = (metrics: IBreakpointMetrics) =>
+    publicLog2<
+      IGlobalMetrics & IBreakpointMetrics,
+      IBreakpointClassification & IGlobalClassification
+    >('js-debug/breakpointStats', { ...globalMetrics, ...metrics });
+
+  const nodeRuntime = (metrics: INodeRuntimeMetrics) => {
+    globalMetrics.nodeVersion = metrics.version;
+    publicLog2<
+      IGlobalMetrics & INodeRuntimeMetrics,
+      INodeRuntimeClassification & IGlobalClassification
+    >('js-debug/nodeRuntime', { ...globalMetrics, ...metrics });
+  };
+
+  const launch = (metrics: ILaunchMetrics) =>
+    publicLog2<IGlobalMetrics & ILaunchMetrics, ILaunchClassification & IGlobalClassification>(
+      'js-debug/launch',
+      { ...globalMetrics, ...metrics },
+    );
+
+  return {
+    breakpointStats,
+    browserVersion,
+    cdpOperation,
+    dapOperation,
+    error,
+    launch,
+    nodeRuntime,
+  };
+};
+
+/**
+ * Type for all logging functions this extension has.
+ */
+export type LogFunctions = ReturnType<typeof createLoggers>;

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -34,6 +34,7 @@ import { Logger } from './logger';
 import { getLogFileForTest } from './reporters/logReporterUtils';
 import { NodePathProvider } from '../targets/node/nodePathProvider';
 import { TargetOrigin } from '../targets/targetOrigin';
+import { TelemetryReporter } from '../telemetry/telemetryReporter';
 
 export const kStabilizeNames = ['id', 'threadId', 'sourceReference', 'variablesReference'];
 
@@ -78,9 +79,9 @@ class Session {
   constructor() {
     const testToAdapter = new Stream();
     const adapterToTest = new Stream();
-    this.adapterConnection = new DapConnection();
+    this.adapterConnection = new DapConnection(new TelemetryReporter());
     this.adapterConnection.init(testToAdapter, adapterToTest);
-    const testConnection = new DapConnection();
+    const testConnection = new DapConnection(new TelemetryReporter());
     testConnection.init(adapterToTest, testToAdapter);
     this.dap = testConnection.createTestApi();
   }
@@ -349,6 +350,7 @@ export class TestRoot {
         ]),
         new NodeAttacher(pathProvider),
       ],
+      new TelemetryReporter(),
       new TargetOrigin('0'),
     );
 

--- a/src/ui/sessionManager.ts
+++ b/src/ui/sessionManager.ts
@@ -22,17 +22,19 @@ import { NodePathProvider } from '../targets/node/nodePathProvider';
 import { assert } from '../common/logging/logger';
 import { DelegateLauncherFactory } from '../targets/delegate/delegateLauncherFactory';
 import { TargetOrigin } from '../targets/targetOrigin';
+import { TelemetryReporter } from '../telemetry/telemetryReporter';
 
 export class Session implements IDisposable {
   public readonly debugSession: vscode.DebugSession;
   public readonly connection: DapConnection;
+  private readonly telemetryReporter = new TelemetryReporter();
   private _server: net.Server;
   private _binder?: Binder;
   private _onTargetNameChanged?: IDisposable;
 
   constructor(debugSession: vscode.DebugSession) {
     this.debugSession = debugSession;
-    this.connection = new DapConnection();
+    this.connection = new DapConnection(this.telemetryReporter);
     this._server = net
       .createServer(async socket => {
         this.connection.init(socket, socket);
@@ -69,6 +71,7 @@ export class Session implements IDisposable {
       delegate,
       this.connection,
       launchers,
+      this.telemetryReporter,
       new TargetOrigin(this.debugSession.id),
     );
   }


### PR DESCRIPTION
This uses our GDPR tooling to tag events via TypeScript annotations.
src/telemetry/classification had the telemetery event data types and
classifications, and they're exposed in the logger. I had to rework
some of our data types because, for example with the batch reports, our
tooling doesn't do arbitrary `[key: string]`'s in objects.