### PR TITLE
fix: removed redundant useWebView: 'advanced' configuration

### DIFF
--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -574,8 +574,7 @@ const chromeBaseConfigurationAttributes: ConfigurationAttributes<IChromeBaseConf
     default: 'http://localhost:8080',
   },
   useWebView: {
-    type: ['boolean', 'string'],
-    enum: [true, false, 'advanced'],
+    type: 'boolean',
     description: refString('edge.useWebView.description'),
     default: false,
   },

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -28,7 +28,7 @@ const strings = {
   'extensionHost.snippet.launch.label': 'VS Code Extension Development',
 
   'edge.useWebView.description':
-    "(Edge (Chromium) only) When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content. When set to 'advanced', the debugger will wait to connect to a WebView matching the urlFilter.",
+    "(Edge (Chromium) only) When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content.",
 
   'chrome.address.description': 'TCP/IP address of debug port',
   'chrome.baseUrl.description':

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -337,7 +337,7 @@ export interface IChromeBaseConfiguration extends IBaseConfiguration {
   /**
    * (Edge only) Enable web view debugging.
    */
-  useWebView: boolean | 'advanced';
+  useWebView: boolean;
 }
 
 /**


### PR DESCRIPTION
This update reflects that the code paths of `useWebView: 'true'` and `useWebView: 'advanced'`  have merged in #285 and now both support the `urlFilter` property and honor the `timeout` property.