### PR TITLE
feat: improve object preview cases

### DIFF
--- a/src/adapter/objectPreview.ts
+++ b/src/adapter/objectPreview.ts
@@ -14,32 +14,32 @@ const maxExceptionTitleLength = 10000;
 const minTableCellWidth = 3;
 const maxTableWidth = 120;
 
-export const primitiveSubtypes = new Set<string | undefined>([
+/**
+ * Object subtypes that should be rendered without any preview.
+ */
+export const subtypesWithoutPreview: ReadonlySet<string | undefined> = new Set([
   'null',
   'regexp',
   'date',
   'error',
-  'proxy',
-  'typedarray',
-  'arraybuffer',
-  'dataview',
 ]);
 
-export function isObject(object: Cdp.Runtime.ObjectPreview): boolean;
-export function isObject(object: Cdp.Runtime.PropertyPreview): boolean;
-export function isObject(object: Cdp.Runtime.RemoteObject): boolean;
-export function isObject(
+/**
+ * Returns whether the given type should be previewed as an expandable
+ * object.
+ */
+export function previewAsObject(
   object: Cdp.Runtime.RemoteObject | Cdp.Runtime.ObjectPreview | Cdp.Runtime.PropertyPreview,
 ): boolean {
   return (
     object.type === 'function' ||
-    (object.type === 'object' && !primitiveSubtypes.has(object.subtype))
+    (object.type === 'object' && !subtypesWithoutPreview.has(object.subtype))
   );
 }
 
-export function isArray(object: Cdp.Runtime.ObjectPreview): boolean;
-export function isArray(object: Cdp.Runtime.PropertyPreview): boolean;
-export function isArray(object: Cdp.Runtime.RemoteObject): boolean;
+/**
+ * Returns whether the given type should be previwed as an array.
+ */
 export function isArray(
   object: Cdp.Runtime.RemoteObject | Cdp.Runtime.ObjectPreview | Cdp.Runtime.PropertyPreview,
 ): boolean {
@@ -98,7 +98,7 @@ function renderPreview(preview: Cdp.Runtime.ObjectPreview, characterBudget: numb
   if (isArray(preview)) return renderArrayPreview(preview, characterBudget);
   if ((preview.subtype as string) === 'internal#entry')
     return stringUtils.trimEnd(preview.description || '', characterBudget);
-  if (isObject(preview)) return renderObjectPreview(preview, characterBudget);
+  if (previewAsObject(preview)) return renderObjectPreview(preview, characterBudget);
   if (preview.type === 'function')
     return formatFunctionDescription(preview.description!, characterBudget);
   return renderPrimitivePreview(preview, characterBudget);

--- a/src/adapter/templates/invokeGetter.ts
+++ b/src/adapter/templates/invokeGetter.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { remoteFunction } from '.';
+
+/**
+ * Gets the object property.
+ */
+export const invokeGetter = remoteFunction(function(
+  this: { [key: string]: unknown },
+  property: string | number,
+) {
+  return this[property];
+});

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -923,7 +923,7 @@ export class Thread implements IVariableStoreDelegate {
 
     let output: string;
     let variablesReference: number | undefined;
-    if (!usedAllArgs || event.args.some(arg => objectPreview.isObject(arg))) {
+    if (!usedAllArgs || event.args.some(arg => objectPreview.previewAsObject(arg))) {
       output = '';
       variablesReference = await this.replVariables.createVariableForOutput(
         messageText + '\n',

--- a/src/test/console/console-format-popular-types.txt
+++ b/src/test/console/console-format-popular-types.txt
@@ -165,25 +165,25 @@ Evaluating: 'console.log([arrayLikeFunction])'
 stdout> > (1) [ƒ]
 
 Evaluating: 'console.log(new Uint16Array(["1", "2", "3"]))'
-stdout> Uint16Array(3) [1, 2, 3]
+stdout> > Uint16Array(3) [1, 2, 3]
 
 Evaluating: 'console.log([new Uint16Array(["1", "2", "3"])])'
 stdout> > (1) [Uint16Array(3)]
 
 Evaluating: 'console.log(tinyTypedArray)'
-stdout> Uint8Array(1) [3]
+stdout> > Uint8Array(1) [3]
 
 Evaluating: 'console.log([tinyTypedArray])'
 stdout> > (1) [Uint8Array(1)]
 
 Evaluating: 'console.log(smallTypedArray)'
-stdout> Uint8Array(400) [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, …]
+stdout> > Uint8Array(400) [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, …]
 
 Evaluating: 'console.log([smallTypedArray])'
 stdout> > (1) [Uint8Array(400)]
 
 Evaluating: 'console.log(bigTypedArray)'
-stdout> Uint8Array(400000000) [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, …]
+stdout> > Uint8Array(400000000) [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, …]
 
 Evaluating: 'console.log([bigTypedArray])'
 stdout> > (1) [Uint8Array(400000000)]

--- a/src/test/evaluate/evaluate-default.txt
+++ b/src/test/evaluate/evaluate-default.txt
@@ -14,6 +14,65 @@ result: 3
 
 <error>: Uncaught ReferenceError: baz is not defined
 
+> result: Uint8Array(3) [1, 2, 3]
+    0: 1
+    1: 2
+    2: 3
+    > get buffer: ƒ buffer()
+    > get byteLength: ƒ byteLength()
+    > get byteOffset: ƒ byteOffset()
+    > get length: ƒ length()
+    > get Symbol(Symbol.toStringTag): ƒ [Symbol.toStringTag]()
+    > __proto__: TypedArray
+
+> result: ArrayBuffer(3)
+    > [[Int8Array]]: Int8Array(3) [1, 2, 3]
+    > [[Uint8Array]]: Uint8Array(3) [1, 2, 3]
+    > get byteLength: ƒ byteLength()
+    > __proto__: ArrayBuffer
+
+> result: Proxy {a: 1}
+    > [[Handler]]: Object
+    [[IsRevoked]]: false
+    > [[Target]]: Object
+
+> result: {}
+    > set foo: ƒ foo(x) {}
+        > get arguments: ƒ ()
+        > set arguments: ƒ ()
+        > get caller: ƒ ()
+        > set caller: ƒ ()
+        length: 1
+        name: 'set foo'
+        [[FunctionLocation]]: @ <eval>/VM<xx>:1
+        > [[Scopes]]: Scopes[1]
+        > __proto__: function () { [native code] }
+    > __proto__: Object
+        > set foo: ƒ foo(x) {}
+        > __proto__: Object
+
+> result: {}
+    > get foo: ƒ foo() { return 42 }
+        42
+    > __proto__: Object
+        > get foo: ƒ foo() { return 42 }
+        > __proto__: Object
+
+> result: {}
+    > get foo: ƒ foo() { throw 'wat'; }
+        > get arguments: ƒ ()
+        > set arguments: ƒ ()
+        > get caller: ƒ ()
+        > set caller: ƒ ()
+        length: 0
+        name: 'get foo'
+        [[FunctionLocation]]: @ <eval>/VM<xx>:1
+        > [[Scopes]]: Scopes[1]
+        > __proto__: function () { [native code] }
+    > __proto__: Object
+        > get foo: ƒ foo() { throw 'wat'; }
+        > __proto__: Object
+
 Evaluating#1: setTimeout(() => { throw new Error('bar')}, 0)
 stderr> Uncaught Error: bar
 stderr> > Uncaught Error: bar

--- a/src/test/evaluate/evaluate.ts
+++ b/src/test/evaluate/evaluate.ts
@@ -35,6 +35,25 @@ describe('evaluate', () => {
     await p.logger.evaluateAndLog(`baz();`);
     p.log('');
 
+    await p.logger.evaluateAndLog(`new Uint8Array([1, 2, 3]);`);
+    p.log('');
+
+    await p.logger.evaluateAndLog(`new Uint8Array([1, 2, 3]).buffer;`);
+    p.log('');
+
+    await p.logger.evaluateAndLog(`new Proxy({ a: 1 }, { get: () => 2 });`);
+    p.log('');
+
+    // prototype-free objs just to avoid adding prototype noise to tests:
+    await p.logger.evaluateAndLog(`Object.create({ set foo(x) {} })`, { depth: 2 });
+    p.log('');
+
+    await p.logger.evaluateAndLog(`Object.create({ get foo() { return 42 } })`, { depth: 2 });
+    p.log('');
+
+    await p.logger.evaluateAndLog(`Object.create({ get foo() { throw 'wat'; } })`, { depth: 2 });
+    p.log('');
+
     p.evaluate(`setTimeout(() => { throw new Error('bar')}, 0)`);
     await p.logger.logOutput(await p.dap.once('output'));
     p.log('');


### PR DESCRIPTION
We were being a little aggressive about declaring types 'primitive',
which prevented people from being able to view arraybuffers, for
instance. The Chrome devtools, only declarees `null`, `regexp`, and
`error` as the types without a preview, this follows that more closely.

While testing cases I also noticed that we weren't able to expand
getters like the chrome devtools can, this fixes that as well.

![Screen Shot 2020-01-17 at 3 57 12 PM](https://user-images.githubusercontent.com/2230985/72654125-f472a400-3942-11ea-8281-6873d194247f.png)

Later on I want to do a little cleanup around object previews, the
decoupling between the DAP, CDP, and internal representations make this
a little awkward: we lose information when we convert to the internal
`RemoteObject` type--I added a flag for getters here but I think making
things a bit tighter there could clean up some logic.

Fixes #234