### PR TITLE
fix: filter should match against `file` property

### DIFF
--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -8,7 +8,6 @@ import * as path from 'path';
 import * as http from 'http';
 import * as https from 'https';
 import { fixDriveLetterAndSlashes, isUncPath } from './pathUtils';
-import Cdp from '../cdp/api';
 import { AnyChromeConfiguration } from '../configuration';
 import { readdir } from './fsUtils';
 import { memoize } from './objUtils';
@@ -361,8 +360,8 @@ export const isLoopback = (address: string) => {
  */
 export const createTargetFilterForConfig = (
   config: AnyChromeConfiguration,
-): ((t: Cdp.Target.TargetInfo) => boolean) => {
-  const filter = config.urlFilter || config.url;
+): ((t: { url: string }) => boolean) => {
+  const filter = config.urlFilter || config.url || ('file' in config && config.file);
   if (!filter) {
     return () => true;
   }


### PR DESCRIPTION
### Problem
Users configuring `file` will not get their target filtered after launch.

### Solution
Add `file` property to filter check created for configs.

### Background
Users may provide a file instead of url, in that case the file path will be converted into a file url (`file://`) and loaded after launch.

The `'file' in config` was needed for TypeScript because `attach` configurations do not have `file` property by default.

### Bonus
Removed restrictive CDP type from filter, this will be helpful for an upcoming web view change.