### PR TITLE
fix: disconnected event ordering, again

### DIFF
--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -613,13 +613,15 @@ export class SourceContainer {
     deferred.resolve();
   }
 
-  removeSource(source: Source) {
+  removeSource(source: Source, silent = false) {
     console.assert(this._sourceByReference.get(source.sourceReference()) === source);
     this._sourceByReference.delete(source.sourceReference());
     if (source._compiledToSourceUrl) this._sourceMapSourcesByUrl.delete(source._url);
     this._sourceByAbsolutePath.delete(source._absolutePath);
     this._disabledSourceMaps.delete(source);
-    source.toDap().then(dap => this._dap.loadedSource({ reason: 'removed', source: dap }));
+    if (!silent) {
+      source.toDap().then(dap => this._dap.loadedSource({ reason: 'removed', source: dap }));
+    }
 
     const sourceMapUrl = source._sourceMapUrl;
     if (!sourceMapUrl) return;

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -620,7 +620,7 @@ export class Thread implements IVariableStoreDelegate {
   }
 
   dispose() {
-    this._removeAllScripts();
+    this._removeAllScripts(true /* silent */);
     for (const [debuggerId, thread] of Thread._allThreadsByDebuggerId) {
       if (thread === this) Thread._allThreadsByDebuggerId.delete(debuggerId);
     }
@@ -988,14 +988,14 @@ export class Thread implements IVariableStoreDelegate {
     return this._sourceScripts.get(source) || new Set();
   }
 
-  _removeAllScripts() {
+  private _removeAllScripts(silent = false) {
     const scripts = Array.from(this._scripts.values());
     this._scripts.clear();
     this._scriptSources.clear();
     for (const script of scripts) {
       const set = this.scriptsFromSource(script.source);
       set.delete(script);
-      if (!set.size) this._sourceContainer.removeSource(script.source);
+      if (!set.size) this._sourceContainer.removeSource(script.source, silent);
     }
   }
 

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -30,6 +30,7 @@ import { IAsyncStackPolicy, getAsyncStackPolicy } from './adapter/asyncStackPoli
 import { TelemetryReporter } from './telemetry/telemetryReporter';
 import { mapValues } from './common/objUtils';
 import * as os from 'os';
+import { delay } from './common/promiseUtil';
 
 const localize = nls.loadMessageBundle();
 
@@ -134,17 +135,21 @@ export class Binder implements IDisposable {
 
   private async _disconnect() {
     await Promise.all([...this._launchers].map(l => l.disconnect()));
-    if (!this.targetList.length) {
+
+    const didTerminate = () => !this.targetList.length && this._terminationCount === 0;
+    if (didTerminate()) {
       return;
     }
 
     await new Promise(resolve =>
       this.onTargetListChanged(() => {
-        if (!this.targetList.length) {
+        if (didTerminate()) {
           resolve();
         }
       }),
     );
+
+    await delay(0); // next task so that we're sure terminated() sent
   }
 
   private async _boot(params: AnyLaunchConfiguration, dap: Dap.Api) {


### PR DESCRIPTION
I was focused on Node before, Chrome is different. In Node, the target
disconnecting is generally 1:1 with the program termination. But in
Chrome, the target (tab) closes before the browser does, and there are
a few more events that get sent out.

Additionally, when tearing down DAP we were previously verbosely
signalling that all sources were removed. This happened during the
disposal process, after everything else was torn down, and they weren't
necessary. Remove them.