### PR TITLE
feat: allow restarting process attachment

### DIFF
--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -290,6 +290,11 @@ const nodeAttachConfig: IDebugger<INodeAttachConfiguration> = {
   ],
   configurationAttributes: {
     ...nodeBaseConfigurationAttributes,
+    restart: {
+      type: 'boolean',
+      description: refString('node.attach.restart.description'),
+      default: true,
+    },
     processId: {
       type: 'string',
       description: refString('node.attach.processId.description'),
@@ -443,7 +448,7 @@ const nodeLaunchConfig: IDebugger<INodeLaunchConfiguration> = {
     },
     restart: {
       type: 'boolean',
-      description: refString('node.restart.description'),
+      description: refString('node.launch.restart.description'),
       default: true,
     },
     runtimeExecutable: {

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -125,7 +125,9 @@ const strings = {
     'A list of minimatch patterns for locations (folders and URLs) in which source maps can be used to resolve local files. This can be used to avoid incorrectly breaking in external source mapped code. Patterns can be prefixed with "!" to exclude them. May be set to an empty array or null to avoid restriction.',
   'node.processattach.config.name': 'Attach to Process',
   'node.remoteRoot.description': 'Absolute path to the remote directory containing the program.',
-  'node.restart.description': 'Restart session after Node.js has terminated.',
+  'node.launch.restart.description':
+    'Try to restart the program if it exits with a non-zero exit code.',
+  'node.attach.restart.description': 'Try to reconnect to the program if we lose connection.',
   'node.showAsyncStacks.description': 'Show the async calls that led to the current call stack.',
   'node.snippet.attach.description': 'Attach to a running node program',
   'node.snippet.attach.label': 'Node.js: Attach',

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -5,6 +5,7 @@
 import Dap from './dap/api';
 import { Contributions } from './common/contributionUtils';
 import { assertNever } from './common/objUtils';
+import { AnyRestartOptions } from './targets/node/restartPolicy';
 
 export interface IMandatedConfiguration extends Dap.LaunchParams {
   /**
@@ -271,7 +272,7 @@ export interface INodeLaunchConfiguration extends INodeBaseConfiguration, IConfi
   /**
    * Restart session after Node.js has terminated.
    */
-  restart: boolean;
+  restart: AnyRestartOptions;
 
   /**
    * Runtime to use. Either an absolute path or the name of a runtime
@@ -351,7 +352,7 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
   /**
    * Restart session after Node.js has terminated.
    */
-  restart: boolean;
+  restart: AnyRestartOptions;
 
   /**
    * ID of process to attach to.
@@ -557,7 +558,7 @@ export const nodeLaunchConfigDefaults: INodeLaunchConfiguration = {
   program: '',
   stopOnEntry: false,
   console: 'internalConsole',
-  restart: true,
+  restart: false,
   args: [],
   runtimeExecutable: 'node',
   runtimeVersion: 'default',
@@ -594,7 +595,7 @@ export const nodeAttachConfigDefaults: INodeAttachConfiguration = {
   type: Contributions.NodeDebugType,
   attachSpawnedProcesses: true,
   attachExistingChildren: true,
-  restart: true,
+  restart: false,
   request: 'attach',
   processId: '',
 };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -349,6 +349,11 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
   request: 'attach';
 
   /**
+   * Restart session after Node.js has terminated.
+   */
+  restart: boolean;
+
+  /**
    * ID of process to attach to.
    */
   processId?: string;
@@ -589,6 +594,7 @@ export const nodeAttachConfigDefaults: INodeAttachConfiguration = {
   type: Contributions.NodeDebugType,
   attachSpawnedProcesses: true,
   attachExistingChildren: true,
+  restart: true,
   request: 'attach',
   processId: '',
 };

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -92,7 +92,7 @@ export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
 
       // lie to the restart policy--the watchdog always gracefully exits
       // when it loses connection, but we may want to restart.
-      const nextRestart = restartPolicy.next({ killed: false, code: 1 });
+      const nextRestart = restartPolicy.next();
       if (!nextRestart) {
         this.onProgramTerminated(result);
         return;
@@ -112,7 +112,7 @@ export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
       }
     };
 
-    return doLaunch(this.restarters.create(runData.params));
+    return doLaunch(this.restarters.create(runData.params.restart));
   }
 
   protected async onFirstInitialize(cdp: Cdp.Api, run: IRunData<INodeAttachConfiguration>) {

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -2,12 +2,13 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import * as nls from 'vscode-nls';
 import { AnyLaunchConfiguration, INodeAttachConfiguration } from '../../configuration';
 import { Contributions } from '../../common/contributionUtils';
 import { retryGetWSEndpoint } from '../browser/launcher';
 import { spawnWatchdog } from './watchdogSpawn';
 import { IRunData } from './nodeLauncherBase';
-import { SubprocessProgram } from './program';
+import { SubprocessProgram, IProgram } from './program';
 import Cdp from '../../cdp/api';
 import { isLoopback } from '../../common/urlUtils';
 import { LeaseFile } from './lease-file';
@@ -15,6 +16,12 @@ import { logger } from '../../common/logging/logger';
 import { LogTag } from '../../common/logging';
 import { NodeAttacherBase } from './nodeAttacherBase';
 import { watchAllChildren } from './nodeAttacherCluster';
+import { IRestartPolicy, RestartPolicyFactory } from './restartPolicy';
+import { delay } from '../../common/promiseUtil';
+import { NodePathProvider } from './nodePathProvider';
+import { IStopMetadata } from '../targets';
+
+const localize = nls.loadMessageBundle();
 
 /**
  * Attaches to ongoing Node processes. This works pretty similar to the
@@ -24,6 +31,13 @@ import { watchAllChildren } from './nodeAttacherCluster';
  * child processes operate just like those we boot with the NodeLauncher.
  */
 export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
+  constructor(
+    pathProvider: NodePathProvider,
+    private readonly restarters = new RestartPolicyFactory(),
+  ) {
+    super(pathProvider);
+  }
+
   /**
    * @inheritdoc
    */
@@ -37,23 +51,68 @@ export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
    * @inheritdoc
    */
   protected async launchProgram(runData: IRunData<INodeAttachConfiguration>): Promise<void> {
-    const wd = spawnWatchdog(await this.resolveNodePath(runData.params), {
-      ipcAddress: runData.serverAddress,
-      scriptName: 'Remote Process',
-      inspectorURL: await retryGetWSEndpoint(
-        `http://${runData.params.address}:${runData.params.port}`,
-        runData.context.cancellationToken,
-      ),
-      waitForDebugger: true,
-      dynamicAttach: true,
-    });
+    const doLaunch = async (restartPolicy: IRestartPolicy): Promise<void> => {
+      const prevProgram = this.program;
 
-    const program = (this.program = new SubprocessProgram(wd));
-    this.program.stopped.then(result => {
-      if (program === this.program) {
-        this.onProgramTerminated(result);
+      let inspectorURL: string;
+      try {
+        inspectorURL = await retryGetWSEndpoint(
+          `http://${runData.params.address}:${runData.params.port}`,
+          runData.context.cancellationToken,
+        );
+      } catch (e) {
+        if (prevProgram /* is a restart */) {
+          return restart(restartPolicy, prevProgram, { killed: false, code: 1 });
+        } else {
+          throw e;
+        }
       }
-    });
+
+      const program = (this.program = new SubprocessProgram(
+        spawnWatchdog(await this.resolveNodePath(runData.params), {
+          ipcAddress: runData.serverAddress,
+          scriptName: 'Remote Process',
+          inspectorURL,
+          waitForDebugger: true,
+          dynamicAttach: true,
+        }),
+      ));
+
+      program.stopped.then(r => restart(restartPolicy, program, r));
+    };
+
+    const restart = async (
+      restartPolicy: IRestartPolicy,
+      program: IProgram,
+      result: IStopMetadata,
+    ) => {
+      if (this.program !== program) {
+        return;
+      }
+
+      // lie to the restart policy--the watchdog always gracefully exits
+      // when it loses connection, but we may want to restart.
+      const nextRestart = restartPolicy.next({ killed: false, code: 1 });
+      if (!nextRestart) {
+        this.onProgramTerminated(result);
+        return;
+      }
+
+      runData.context.dap.output({
+        output: localize(
+          'node.attach.restart.message',
+          'Lost connection to debugee, reconnecting in {0}ms\r\n',
+          nextRestart.delay,
+        ),
+      });
+
+      await delay(nextRestart.delay);
+      if (this.program === program) {
+        return doLaunch(nextRestart);
+      }
+    };
+
+    return doLaunch(this.restarters.create(runData.params));
   }
 
   protected async onFirstInitialize(cdp: Cdp.Api, run: IRunData<INodeAttachConfiguration>) {

--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -116,7 +116,12 @@ export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
           return;
         }
 
-        const nextRestart = restartPolicy.next(result);
+        if (result.killed || result.code === 0) {
+          this.onProgramTerminated(result);
+          return;
+        }
+
+        const nextRestart = restartPolicy.next();
         if (!nextRestart) {
           this.onProgramTerminated(result);
           return;
@@ -137,7 +142,7 @@ export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
       });
     };
 
-    return doLaunch(this.restarters.create(runData.params));
+    return doLaunch(this.restarters.create(runData.params.restart));
   }
 
   /**

--- a/src/targets/node/restartPolicy.ts
+++ b/src/targets/node/restartPolicy.ts
@@ -2,18 +2,46 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { IStopMetadata } from '../targets';
+import { assertNever } from '../../common/objUtils';
+
+export type AnyRestartOptions =
+  | boolean
+  | { exponential: Partial<IExponentialRestartOptions> }
+  | { static: Partial<IStaticRestartOptions> };
+
+const defaultOptions: IExponentialRestartOptions = {
+  maxDelay: 10000,
+  maxAttempts: 10,
+  exponent: 2,
+  initialDelay: 128,
+};
 
 /**
  * Creates restart policies from the configuration.
  */
 export class RestartPolicyFactory {
-  public create(config: { restart: boolean }): IRestartPolicy {
-    if (!config.restart) {
+  public create(config: AnyRestartOptions): IRestartPolicy {
+    if (config === false) {
       return new NeverRestartPolicy();
     }
 
-    return new StaticRestartPolicy(1000);
+    if (config === true) {
+      return new ExponentialRestartPolicy(defaultOptions);
+    }
+
+    if ('exponential' in config) {
+      return new ExponentialRestartPolicy({ ...defaultOptions, ...config.exponential });
+    }
+
+    if ('static' in config) {
+      return new StaticRestartPolicy({
+        maxAttempts: defaultOptions.maxAttempts,
+        delay: 1000,
+        ...config.static,
+      });
+    }
+
+    throw assertNever(config, 'Unexpected value for restart configuration');
   }
 }
 
@@ -27,7 +55,65 @@ export interface IRestartPolicy {
    * Returns the delay before the server should be restarted, or undefined
    * if no restart should occur.
    */
-  next(result: IStopMetadata): IRestartPolicy | undefined;
+  next(): IRestartPolicy | undefined;
+}
+
+export interface IExponentialRestartOptions {
+  /**
+   * Maximum delay, in milliseconds. Defaults to 10s.
+   */
+  maxDelay: number;
+
+  /**
+   * Maximum retry attempts.  Defaults to 10.
+   */
+  maxAttempts: number;
+
+  /**
+   * Backoff exponent. Defaults to 2.
+   */
+  exponent: number;
+
+  /**
+   * The initial, first delay of the backoff, in milliseconds.
+   * Defaults to 128ms.
+   */
+  initialDelay: number;
+}
+
+/**
+ * A simple, jitter-free exponential backoff.
+ */
+class ExponentialRestartPolicy implements IRestartPolicy {
+  public get delay() {
+    return Math.min(
+      this.options.maxDelay,
+      this.options.initialDelay * this.options.exponent ** this.attempt,
+    );
+  }
+
+  constructor(
+    private readonly options: IExponentialRestartOptions,
+    private readonly attempt: number = 0,
+  ) {}
+
+  public next() {
+    return this.attempt === this.options.maxAttempts
+      ? undefined
+      : new ExponentialRestartPolicy(this.options, this.attempt + 1);
+  }
+}
+
+export interface IStaticRestartOptions {
+  /**
+   * Constant delay.
+   */
+  delay: number;
+
+  /**
+   * Maximum retry attempts. Defaults to 10.
+   */
+  maxAttempts: number;
 }
 
 /**
@@ -35,14 +121,16 @@ export interface IRestartPolicy {
  * @see https://github.com/microsoft/vscode-pwa/issues/26
  */
 class StaticRestartPolicy implements IRestartPolicy {
-  constructor(public readonly delay: number) {}
+  public get delay() {
+    return this.options.delay;
+  }
 
-  public next(result: IStopMetadata) {
-    if (result.killed || result.code === 0) {
-      return;
-    }
+  constructor(private readonly options: IStaticRestartOptions, private readonly attempt = 0) {}
 
-    return this;
+  public next() {
+    return this.attempt === this.options.maxAttempts
+      ? undefined
+      : new StaticRestartPolicy(this.options, this.attempt + 1);
   }
 }
 

--- a/src/targets/node/restartPolicy.ts
+++ b/src/targets/node/restartPolicy.ts
@@ -1,14 +1,14 @@
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
-import { INodeLaunchConfiguration } from '../../configuration';
+
 import { IStopMetadata } from '../targets';
 
 /**
  * Creates restart policies from the configuration.
  */
 export class RestartPolicyFactory {
-  public create(config: INodeLaunchConfiguration): IRestartPolicy {
+  public create(config: { restart: boolean }): IRestartPolicy {
     if (!config.restart) {
       return new NeverRestartPolicy();
     }

--- a/src/test/node/node-runtime-attaching-restarts-if-requested.txt
+++ b/src/test/node/node-runtime-attaching-restarts-if-requested.txt
@@ -1,0 +1,17 @@
+{
+    allThreadsStopped : false
+    description : Paused on debugger statement
+    reason : pause
+    threadId : <number>
+}
+{
+    allThreadsStopped : false
+    description : Paused on debugger statement
+    reason : pause
+    threadId : <number>
+}
+setInterval @ ${fixturesDir}/test.js:1:21
+ontimeout @ timers.js:436:11
+tryOnTimeout @ timers.js:300:5
+listOnTimeout @ timers.js:263:5
+processTimers @ timers.js:223:10

--- a/src/test/node/node-runtime-attaching-restarts-if-requested.txt
+++ b/src/test/node/node-runtime-attaching-restarts-if-requested.txt
@@ -10,8 +10,4 @@
     reason : pause
     threadId : <number>
 }
-setInterval @ ${fixturesDir}/test.js:1:21
-ontimeout @ timers.js:436:11
-tryOnTimeout @ timers.js:300:5
-listOnTimeout @ timers.js:263:5
-processTimers @ timers.js:223:10
+<anonymous> @ ${fixturesDir}/test.js:1:21

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -399,6 +399,11 @@ export class TestRoot {
     return this._root.dap;
   }
 
+  async waitForTopLevel() {
+    const result = await new Promise(f => (this._launchCallback = f));
+    return result as TestP;
+  }
+
   async _launch(url: string, options: Partial<IChromeLaunchConfiguration> = {}): Promise<TestP> {
     await this.initialize;
     this._launchUrl = url;


### PR DESCRIPTION
This borrows some code from the Node process launcher to implement
restarting process attachment. We'll print reconnecting messages to the
console while we're working on reconnection, and query the original
address/port to get a new inspector URL.

Fixes #245