### PR TITLE
feat: make logpoint parsing more resilient

### DIFF
--- a/src/adapter/breakpoints/logPoint.ts
+++ b/src/adapter/breakpoints/logPoint.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as ts from 'typescript';
+import { assert, logger } from '../../common/logging/logger';
+import { invalidLogPointSyntax } from '../../dap/errors';
+import { LogTag } from '../../common/logging';
+/**
+ * Statments which we should not prefix with `return {}`
+ */
+const unreturnable: ReadonlySet<ts.SyntaxKind> = new Set([
+  ts.SyntaxKind.ReturnStatement,
+  ts.SyntaxKind.IfStatement,
+  ts.SyntaxKind.DoStatement,
+  ts.SyntaxKind.WhileStatement,
+  ts.SyntaxKind.ForStatement,
+  ts.SyntaxKind.ForInStatement,
+  ts.SyntaxKind.ForOfStatement,
+  ts.SyntaxKind.ContinueStatement,
+  ts.SyntaxKind.BreakStatement,
+  ts.SyntaxKind.ReturnStatement,
+  ts.SyntaxKind.WithStatement,
+  ts.SyntaxKind.SwitchStatement,
+  ts.SyntaxKind.LabeledStatement,
+  ts.SyntaxKind.TryStatement,
+  ts.SyntaxKind.ThrowStatement,
+  ts.SyntaxKind.DebuggerStatement,
+  ts.SyntaxKind.VariableDeclaration,
+  ts.SyntaxKind.VariableDeclarationList,
+]);
+
+function serializeLogStatements(statements: ReadonlyArray<ts.Statement>) {
+  let output = `(() => {
+    try {`;
+  for (let i = 0; i < statements.length; i++) {
+    const stmt = statements[i];
+    if (i === statements.length - 1 && !unreturnable.has(stmt.kind)) {
+      output += `return `;
+    }
+
+    output += stmt.getText().trim() + ';';
+  }
+
+  const result = `${output}
+    } catch (e) {
+      return e.stack || e.message || String(e);
+    }
+  })()`;
+
+  // Make sure it's good syntax. This won't actually
+  // run the user script, just ask V8 to parse it.
+  try {
+    new Function(result);
+  } catch (e) {
+    logger.warn(LogTag.Runtime, 'Error parsing logpoint BP', {
+      code: result,
+      input: statements[0].getSourceFile().getText(),
+    });
+
+    // todo(connor4312): this doesn't actually get handled in VS Code, but once it
+    // does it should 'just work': https://github.com/microsoft/vscode/issues/89059
+    throw invalidLogPointSyntax(e.message);
+  }
+
+  return result;
+}
+
+/**
+ * Converts the log message in the form of `hello {name}!` to an expression
+ * like `console.log('hello %O!', name);` (with some extra wrapping). This is
+ * used to implement logpoint breakpoints.
+ */
+export function logMessageToExpression(msg: string) {
+  const unescape = (str: string) => str.replace(/%/g, '%%');
+  const formatParts = [];
+  const args = [];
+
+  let end = 0;
+
+  // Parse each interpolated {code} in the message as a TS program. TS will
+  // parse the first {code} as a "Block", the first statement in the program.
+  // We want to reach to the end of that block and evaluate any code therein.
+  while (true) {
+    const start = msg.indexOf('{', end);
+    if (start === -1) {
+      formatParts.push(unescape(msg.slice(end)));
+      break;
+    }
+
+    formatParts.push(unescape(msg.slice(end, start)));
+
+    const sourceFile = ts.createSourceFile(
+      'file.js',
+      msg.slice(start),
+      ts.ScriptTarget.ESNext,
+      true,
+    );
+
+    const firstBlock = sourceFile.statements[0];
+    end = start + firstBlock.end;
+
+    // unclosed or empty bracket is not valid, emit it as text
+    if (end - 1 === start + 1 || msg[end - 1] !== '}') {
+      formatParts.push(unescape(msg.slice(start, end)));
+      continue;
+    }
+
+    if (!assert(ts.isBlock(firstBlock), 'Expected first statement in logpoint to be block')) {
+      break;
+    }
+
+    args.push(serializeLogStatements((firstBlock as ts.Block).statements));
+    formatParts.push('%O');
+  }
+
+  return `console.log(${[JSON.stringify(formatParts.join('')), ...args].join(', ')})`;
+}

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -187,6 +187,11 @@ export const assert = <T>(
 ): assertion is T => {
   if (assertion === false || assertion === undefined || assertion === null) {
     logger.error(LogTag.RuntimeAssertion, message, { error: new Error('Assertion failed') });
+
+    if (process.env.JS_DEBUG_THROW_ASSERTIONS) {
+      throw new Error(message);
+    }
+
     debugger; // break when running in development
     return false;
   }

--- a/src/common/sourceUtils.ts
+++ b/src/common/sourceUtils.ts
@@ -266,27 +266,6 @@ export function parseSourceMappingUrl(content: string): string | undefined {
   return sourceMapUrl;
 }
 
-const LOGMESSAGE_VARIABLE_REGEXP = /{(.*?)}/g;
-export function logMessageToExpression(msg: string): string {
-  msg = msg.replace('%', '%%');
-
-  const args: string[] = [];
-  let format = msg.replace(LOGMESSAGE_VARIABLE_REGEXP, (_match, group) => {
-    const a = group.trim();
-    if (a) {
-      args.push(`(${a})`);
-      return '%O';
-    } else {
-      return '';
-    }
-  });
-
-  format = format.replace("'", "\\'");
-
-  const argStr = args.length ? `, ${args.join(', ')}` : '';
-  return `console.log('${format}'${argStr});`;
-}
-
 export async function checkContentHash(
   absolutePath: string,
   contentHash?: string,

--- a/src/dap/errors.ts
+++ b/src/dap/errors.ts
@@ -17,6 +17,7 @@ export const enum ErrorCodes {
   CannotFindNodeBinary,
   NodeBinaryOutOfDate,
   InvalidHitCondition,
+  InvalidLogPointBreakpointSyntax,
 }
 
 export function reportToConsole(dap: Dap.Api, error: string) {
@@ -119,6 +120,9 @@ export const invalidHitCondition = (expression: string) =>
     ),
     ErrorCodes.InvalidHitCondition,
   );
+
+export const invalidLogPointSyntax = (error: string) =>
+  createUserError(error, ErrorCodes.InvalidLogPointBreakpointSyntax);
 
 export class ProtocolError extends Error {
   public readonly cause: Dap.Message;

--- a/src/test/breakpoints/breakpoints-logpoints-basic.txt
+++ b/src/test/breakpoints/breakpoints-logpoints-basic.txt
@@ -1,6 +1,14 @@
 stdout> 123
+stdout> > {foo: 'bar'}
+stdout>     > arg1: {foo: 'bar'}
 stdout> 1
 stdout> foo 1 bar
 stdout> foo barbaz
 stdout> barbaz
+stdout> barbaz
+stdout> Error: oof
+    at eval (logpoint.cdp:2:16)
+    at eval (logpoint.cdp:6:5)
+    at f (http://localhost:8001/logging.js:22:3)
+    at http://localhost:8001/logging.js:24:1
 stdout> hi

--- a/src/test/breakpoints/breakpointsTest.ts
+++ b/src/test/breakpoints/breakpointsTest.ts
@@ -331,19 +331,14 @@ describe('breakpoints', () => {
       };
       const breakpoints = [
         { line: 6, column: 0, logMessage: '123' },
-        // Logpoint limitations: #226
-        // { line: 7, column: 0, logMessage: "{foo: 'bar'}" },
-        // { line: 8, column: 0, logMessage: '`bar`' },
-        // { line: 9, column: 0, logMessage: '`${bar}`' },
-        { line: 7, column: 0, logMessage: '{foo}' },
-        { line: 8, column: 0, logMessage: 'foo {foo} bar' },
-        { line: 9, column: 0, logMessage: 'foo {bar + baz}' },
-        // { line: 10, column: 0, logMessage: '`${bar} ${foo}`' },
-        // { line: 11, column: 0, logMessage: '{const a = bar + baz; a}' },
-        // { line: 12, column: 0, logMessage: 'const a = bar + baz; `a=${a}`' },
-        { line: 13, column: 0, logMessage: '{(x=>x+baz)(bar)}' },
-        // { line: 14, column: 0, logMessage: 'const b=(x=>x+baz)(bar); `b=${b}`' },
-        { line: 15, column: 0, logMessage: "{'hi'}" },
+        { line: 7, column: 0, logMessage: "{{foo: 'bar'}}" },
+        { line: 8, column: 0, logMessage: '{foo}' },
+        { line: 9, column: 0, logMessage: 'foo {foo} bar' },
+        { line: 10, column: 0, logMessage: 'foo {bar + baz}' },
+        { line: 11, column: 0, logMessage: '{const a = bar + baz; a}' },
+        { line: 12, column: 0, logMessage: '{(x=>x+baz)(bar)}' },
+        { line: 13, column: 0, logMessage: '{throw new Error("oof")}' },
+        { line: 14, column: 0, logMessage: "{'hi'}" },
       ];
       await p.dap.setBreakpoints({
         source,

--- a/src/test/sources/sourceUtils.test.ts
+++ b/src/test/sources/sourceUtils.test.ts
@@ -4,6 +4,7 @@
 
 import { wrapObjectLiteral } from '../../common/sourceUtils';
 import { expect } from 'chai';
+import { logMessageToExpression } from '../../adapter/breakpoints/logPoint';
 
 describe('sourceUtils', () => {
   describe('wrapObjectLiteral', () => {
@@ -18,6 +19,50 @@ describe('sourceUtils', () => {
 
     for (const [input, output] of cases) {
       it(input, () => expect(wrapObjectLiteral(input)).to.equal(output));
+    }
+  });
+
+  const wrapped = (text: string) => `(() => {
+    try {${text}
+    } catch (e) {
+      return e.stack || e.message || String(e);
+    }
+  })()`;
+
+  describe('logMessageToExpression', () => {
+    const cases: { [name: string]: [string, string] } = {
+      'simple text': ['hello', 'console.log("hello")'],
+      suffix: ['hello {name}', `console.log("hello %O", ${wrapped('return name;')})`],
+      infix: ['hello {name}!', `console.log("hello %O!", ${wrapped('return name;')})`],
+      prefix: ['{greet} world', `console.log("%O world", ${wrapped('return greet;')})`],
+      multi: [
+        '{greet} {name}!',
+        `console.log("%O %O!", ${wrapped('return greet;')}, ${wrapped('return name;')})`,
+      ],
+      unreturned: ['{throw "foo"}!', `console.log("%O!", ${wrapped('throw "foo";')})`],
+      escaping: [
+        'greet%:o%"\' {greet} name:%"\'  {name} %',
+        `console.log("greet%%:o%%\\"' %O name:%%\\"'  %O %%", ${wrapped(
+          'return greet;',
+        )}, ${wrapped('return name;')})`,
+      ],
+      'complex expression': [
+        'hello {n++;v=() => { return true }}',
+        `console.log("hello %O", (() => {
+    try {n++;;return v=() => { return true };
+    } catch (e) {
+      return e.stack || e.message || String(e);
+    }
+  })())`,
+      ],
+      'invalid empty': ['hello {}!', 'console.log("hello {}!")'],
+      'invalid unclosed': ['hello {!', 'console.log("hello {!")'],
+      'invalid unclosed at end': ['hello {', 'console.log("hello {")'],
+    };
+
+    for (const name of Object.keys(cases)) {
+      const [input, expected] = cases[name];
+      it(name, () => expect(logMessageToExpression(input)).to.equal(expected));
     }
   });
 });

--- a/src/test/sources/sourceUtils.test.ts
+++ b/src/test/sources/sourceUtils.test.ts
@@ -49,7 +49,7 @@ describe('sourceUtils', () => {
       'complex expression': [
         'hello {n++;v=() => { return true }}',
         `console.log("hello %O", (() => {
-    try {n++;;return v=() => { return true };
+    try {n++;return v=() => { return true };
     } catch (e) {
       return e.stack || e.message || String(e);
     }


### PR DESCRIPTION
Fixes #226. As suggested in the original issue, we use the TS parser
to parse the code inside the {} 'blocks', which lets us handle more
complex expressions. We also now support multiple statements, and
(try to) return the last one, and log the stacks of any thrown errors
rather than silently failing. Finally, we return a verbose error to the
user in the event that their logpoint isn't valid JS, though there's
an issue with VS Code right now: https://github.com/microsoft/vscode/issues/89059