### PR TITLE
Add newline to simple text output event

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -908,7 +908,7 @@ export class Thread implements IVariableStoreDelegate {
         stackTrace,
       );
     } else {
-      output = messageText;
+      output = messageText + '\n';
       variablesReference = undefined;
     }
 


### PR DESCRIPTION
Fix #279

Need to force a newline here, because VS Code gives the DA control over whether logs should end with a newline.