### PR TITLE
fix: wait for targets before returning from disconnect

### DIFF
--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -269,7 +269,9 @@ export class BrowserLauncher implements ILauncher {
   }
 
   async terminate(): Promise<void> {
-    if (this._mainTarget) this._mainTarget.cdp().Page.navigate({ url: 'about:blank' });
+    if (this._mainTarget) {
+      await this._mainTarget.cdp().Page.navigate({ url: 'about:blank' });
+    }
   }
 
   async disconnect(): Promise<void> {

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -144,17 +144,17 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
    */
   public async terminate(): Promise<void> {
     if (this.program) {
-      this.program.stop();
+      await this.program.stop();
+    } else {
+      this.onProgramTerminated({ code: 0, killed: true });
     }
-
-    this.onProgramTerminated({ code: 0, killed: true });
   }
 
   /**
    * @inheritdoc
    */
   public async disconnect(): Promise<void> {
-    this.terminate();
+    await this.terminate();
   }
 
   /**


### PR DESCRIPTION
Also reworks the terminal process launcher to verify the process is
killed before returning.

Probably fixes #165