### PR TITLE
feat: assign workspace folders for attaching to processes

### DIFF
--- a/src/test/node/process-tree.test.ts
+++ b/src/test/node/process-tree.test.ts
@@ -45,6 +45,13 @@ describe('process tree', () => {
     expect(data[0].command).to.match(/./); // not empty string
   });
 
+  if (process.platform !== 'win32') {
+    it('gets the working directory', async () => {
+      const currentWd = await processTree.getWorkingDirectory(process.pid);
+      expect(currentWd).to.equal(process.cwd());
+    });
+  }
+
   it('works for darwin', async () => {
     await assertParses(
       new DarwinProcessTree(),

--- a/src/ui/processTree/baseProcessTree.ts
+++ b/src/ui/processTree/baseProcessTree.ts
@@ -15,6 +15,11 @@ export abstract class BaseProcessTree implements IProcessTree {
   /**
    * @inheritdoc
    */
+  public abstract getWorkingDirectory(processId: number): Promise<string | undefined>;
+
+  /**
+   * @inheritdoc
+   */
   public lookup<T>(onEntry: (process: IProcess, accumulator: T) => T, value: T): Promise<T> {
     return new Promise((resolve, reject) => {
       const proc = this.createProcess();

--- a/src/ui/processTree/darwinProcessTree.ts
+++ b/src/ui/processTree/darwinProcessTree.ts
@@ -43,7 +43,11 @@ export class DarwinProcessTree extends BaseProcessTree {
    * @inheritdoc
    */
   protected createProcess() {
-    return this.spawn('/bin/ps', ['-xo', 'pid=PID,ppid=PPID,comm=BINARY,command=COMMAND']);
+    return this.spawn('/bin/ps', [
+      '-xo',
+      // The "aaaa" is needed otherwise the command name can get truncated.
+      `pid=PID,ppid=PPID,comm=${'a'.repeat(256)},command=COMMAND`,
+    ]);
   }
 
   /**

--- a/src/ui/processTree/darwinProcessTree.ts
+++ b/src/ui/processTree/darwinProcessTree.ts
@@ -4,8 +4,41 @@
 
 import { IProcess } from './processTree';
 import { BaseProcessTree } from './baseProcessTree';
+import { spawnAsync, ChildProcessError } from '../../common/processUtils';
+import { isAbsolute } from 'path';
+import { exists } from '../../common/fsUtils';
 
 export class DarwinProcessTree extends BaseProcessTree {
+  public async getWorkingDirectory(processId: number) {
+    try {
+      const { stdout } = await spawnAsync('lsof', [
+        // AND options
+        '-a',
+        // Get the cwd
+        '-dcwd',
+        // Filter to the cwd
+        '-Fn',
+        // For this process
+        `-p${processId}`,
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const cwd = stdout
+        .trim()
+        .split('\n')
+        .pop()!
+        .slice(1);
+
+      return cwd && isAbsolute(cwd) && (await exists(cwd)) ? cwd : undefined;
+    } catch (e) {
+      if (e instanceof ChildProcessError) {
+        return undefined;
+      }
+
+      throw e;
+    }
+  }
+
   /**
    * @inheritdoc
    */

--- a/src/ui/processTree/processTree.ts
+++ b/src/ui/processTree/processTree.ts
@@ -72,12 +72,12 @@ export function analyseArguments(args: string) {
 
   // match --inspect, --inspect=1234, --inspect-brk, --inspect-brk=1234
   let matches = DEBUG_FLAGS_PATTERN.exec(args);
-  if (matches && matches.length >= 2) {
-    if (matches.length >= 6 && matches[5]) {
-      address = matches[5];
+  if (matches && matches.length >= 1) {
+    if (matches.length >= 5 && matches[4]) {
+      address = matches[4];
     }
-    if (matches.length >= 7 && matches[6]) {
-      port = parseInt(matches[6]);
+    if (matches.length >= 6 && matches[5]) {
+      port = parseInt(matches[5]);
     }
   }
 

--- a/src/ui/processTree/processTree.ts
+++ b/src/ui/processTree/processTree.ts
@@ -43,6 +43,11 @@ export interface IProcessTree {
    * Looks up process in the tree, accumulating them into a result.
    */
   lookup<T>(onEntry: (process: IProcess, accumulator: T) => T, initial: T): Promise<T>;
+
+  /**
+   * Gets the working directory of the process, if possible.
+   */
+  getWorkingDirectory(processId: number): Promise<string | undefined>;
 }
 
 /**

--- a/src/ui/processTree/windowsProcessTree.ts
+++ b/src/ui/processTree/windowsProcessTree.ts
@@ -10,6 +10,13 @@ export class WindowsProcessTree extends BaseProcessTree {
   /**
    * @inheritdoc
    */
+  public async getWorkingDirectory() {
+    return undefined; // not supported
+  }
+
+  /**
+   * @inheritdoc
+   */
   protected createProcess() {
     const wmic = join(process.env['WINDIR'] || 'C:\\Windows', 'System32', 'wbem', 'WMIC.exe');
     return this.spawn(wmic, [


### PR DESCRIPTION
Previously if you attached to a process in a multi-root workspace, we'd
fail because we needed a working directory. This adds functionality
(which only works on *nix, unfortunately) that automatically tries to
assign the workspace folder from the working directory of the process.

Also cleans up handling of process IDs a little bit; these can be made
simpler now that we no longer need to support
the legacy debugger protocol.