### PR TITLE
fix: spaces in paths breaking electron apps

### DIFF
--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -286,6 +286,10 @@ export function urlToRegex(aPath: string) {
     aPath = aPath.replace(/[a-z]/gi, letter => `[${letter.toLowerCase()}${letter.toUpperCase()}]`);
   }
 
+  // In some environments, Chrome(/Electron) doesn't escape spaces in paths.
+  // This was observed in the "Launch VS Code" configuration.
+  aPath = aPath.replace(/ |%20/g, '( |%20)');
+
   return aPath;
 }
 

--- a/src/test/common/urlUtils.test.ts
+++ b/src/test/common/urlUtils.test.ts
@@ -93,7 +93,7 @@ describe('urlUtils', () => {
 
     it('space in path', () => {
       expect(urlToRegex('file:///a/space%20path.js')).to.equal(
-        'file:\\/\\/\\/a\\/space%20path\\.js|\\/a\\/space path\\.js',
+        'file:\\/\\/\\/a\\/space( |%20)path\\.js|\\/a\\/space( |%20)path\\.js',
       );
     });
   });
@@ -122,7 +122,7 @@ describe('urlUtils', () => {
 
     it('space in path', () => {
       expect(urlToRegex('file:///a/space%20path.js')).to.equal(
-        '[fF][iI][lL][eE]:\\/\\/\\/[aA]\\/[sS][pP][aA][cC][eE]%20[pP][aA][tT][hH]\\.[jJ][sS]|\\/[aA]\\/[sS][pP][aA][cC][eE] [pP][aA][tT][hH]\\.[jJ][sS]',
+        '[fF][iI][lL][eE]:\\/\\/\\/[aA]\\/[sS][pP][aA][cC][eE]( |%20)[pP][aA][tT][hH]\\.[jJ][sS]|\\/[aA]\\/[sS][pP][aA][cC][eE]( |%20)[pP][aA][tT][hH]\\.[jJ][sS]',
       );
     });
   });


### PR DESCRIPTION
One more super annoying thing. _Apparently_ the debugger in electron doesn't url encode spaces in paths. This was causing the setup on my windows VM to never hit breakpoints, since it was looking for a path with %20 in it.

![image](https://user-images.githubusercontent.com/2230985/73773844-c1e4eb80-4737-11ea-85f4-fd59fc2631f2.png)

It looks like the old debugger didn't escape spaces at all. Maybe we should unescape everything/apply this same treatment to all characters. I don't want to modify URLs throughout the adapter to be unescaped, but this function could handle that for the purposes of matcing. Thoughts @roblourens?
