### PR TITLE
Handle skipFiles for multiple source files built into a bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,12 @@
         {
           "command": "extension.NAMESPACE(node-debug).toggleSkippingFile",
           "group": "navigation",
-          "when": "inDebugMode && callStackItemType == 'stackFrame'"
+          "when": "inDebugMode && debugType == NAMESPACE(node) && callStackItemType == 'stackFrame'"
+        },
+        {
+          "command": "extension.NAMESPACE(node-debug).toggleSkippingFile",
+          "group": "navigation",
+          "when": "inDebugMode && debugType == NAMESPACE(chrome) && callStackItemType == 'stackFrame'"
         }
       ],
       "view/title": [

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -111,7 +111,7 @@ export class DebugAdapter {
       sourceMapRepo,
       this._scriptSkipper,
     );
-    this._scriptSkipper.setSourceContainer(this.sourceContainer); // TODO Try to resolve circular dependency btw SourceContainer < - > ScriptSkipper
+    this._scriptSkipper.setSourceContainer(this.sourceContainer);
     this.breakpointManager = new BreakpointManager(
       this.dap,
       this.sourceContainer,

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -330,7 +330,7 @@ export class DebugAdapter {
   async _toggleSkipFileStatus(
     params: Dap.ToggleSkipFileStatusParams,
   ): Promise<Dap.ToggleSkipFileStatusResult | Dap.Error> {
-    await this._scriptSkipper.toggleSkippingFile(params, this.sourceContainer);
+    await this._scriptSkipper.toggleSkippingFile(params);
     await this._refreshStackTrace();
     return {};
   }

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -46,7 +46,7 @@ export class DebugAdapter {
     dap: Dap.Api,
     rootPath: string | undefined,
     sourcePathResolver: ISourcePathResolver,
-    private scriptSkipper: ScriptSkipper,
+    private readonly _scriptSkipper: ScriptSkipper,
     private readonly asyncStackPolicy: IAsyncStackPolicy,
     private readonly launchConfig: AnyLaunchConfiguration,
     private readonly _rawTelemetryReporter: TelemetryReporter,
@@ -109,8 +109,9 @@ export class DebugAdapter {
       rootPath,
       sourcePathResolver,
       sourceMapRepo,
-      scriptSkipper,
+      this._scriptSkipper,
     );
+    this._scriptSkipper.setSourceContainer(this.sourceContainer); // TODO Try to resolve circular dependency btw SourceContainer < - > ScriptSkipper
     this.breakpointManager = new BreakpointManager(
       this.dap,
       this.sourceContainer,
@@ -329,7 +330,7 @@ export class DebugAdapter {
   async _toggleSkipFileStatus(
     params: Dap.ToggleSkipFileStatusParams,
   ): Promise<Dap.ToggleSkipFileStatusResult | Dap.Error> {
-    await this.scriptSkipper.toggleSkippingFile(params, this.sourceContainer);
+    await this._scriptSkipper.toggleSkippingFile(params, this.sourceContainer);
     await this._refreshStackTrace();
     return {};
   }

--- a/src/adapter/scriptSkipper.ts
+++ b/src/adapter/scriptSkipper.ts
@@ -12,6 +12,7 @@ import * as urlUtils from '../common/urlUtils';
 import Dap from '../dap/api';
 import { ITarget } from '../targets/targets';
 import { Source, SourceContainer } from './sources';
+import { escapeRegexSpecialChars } from '../common/stringUtils';
 
 interface ISharedSkipToggleEvent {
   rootTargetId: string;
@@ -90,6 +91,7 @@ export class ScriptSkipper {
   }
 
   private _createRegexString(patterns: string[]): string {
+    // TODO this should use node-glob directly
     return patterns.map(pattern => utils.pathGlobToBlackboxedRegex(pattern)).join('|');
   }
 
@@ -115,8 +117,9 @@ export class ScriptSkipper {
   }
 
   private async _updateBlackboxedUrls(urlsToBlackbox: string[]): Promise<void> {
-    // TODO safely escape url for regex
-    const blackboxPatterns = urlsToBlackbox.map(url => '^' + url + '$');
+    const blackboxPatterns = urlsToBlackbox
+      .map(url => escapeRegexSpecialChars(url))
+      .map(url => `^${url}$`);
     await this.cdp.Debugger.setBlackboxPatterns({ patterns: blackboxPatterns });
   }
 

--- a/src/adapter/scriptSkipper.ts
+++ b/src/adapter/scriptSkipper.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import cdp from '../cdp/api';
+import cdp, { Cdp } from '../cdp/api';
 import Dap from '../dap/api';
 import * as utils from '../common/sourceUtils';
 import { ITarget } from '../targets/targets';
@@ -13,38 +13,43 @@ import { debounce } from '../common/objUtils';
 import { MapUsingProjection } from '../common/datastructure/mapUsingProjection';
 
 export class BlackBoxSender {
-  private _blackboxSender: (
-    params: cdp.Debugger.SetBlackboxPatternsParams,
-  ) => Promise<cdp.Debugger.SetBlackboxPatternsResult | undefined>;
-
   public sendPatterns(blackboxPatterns: string[]) {
-    this._blackboxSender({ patterns: blackboxPatterns });
+    this.debuggerAPI.setBlackboxPatterns({ patterns: blackboxPatterns });
   }
 
-  constructor(debuggerAPI: cdp.DebuggerApi) {
-    this._blackboxSender = debuggerAPI.setBlackboxPatterns.bind(debuggerAPI);
+  public sendRanges(params: cdp.Debugger.SetBlackboxedRangesParams): void {
+    this.debuggerAPI.setBlackboxedRanges(params);
+  }
+
+  constructor(public targetId: string, private debuggerAPI: cdp.DebuggerApi) {
   }
 }
 
 export class ScriptSkipper {
+  // TODO yikes
+  public sourceContainerToTarget = new Map<SourceContainer, string>();
+
   private _nonNodeInternalRegex: RegExp | null = null;
 
   // filtering node internals
   private _nodeInternalsRegex: RegExp | null = null;
   private _allNodeInternals?: string[]; // only set by Node
 
-  private _isUrlSkippedMap: Map<string, boolean>;
+  private _isUrlSkipped: Map<string, boolean>;
+  private _isAuthoredUrlSkipped: Map<string, boolean>;
+
   private _blackboxSenders = new Set<BlackBoxSender>();
 
   private _newScriptDebouncer: () => void;
-  private _unprocessedSources: Source[] = [];
+  private _unprocessedSources: [Source, SourceContainer][] = [];
 
   constructor(skipPatterns: ReadonlyArray<string>) {
-    this._isUrlSkippedMap = new MapUsingProjection<string, boolean>(key => this._normalizeUrl(key));
+    this._isUrlSkipped = new MapUsingProjection<string, boolean>(key => this._normalizeUrl(key));
+    this._isAuthoredUrlSkipped = new MapUsingProjection<string, boolean>(key => this._normalizeUrl(key));
 
     this._preprocessNodeInternals(skipPatterns);
     this._setRegexForNonNodeInternals(skipPatterns);
-    this._newScriptDebouncer = debounce(400, () => this._updateSkippingValueForAllScripts());
+    this._newScriptDebouncer = debounce(100, () => this._initializeSkippingValueForNewSources());
   }
 
   private _preprocessNodeInternals(userSkipPatterns: ReadonlyArray<string>): void {
@@ -77,20 +82,16 @@ export class ScriptSkipper {
     return patterns.map(pattern => utils.pathGlobToBlackboxedRegex(pattern)).join('|');
   }
 
-  private _testRegex(regex: RegExp, strToTest: string): boolean {
-    return regex.test(strToTest);
-  }
-
   private _testSkipNodeInternal(testString: string): boolean {
     if (this._nodeInternalsRegex) {
-      return this._testRegex(this._nodeInternalsRegex, testString);
+      return this._nodeInternalsRegex.test(testString);
     }
     return false;
   }
 
   private _testSkipNonNodeInternal(testString: string): boolean {
     if (this._nonNodeInternalRegex) {
-      return this._testRegex(this._nonNodeInternalRegex, testString);
+      return this._nonNodeInternalRegex.test(testString);
     }
     return false;
   }
@@ -98,18 +99,19 @@ export class ScriptSkipper {
   private _isNodeInternal(url: string): boolean {
     return (
       (this._allNodeInternals && this._allNodeInternals.includes(url)) ||
-      this._testRegex(/^internal\/.+\.js$/, url)
+      /^internal\/.+\.js$/.test(url)
     );
   }
 
   private _updateBlackboxedUrls(urlsToBlackbox: string[]) {
+    // TODO safely escape url for regex
     const blackboxPatterns = urlsToBlackbox.map(url => '^' + url + '$');
     this._sendBlackboxPatterns(blackboxPatterns);
   }
 
-  private _updateAllScriptsToBeSkipped(): void {
+  private _updateGeneratedSkippedSources(): void {
     const urlsToSkip: string[] = [];
-    for (const [url, isSkipped] of this._isUrlSkippedMap.entries()) {
+    for (const [url, isSkipped] of this._isUrlSkipped.entries()) {
       if (isSkipped) {
         urlsToSkip.push(url);
       }
@@ -127,8 +129,8 @@ export class ScriptSkipper {
     return pathUtils.forceForwardSlashes(url.toLowerCase());
   }
 
-  public registerNewBlackBoxSender(debuggerAPI: cdp.DebuggerApi) {
-    const sender = new BlackBoxSender(debuggerAPI);
+  public registerNewBlackBoxSender(id: string, debuggerAPI: cdp.DebuggerApi) {
+    const sender = new BlackBoxSender(id, debuggerAPI);
     if (!this._blackboxSenders.has(sender)) {
       this._blackboxSenders.add(sender);
     }
@@ -136,75 +138,184 @@ export class ScriptSkipper {
 
   private _setSkippingValueForScripts(urls: string[], skipValue: boolean): void {
     urls.forEach(url => {
-      this._isUrlSkippedMap.set(url, skipValue);
+      this._isUrlSkipped.set(url, skipValue);
     });
 
-    this._updateAllScriptsToBeSkipped();
+    this._updateGeneratedSkippedSources();
   }
 
   public isScriptSkipped(url: string): boolean {
-    return this._isUrlSkippedMap.get(this._normalizeUrl(url)) === true;
+    return this._isUrlSkipped.get(this._normalizeUrl(url)) === true ||
+      this._isAuthoredUrlSkipped.get(this._normalizeUrl(url)) === true;
   }
 
   private _hasScript(url: string): boolean {
-    return this._isUrlSkippedMap.has(this._normalizeUrl(url));
+    return this._isUrlSkipped.has(this._normalizeUrl(url));
   }
 
-  public updateSkippingValueForScript(source: Source) {
-    this._unprocessedSources.push(source);
+  private async _initializeSourceMappedSources(source: Source, sourceContainer: SourceContainer): Promise<void> {
+    const targetId = this.sourceContainerToTarget.get(sourceContainer);
+
+    // source._compiledToSourceUrl?.forEach((url, compiledSource) => {
+    //   this._blackboxSenders.forEach(sender => {
+    //     if (targetId === sender.targetId) {
+    //       sender.sendRanges({ scriptId: compiledSource.scriptId!, positions: [{ columnNumber: 0, lineNumber: 89 }, {columnNumber: 0, lineNumber: 103}] });
+    //     }
+    //   });
+    // });
+
+    // Order "should" be correct
+    const parentIsSkipped = this.isScriptSkipped(source.url());
+    const skipRanges: Cdp.Debugger.ScriptPosition[] = [];
+    let inSkipRange = parentIsSkipped;
+    Array.from(source._sourceMapSourceByUrl!.values()).forEach(authoredSource => {
+      let isSkippedSource = this.isScriptSkipped(authoredSource.url());
+      if (typeof isSkippedSource === 'undefined') {
+        // If not toggled or specified in launch config, inherit the parent's status
+        isSkippedSource = parentIsSkipped;
+      }
+
+      if (isSkippedSource !== inSkipRange) {
+        const locations = sourceContainer.currentSiblingUiLocations({ source: authoredSource, lineNumber: 1, columnNumber: 1 }, source);
+        if (locations[0]) {
+          skipRanges.push({
+            lineNumber: locations[0].lineNumber - 1,
+            columnNumber: locations[0].columnNumber - 1
+          });
+          inSkipRange = !inSkipRange;
+        } else {
+          // log something
+        }
+      }
+    });
+
+    this._blackboxSenders.forEach(sender => {
+      if (targetId === sender.targetId) {
+        sender.sendRanges({ scriptId: source.scriptId!, positions: skipRanges });
+      }
+    });
+  }
+
+//   public async resolveSkipFiles(script: Crdp.Debugger.ScriptParsedEvent, mappedUrl: string, sources: string[], toggling?: boolean): Promise<void> {
+//     if (sources && sources.length) {
+//         const parentIsSkipped = this.shouldSkipSource(script.url);
+//         const libPositions: Crdp.Debugger.ScriptPosition[] = [];
+
+//         // Figure out skip/noskip transitions within script
+//         let inLibRange = parentIsSkipped;
+//         for (let s of sources) {
+//             let isSkippedFile = this.shouldSkipSource(s);
+//             if (typeof isSkippedFile !== 'boolean') {
+//                 // Inherit the parent's status
+//                 isSkippedFile = parentIsSkipped;
+//             }
+
+//             this._skipFileStatuses.set(s, isSkippedFile);
+
+//             if ((isSkippedFile && !inLibRange) || (!isSkippedFile && inLibRange)) {
+//                 const details = await this._transformers.sourceMapTransformer.allSourcePathDetails(mappedUrl);
+//                 const detail = details.find(d => d.inferredPath === s);
+//                 if (detail.startPosition) {
+//                     libPositions.push({
+//                         lineNumber: detail.startPosition.line,
+//                         columnNumber: detail.startPosition.column
+//                     });
+//                 }
+
+//                 inLibRange = !inLibRange;
+//             }
+//         }
+
+//         // If there's any change from the default, set proper blackboxed ranges
+//         if (libPositions.length || toggling) {
+//             if (parentIsSkipped) {
+//                 libPositions.splice(0, 0, { lineNumber: 0, columnNumber: 0});
+//             }
+
+//             if (libPositions[0].lineNumber !== 0 || libPositions[0].columnNumber !== 0) {
+//                 // The list of blackboxed ranges must start with 0,0 for some reason.
+//                 // https://github.com/Microsoft/vscode-chrome-debug/issues/667
+//                 libPositions[0] = {
+//                     lineNumber: 0,
+//                     columnNumber: 0
+//                 };
+//             }
+
+//             await this.chrome.Debugger.setBlackboxedRanges({
+//                 scriptId: script.scriptId,
+//                 positions: []
+//             }).catch(() => this.warnNoSkipFiles());
+
+//             if (libPositions.length) {
+//                 this.chrome.Debugger.setBlackboxedRanges({
+//                     scriptId: script.scriptId,
+//                     positions: libPositions
+//                 }).catch(() => this.warnNoSkipFiles());
+//             }
+//         }
+//     } else {
+//         const status = await this.getSkipStatus(mappedUrl);
+//         const skippedByPattern = this.matchesSkipFilesPatterns(mappedUrl);
+//         if (typeof status === 'boolean' && status !== skippedByPattern) {
+//             const positions = status ? [{ lineNumber: 0, columnNumber: 0 }] : [];
+//             this.chrome.Debugger.setBlackboxedRanges({
+//                 scriptId: script.scriptId,
+//                 positions
+//             }).catch(() => this.warnNoSkipFiles());
+//         }
+//     }
+// }
+
+  public initializeSkippingValueForSource(source: Source, sourceContainer: SourceContainer) {
+    this._unprocessedSources.push([source, sourceContainer]);
     this._newScriptDebouncer();
   }
 
-  private async _updateSkippingValueForAllScripts() {
+  private async _initializeSkippingValueForNewSources() {
     const skipStatuses = await Promise.all(
-      this._unprocessedSources.map(s => this._updateSkippingValueForScript(s)),
+      this._unprocessedSources.map(([source, sourceContainer]) => this._initializeSkippingValueForSource(source, sourceContainer)),
     );
 
     if (skipStatuses.some(s => !!s)) {
-      this._updateAllScriptsToBeSkipped();
+      this._updateGeneratedSkippedSources();
     }
 
     this._unprocessedSources = [];
   }
 
-  private async _updateSkippingValueForScript(source: Source): Promise<boolean> {
+  private async _initializeSkippingValueForSource(source: Source, sourceContainer: SourceContainer): Promise<boolean> {
+    const map = isAuthored(source) ? this._isAuthoredUrlSkipped : this._isUrlSkipped;
+
     const url = source.url();
-    if (!this._isUrlSkippedMap.has(this._normalizeUrl(url))) {
-      // applying sourcemappathoverrides results in incorrect absolute paths
-      // for some sources that don't map to disk (e.g. node_internals), so here
-      // we're checking for whether a file actually corresponds to a file on disk
+    if (!map.has(this._normalizeUrl(url))) { // TODO is this check correct (?)
       const pathOnDisk = await source.existingAbsolutePath();
       if (pathOnDisk) {
         // file maps to file on disk
-        this._isUrlSkippedMap.set(url, this._testSkipNonNodeInternal(pathOnDisk));
+        map.set(url, this._testSkipNonNodeInternal(pathOnDisk));
       } else {
         if (this._isNodeInternal(url)) {
-          this._isUrlSkippedMap.set(url, this._testSkipNodeInternal(url));
+          map.set(url, this._testSkipNodeInternal(url));
         } else {
-          this._isUrlSkippedMap.set(url, this._testSkipNonNodeInternal(url));
+          map.set(url, this._testSkipNonNodeInternal(url));
         }
       }
 
-      let correspondingSources: Source[] | null = null;
+      if (this.isScriptSkipped(source._url)) {
+        if (source._sourceMapSourceByUrl) {
+          // if compiled and skipped, also skip authored sources
+          const authoredSources = Array.from(source._sourceMapSourceByUrl.values());
+            authoredSources.forEach(authoredSource => {
+              this._isAuthoredUrlSkipped.set(authoredSource._url, true);
+            });
+        }
+      }
+
       if (source._sourceMapSourceByUrl) {
-        // if compiled, get authored sources
-        correspondingSources = Array.from(source._sourceMapSourceByUrl.values());
-      } else if (source._compiledToSourceUrl) {
-        correspondingSources = Array.from(source._compiledToSourceUrl.keys());
-        // if authored, get compiled sources
+        const sourceMapSources = Array.from(source._sourceMapSourceByUrl.values());
+        await Promise.all(sourceMapSources.map(s => this._initializeSkippingValueForSource(s, sourceContainer)));
+        this._initializeSourceMappedSources(source, sourceContainer);
       }
 
-      if (correspondingSources) {
-        const correspondingScriptIsSkipped = correspondingSources.some(correspondingSource =>
-          this.isScriptSkipped(correspondingSource._url),
-        );
-        if (this.isScriptSkipped(source._url) || correspondingScriptIsSkipped) {
-          this._isUrlSkippedMap.set(source._url, true);
-          correspondingSources.forEach(correspondingSource => {
-            this._isUrlSkippedMap.set(correspondingSource._url, true);
-          });
-        }
-      }
 
       return this.isScriptSkipped(url);
     }
@@ -228,7 +339,7 @@ export class ScriptSkipper {
       }
     }
 
-    this.registerNewBlackBoxSender(debuggerAPI);
+    this.registerNewBlackBoxSender(target.id(), debuggerAPI);
   }
 
   public async toggleSkippingFile(
@@ -262,10 +373,14 @@ export class ScriptSkipper {
       this._setSkippingValueForScripts(urlsToSkip, newSkipValue);
     } else {
       if (params.resource && this._hasScript(params.resource)) {
-        this._isUrlSkippedMap.set(params.resource, !this.isScriptSkipped(params.resource));
+        this._isUrlSkipped.set(params.resource, !this.isScriptSkipped(params.resource));
       }
     }
 
     return {};
   }
+}
+
+function isAuthored(source: Source) {
+  return source._compiledToSourceUrl;
 }

--- a/src/adapter/scriptSkipper.ts
+++ b/src/adapter/scriptSkipper.ts
@@ -13,6 +13,8 @@ import Dap from '../dap/api';
 import { ITarget } from '../targets/targets';
 import { Source, SourceContainer } from './sources';
 import { escapeRegexSpecialChars } from '../common/stringUtils';
+import { logger } from '../common/logging/logger';
+import { LogTag } from '../common/logging';
 
 interface ISharedSkipToggleEvent {
   rootTargetId: string;
@@ -171,7 +173,10 @@ export class ScriptSkipper {
           });
           inSkipRange = !inSkipRange;
         } else {
-          // log something
+          logger.error(
+            LogTag.Internal,
+            'Could not map script beginning for ' + authoredSource._name,
+          );
         }
       }
     });
@@ -210,7 +215,6 @@ export class ScriptSkipper {
 
     const url = source.url();
     if (!map.has(this._normalizeUrl(url))) {
-      // TODO is this check correct (?)
       const pathOnDisk = await source.existingAbsolutePath();
       if (pathOnDisk) {
         // file maps to file on disk

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -20,6 +20,7 @@ import { assert, logger } from '../common/logging/logger';
 import { SourceMapCache } from './sourceMapCache';
 import { LogTag } from '../common/logging';
 import { fixDriveLetterAndSlashes } from '../common/pathUtils';
+import Cdp from '../cdp/api';
 
 const localize = nls.loadMessageBundle();
 
@@ -117,6 +118,8 @@ export class Source {
 
   private _content?: Promise<string | undefined>;
 
+  private readonly _scriptIds: Cdp.Runtime.ScriptId[] = [];
+
   constructor(
     container: SourceContainer,
     url: string,
@@ -147,6 +150,14 @@ export class Source {
 
   url(): string {
     return this._url;
+  }
+
+  addScriptId(scriptId: Cdp.Runtime.ScriptId): void {
+    this._scriptIds.push(scriptId);
+  }
+
+  scriptIds(): Cdp.Runtime.ScriptId[] {
+    return this._scriptIds;
   }
 
   sourceReference(): number {
@@ -684,7 +695,6 @@ export class SourceContainer {
         source._compiledToSourceUrl = new Map();
         source._compiledToSourceUrl.set(compiled, url);
         compiled._sourceMapSourceByUrl.set(url, source);
-
       } else {
         source._compiledToSourceUrl!.set(compiled, url);
         compiled._sourceMapSourceByUrl.set(url, source);

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -194,7 +194,7 @@ export class Source {
       sourceReference: this._sourceReference,
       sources,
       presentationHint: this.blackboxed() ? 'deemphasize' : undefined,
-      origin: this.blackboxed() ? localize('source.isBlackboxed', 'blackboxed') : undefined,
+      origin: this.blackboxed() ? localize('source.skipFiles', 'Skipped by skipFiles') : undefined,
     };
     if (existingAbsolutePath) {
       dap.sourceReference = 0;
@@ -553,7 +553,7 @@ export class SourceContainer {
       inlineSourceRange,
       contentHash,
     );
-    await this._scriptSkipper.updateSkippingValueForScript(source);
+    this._scriptSkipper.updateSkippingValueForScript(source);
     this._addSource(source);
     return source;
   }

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1035,11 +1035,13 @@ export class Thread implements IVariableStoreDelegate {
       const hash = this._delegate.shouldCheckContentHash() ? event.hash : undefined;
       source = await this._sourceContainer.addSource(
         event.url,
+        event.scriptId,
         contentGetter,
         resolvedSourceMapUrl,
         inlineSourceOffset,
         hash,
       );
+      this._sourceContainer._scriptSkipper.initializeSkippingValueForSource(source, this._sourceContainer);
       urlHashMap.set(event.hash, source);
     }
 

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1042,6 +1042,7 @@ export class Thread implements IVariableStoreDelegate {
       urlHashMap.set(event.hash, source);
     }
 
+    source.addScriptId(event.scriptId);
     const script = { url: event.url, scriptId: event.scriptId, source, hash: event.hash };
     this._scripts.set(event.scriptId, script);
 

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -16,7 +16,6 @@ import * as completions from './completions';
 import { CustomBreakpointId, customBreakpoints } from './customBreakpoints';
 import * as messageFormat from './messageFormat';
 import * as objectPreview from './objectPreview';
-import { ScriptSkipper } from './scriptSkipper';
 import { SmartStepper } from './smartStepping';
 import {
   IPreferredUiLocation,
@@ -78,7 +77,6 @@ export interface IThreadDelegate {
   defaultScriptOffset(): InlineScriptOffset | undefined;
   scriptUrlToUrl(url: string): string;
   executionContextName(description: Cdp.Runtime.ExecutionContextDescription): string;
-  skipFiles(): ScriptSkipper | undefined;
   initialize(): Promise<void>;
 }
 
@@ -1035,13 +1033,12 @@ export class Thread implements IVariableStoreDelegate {
       const hash = this._delegate.shouldCheckContentHash() ? event.hash : undefined;
       source = await this._sourceContainer.addSource(
         event.url,
-        event.scriptId,
         contentGetter,
         resolvedSourceMapUrl,
         inlineSourceOffset,
         hash,
       );
-      this._sourceContainer._scriptSkipper.initializeSkippingValueForSource(source, this._sourceContainer);
+      this._sourceContainer.scriptSkipper.initializeSkippingValueForSource(source, event.scriptId);
       urlHashMap.set(event.hash, source);
     }
 

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -324,6 +324,8 @@ export class Binder implements IDisposable {
       this._launchParams!,
       this.telemetryReporter,
     );
+    this._scriptSkipper?.sourceContainerToTarget.set(debugAdapter.sourceContainer, target.id()); // TODO
+
     await this.attachScriptSkipper(target, cdp, dap);
     const thread = debugAdapter.createThread(target.name(), cdp, target);
     this._threads.set(target, { thread, debugAdapter });

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -24,7 +24,6 @@ import * as errors from './dap/errors';
 import { ILauncher, ILaunchResult, ITarget } from './targets/targets';
 import { filterErrorsReportedToTelemetry } from './telemetry/unhandledErrorReporter';
 import { ScriptSkipper } from './adapter/scriptSkipper';
-import Cdp from './cdp/api';
 import { ITargetOrigin } from './targets/targetOrigin';
 import { IAsyncStackPolicy, getAsyncStackPolicy } from './adapter/asyncStackPolicy';
 import { TelemetryReporter } from './telemetry/telemetryReporter';
@@ -55,7 +54,6 @@ export class Binder implements IDisposable {
   private _targetOrigin: ITargetOrigin;
   private _launchParams?: AnyLaunchConfiguration;
   private _clientCapabilities: Dap.InitializeParams | undefined;
-  private _scriptSkipper?: ScriptSkipper;
   private _asyncStackPolicy?: IAsyncStackPolicy;
 
   constructor(
@@ -156,7 +154,6 @@ export class Binder implements IDisposable {
 
     if (params.rootPath) params.rootPath = urlUtils.platformPathToPreferredCase(params.rootPath);
     this._launchParams = params;
-    this._scriptSkipper = new ScriptSkipper(this._launchParams.skipFiles);
     let results = await Promise.all(
       [...this._launchers].map(l => this._launch(l, params, cts.token)),
     );
@@ -300,10 +297,6 @@ export class Binder implements IDisposable {
     return result;
   }
 
-  async attachScriptSkipper(target: ITarget, cdp: Cdp.Api, dap: Dap.Api): Promise<void> {
-    this._scriptSkipper!.initNewTarget(target, cdp.Runtime, cdp.Debugger);
-  }
-
   async attach(target: ITarget) {
     if (!target.canAttach()) return;
     const cdp = await target.attach();
@@ -315,18 +308,16 @@ export class Binder implements IDisposable {
       this._asyncStackPolicy = getAsyncStackPolicy(this._launchParams!.showAsyncStacks);
     }
 
+    const scriptSkipper = new ScriptSkipper(this._launchParams!.skipFiles, cdp, target);
     const debugAdapter = new DebugAdapter(
       dap,
       this._launchParams?.rootPath || undefined,
       target.sourcePathResolver(),
-      this._scriptSkipper!,
+      scriptSkipper,
       this._asyncStackPolicy,
       this._launchParams!,
       this.telemetryReporter,
     );
-    this._scriptSkipper?.sourceContainerToTarget.set(debugAdapter.sourceContainer, target.id()); // TODO
-
-    await this.attachScriptSkipper(target, cdp, dap);
     const thread = debugAdapter.createThread(target.name(), cdp, target);
     this._threads.set(target, { thread, debugAdapter });
     const startThread = async () => {

--- a/src/common/datastructure/mapUsingProjection.ts
+++ b/src/common/datastructure/mapUsingProjection.ts
@@ -17,7 +17,7 @@ class KeyAndValue<K, V> {
  * equivalent to define a custom comparison criteria in other languages)
  */
 export class MapUsingProjection<K, V, P = K> implements Map<K, V> {
-  private readonly projectionToKeyAndvalue: Map<P, KeyAndValue<K, V>>;
+  private readonly projectionToKeyAndValue: Map<P, KeyAndValue<K, V>>;
 
   constructor(
     private readonly projection: (key: K) => P,
@@ -30,57 +30,57 @@ export class MapUsingProjection<K, V, P = K> implements Map<K, V> {
       },
     );
 
-    this.projectionToKeyAndvalue = new Map<P, KeyAndValue<K, V>>(entries);
+    this.projectionToKeyAndValue = new Map<P, KeyAndValue<K, V>>(entries);
   }
 
   public clear(): void {
-    this.projectionToKeyAndvalue.clear();
+    this.projectionToKeyAndValue.clear();
   }
 
   public delete(key: K): boolean {
     const keyProjected = this.projection(key);
-    return this.projectionToKeyAndvalue.delete(keyProjected);
+    return this.projectionToKeyAndValue.delete(keyProjected);
   }
 
   public forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void {
-    this.projectionToKeyAndvalue.forEach(keyAndValue => {
+    this.projectionToKeyAndValue.forEach(keyAndValue => {
       callbackfn.call(thisArg, keyAndValue.value, keyAndValue.key, this);
     }, thisArg);
   }
 
   public get(key: K): V | undefined {
     const keyProjected = this.projection(key);
-    const value = this.projectionToKeyAndvalue.get(keyProjected);
+    const value = this.projectionToKeyAndValue.get(keyProjected);
     return value ? value.value : undefined;
   }
 
   public has(key: K): boolean {
-    return this.projectionToKeyAndvalue.has(this.projection(key));
+    return this.projectionToKeyAndValue.has(this.projection(key));
   }
 
   public set(key: K, value: V): this {
-    this.projectionToKeyAndvalue.set(this.projection(key), new KeyAndValue(key, value));
+    this.projectionToKeyAndValue.set(this.projection(key), new KeyAndValue(key, value));
     return this;
   }
 
   public get size(): number {
-    return this.projectionToKeyAndvalue.size;
+    return this.projectionToKeyAndValue.size;
   }
 
   public *entries(): IterableIterator<[K, V]> {
-    for (const keyAndValue of this.projectionToKeyAndvalue.values()) {
+    for (const keyAndValue of this.projectionToKeyAndValue.values()) {
       yield [keyAndValue.key, keyAndValue.value];
     }
   }
 
   public *keys(): IterableIterator<K> {
-    for (const keyAndValue of this.projectionToKeyAndvalue.values()) {
+    for (const keyAndValue of this.projectionToKeyAndValue.values()) {
       yield keyAndValue.key;
     }
   }
 
   public *values(): IterableIterator<V> {
-    for (const keyAndValue of this.projectionToKeyAndvalue.values()) {
+    for (const keyAndValue of this.projectionToKeyAndValue.values()) {
       yield keyAndValue.value;
     }
   }

--- a/src/common/sourceUtils.ts
+++ b/src/common/sourceUtils.ts
@@ -11,6 +11,7 @@ import { SourceMap, ISourceMapMetadata } from './sourceMaps/sourceMap';
 import { logger } from './logging/logger';
 import { LogTag } from './logging';
 import { hashBytes, hashFile } from './hash';
+import { escapeRegexSpecialChars } from './stringUtils';
 
 export async function prettyPrintAsSourceMap(
   fileName: string,
@@ -304,16 +305,4 @@ export function pathGlobToBlackboxedRegex(glob: string): string {
       // Match either slash direction
       .replace(/\\\/|\\\\/g, '[/\\\\]')
   ); // / -> [/|\], \ -> [/|\]
-}
-
-const regexChars = '/\\.?*()^${}|[]+';
-export function escapeRegexSpecialChars(str: string, except?: string): string {
-  const useRegexChars = regexChars
-    .split('')
-    .filter(c => !except || except.indexOf(c) < 0)
-    .join('')
-    .replace(/[\\\]]/g, '\\$&');
-
-  const r = new RegExp(`[${useRegexChars}]`, 'g');
-  return str.replace(r, '\\$&');
 }

--- a/src/common/sourceUtils.ts
+++ b/src/common/sourceUtils.ts
@@ -11,7 +11,6 @@ import { SourceMap, ISourceMapMetadata } from './sourceMaps/sourceMap';
 import { logger } from './logging/logger';
 import { LogTag } from './logging';
 import { hashBytes, hashFile } from './hash';
-import { escapeRegexSpecialChars } from './stringUtils';
 
 export async function prettyPrintAsSourceMap(
   fileName: string,
@@ -290,19 +289,4 @@ export function positionToOffset(text: string, line: number, column: number): nu
   for (let l = 1; l < line; ++l) offset += lines[l - 1].length + 1;
   offset += column - 1;
   return offset;
-}
-
-export function pathGlobToBlackboxedRegex(glob: string): string {
-  return (
-    escapeRegexSpecialChars(glob, '*')
-      .replace(/([^*]|^)\*([^*]|$)/g, '$1.*$2') // * -> .*
-      .replace(/\*\*(\\\/|\\\\)?/g, '(.*\\/)?') // **/ -> (.*\/)?
-
-      // Just to simplify
-      .replace(/\.\*\\\/\.\*/g, '.*') // .*\/.* -> .*
-      .replace(/\.\*\.\*/g, '.*') // .*.* -> .*
-
-      // Match either slash direction
-      .replace(/\\\/|\\\\/g, '[/\\\\]')
-  ); // / -> [/|\], \ -> [/|\]
 }

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -9,11 +9,11 @@ import * as http from 'http';
 import * as https from 'https';
 import { fixDriveLetterAndSlashes, isUncPath } from './pathUtils';
 import Cdp from '../cdp/api';
-import { escapeRegexSpecialChars } from './sourceUtils';
 import { AnyChromeConfiguration } from '../configuration';
 import { readdir } from './fsUtils';
 import { memoize } from './objUtils';
 import { assert } from './logging/logger';
+import { escapeRegexSpecialChars } from './stringUtils';
 
 let isCaseSensitive = process.platform !== 'win32';
 

--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -14,7 +14,13 @@ import { EventEmitter, IDisposable } from '../../common/events';
 import { absolutePathToFileUrl } from '../../common/urlUtils';
 import { AnyChromeConfiguration, IChromeLaunchConfiguration } from '../../configuration';
 import Dap from '../../dap/api';
-import { ILaunchContext, ILauncher, ILaunchResult, IStopMetadata, ITarget } from '../../targets/targets';
+import {
+  ILaunchContext,
+  ILauncher,
+  ILaunchResult,
+  IStopMetadata,
+  ITarget,
+} from '../../targets/targets';
 import { TelemetryReporter } from '../../telemetry/telemetryReporter';
 import { baseURL } from './browserLaunchParams';
 import { BrowserSourcePathResolver } from './browserPathResolver';

--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -4,30 +4,23 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { IDisposable, EventEmitter } from '../../common/events';
+import { CancellationToken } from 'vscode';
 import * as nls from 'vscode-nls';
 import CdpConnection from '../../cdp/connection';
-import findBrowser from './findBrowser';
-import * as launcher from './launcher';
-import { BrowserTarget, BrowserTargetManager } from './browserTargets';
-import {
-  ITarget,
-  ILauncher,
-  ILaunchResult,
-  ILaunchContext,
-  IStopMetadata,
-} from '../../targets/targets';
-import { BrowserSourcePathResolver } from './browserPathResolver';
-import { baseURL } from './browserLaunchParams';
-import { AnyChromeConfiguration, IChromeLaunchConfiguration } from '../../configuration';
+import { timeoutPromise } from '../../common/cancellation';
 import { Contributions } from '../../common/contributionUtils';
 import { EnvironmentVars } from '../../common/environmentVars';
-import { ScriptSkipper } from '../../adapter/scriptSkipper';
-import { TelemetryReporter } from '../../telemetry/telemetryReporter';
+import { EventEmitter, IDisposable } from '../../common/events';
 import { absolutePathToFileUrl } from '../../common/urlUtils';
-import { timeoutPromise } from '../../common/cancellation';
-import { CancellationToken } from 'vscode';
+import { AnyChromeConfiguration, IChromeLaunchConfiguration } from '../../configuration';
 import Dap from '../../dap/api';
+import { ILaunchContext, ILauncher, ILaunchResult, IStopMetadata, ITarget } from '../../targets/targets';
+import { TelemetryReporter } from '../../telemetry/telemetryReporter';
+import { baseURL } from './browserLaunchParams';
+import { BrowserSourcePathResolver } from './browserPathResolver';
+import { BrowserTarget, BrowserTargetManager } from './browserTargets';
+import findBrowser from './findBrowser';
+import * as launcher from './launcher';
 
 const localize = nls.loadMessageBundle();
 
@@ -205,10 +198,6 @@ export class BrowserLauncher implements ILauncher {
     this._targetManager.onTargetRemoved(() => {
       this._onTargetListChangedEmitter.fire();
     });
-
-    if (params.skipFiles) {
-      this._targetManager.setSkipFiles(new ScriptSkipper(params.skipFiles));
-    }
 
     // Note: assuming first page is our main target breaks multiple debugging sessions
     // sharing the browser instance. This can be fixed.

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -63,10 +63,6 @@ export class BrowserTargetManager implements IDisposable {
     );
   }
 
-  setSkipFiles(scriptSkipper: ScriptSkipper) {
-    this._scriptSkipper = scriptSkipper;
-  }
-
   constructor(
     connection: CdpConnection,
     private readonly process: IBrowserProcess | undefined,
@@ -419,10 +415,6 @@ export class BrowserTarget implements ITarget, IThreadDelegate {
   }
 
   defaultScriptOffset(): InlineScriptOffset | undefined {
-    return undefined;
-  }
-
-  skipFiles(): ScriptSkipper | undefined {
     return undefined;
   }
 

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -2,16 +2,15 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { ITarget } from '../targets';
+import { basename } from 'path';
+import { IThreadDelegate } from '../../adapter/threads';
 import Cdp from '../../cdp/api';
 import Connection from '../../cdp/connection';
-import { InlineScriptOffset, ISourcePathResolver } from '../../common/sourcePathResolver';
 import { EventEmitter } from '../../common/events';
+import { InlineScriptOffset, ISourcePathResolver } from '../../common/sourcePathResolver';
 import { absolutePathToFileUrl } from '../../common/urlUtils';
-import { basename } from 'path';
-import { ScriptSkipper } from '../../adapter/scriptSkipper';
-import { IThreadDelegate } from '../../adapter/threads';
 import { ITargetOrigin } from '../targetOrigin';
+import { ITarget } from '../targets';
 
 export interface INodeTargetLifecycleHooks {
   /**
@@ -37,8 +36,6 @@ export class NodeTarget implements ITarget, IThreadDelegate {
   private _waitingForDebugger: boolean;
   private _onNameChangedEmitter = new EventEmitter<void>();
   private _onDisconnectEmitter = new EventEmitter<void>();
-
-  private _scriptSkipper?: ScriptSkipper;
 
   public readonly onDisconnect = this._onDisconnectEmitter.event;
   public readonly onNameChanged = this._onNameChangedEmitter.event;
@@ -105,10 +102,6 @@ export class NodeTarget implements ITarget, IThreadDelegate {
 
   defaultScriptOffset(): InlineScriptOffset {
     return { lineOffset: 0, columnOffset: 0 };
-  }
-
-  skipFiles(): ScriptSkipper | undefined {
-    return this._scriptSkipper;
   }
 
   scriptUrlToUrl(url: string): string {

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -2,14 +2,13 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { CancellationToken } from 'vscode';
 import Cdp from '../cdp/api';
 import { IDisposable, IEvent } from '../common/events';
 import { InlineScriptOffset, ISourcePathResolver } from '../common/sourcePathResolver';
 import { AnyLaunchConfiguration } from '../configuration';
-import { ScriptSkipper } from '../adapter/scriptSkipper';
 import Dap from '../dap/api';
 import { TelemetryReporter } from '../telemetry/telemetryReporter';
-import { CancellationToken } from 'vscode';
 import { ITargetOrigin } from './targetOrigin';
 
 /**
@@ -48,7 +47,6 @@ export interface ITarget {
   scriptUrlToUrl(url: string): string;
   sourcePathResolver(): ISourcePathResolver;
   executionContextName(context: Cdp.Runtime.ExecutionContextDescription): string;
-  skipFiles(): ScriptSkipper | undefined;
 }
 
 export interface ILaunchContext {

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -7,7 +7,6 @@ import * as mkdirp from 'mkdirp';
 import * as path from 'path';
 import * as stream from 'stream';
 import { DebugAdapter } from '../adapter/debugAdapter';
-import { ScriptSkipper } from '../adapter/scriptSkipper';
 import { Binder } from '../binder';
 import Cdp from '../cdp/api';
 import CdpConnection from '../cdp/connection';
@@ -304,7 +303,6 @@ export class TestRoot {
   private _webRoot: string | undefined;
   _launchUrl: string | undefined;
   private _args: string[];
-  private _skipFiles?: ScriptSkipper;
 
   private _worker: Promise<ITestHandle>;
   private _workerCallback: (session: ITestHandle) => void;
@@ -362,8 +360,6 @@ export class TestRoot {
   }
 
   public async acquireDap(target: ITarget): Promise<DapConnection> {
-    if (this._skipFiles) target.skipFiles = () => this._skipFiles;
-
     const p = target.type() === 'page' ? new TestP(this, target) : new NodeTestHandle(this, target);
     this._targetToP.set(target, p);
     return p._session.adapterConnection;


### PR DESCRIPTION
Fixes #253

The basic idea is that I keep track of authored source skip status separately from generated scripts', and instead of sending their paths to the runtime, send the ranges in the file that is skipped.

Since we have to send this separately per scriptID to each Cdp, it got a lot easier to change ScriptSkipper from one shared instance per root session, to one instance per Target. To get the instances to share toggle statuses under the same root session, they now fire events at each other with their root target id whenever a toggle happens.

Also some other minor tweaks and fixes.