### PR TITLE
fix: Move common js entrypoints to a single spot in the gulpfile.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -166,6 +166,14 @@ gulp.task('compile:static', () =>
 gulp.task('compile', gulp.series('compile:ts', 'compile:static', 'compile:dynamic'));
 
 async function runWebpack(packages) {
+
+  // add the entrypoints common to both vscode and vs here
+  packages.push(...[
+    { entry: `${buildSrcDir}/common/hash/hash.js`, library: false },
+    { entry: `${buildSrcDir}/${nodeTargetsDir}/bootloader.js`, library: false },
+    { entry: `${buildSrcDir}/${nodeTargetsDir}/watchdog.js`, library: false },
+  ]);
+
   for (const { entry, library } of packages) {
     const config = {
       mode: 'production',
@@ -209,23 +217,16 @@ async function runWebpack(packages) {
 /** Run webpack to bundle the extension output files */
 gulp.task('package:webpack-bundle', async () => {
   const packages = [
-    { entry: `${buildSrcDir}/extension.js`, library: true },
-    { entry: `${buildSrcDir}/common/hash/hash.js`, library: false },
-    { entry: `${buildSrcDir}/${nodeTargetsDir}/bootloader.js`, library: false },
-    { entry: `${buildSrcDir}/${nodeTargetsDir}/watchdog.js`, library: false },
+    { entry: `${buildSrcDir}/extension.js`, library: true }
   ];
-
   return runWebpack(packages);
 });
 
 /** Run webpack to bundle into the flat session launcher (for VS or standalone debug server)  */
 gulp.task('flatSessionBundle:webpack-bundle', async () => {
   const packages = [
-    { entry: `${buildSrcDir}/flatSessionLauncher.js`, library: true },
-    { entry: `${buildSrcDir}/${nodeTargetsDir}/bootloader.js`, library: false },
-    { entry: `${buildSrcDir}/${nodeTargetsDir}/watchdog.js`, library: false },
+    { entry: `${buildSrcDir}/flatSessionLauncher.js`, library: true }
   ];
-
   return runWebpack(packages);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -168,11 +168,11 @@ gulp.task('compile', gulp.series('compile:ts', 'compile:static', 'compile:dynami
 async function runWebpack(packages) {
 
   // add the entrypoints common to both vscode and vs here
-  packages.push(...[
+  packages = [...packages,
     { entry: `${buildSrcDir}/common/hash/hash.js`, library: false },
     { entry: `${buildSrcDir}/${nodeTargetsDir}/bootloader.js`, library: false },
     { entry: `${buildSrcDir}/${nodeTargetsDir}/watchdog.js`, library: false },
-  ]);
+  ];
 
   for (const { entry, library } of packages) {
     const config = {


### PR DESCRIPTION
VS was broken because it wasn't including hash.js in the bundled build. Side node, it might be nice to have some fail-fast way of knowing that the hashing subprocess is broken, as it's hard to diagnose at the moment (no error messages, things like stackTrace requests just start hanging because the absoluteFilePath promise never returns).