### PR TITLE
fix: weirdness around invalid hit count breakpoints

### DIFF
--- a/src/adapter/breakpoints/hitCondition.ts
+++ b/src/adapter/breakpoints/hitCondition.ts
@@ -20,7 +20,7 @@ const hitConditionRe = /^(>|>=|={1,3}|<|<=|%)?\s*([0-9]+)$/;
 export class HitCondition {
   private hits = 0;
 
-  protected constructor(private readonly predicate: (n: number) => boolean) {}
+  constructor(private readonly predicate: (n: number) => boolean) {}
 
   /**
    * Indicates that the breakpoint was hit, and returns whether the debugger

--- a/src/adapter/breakpoints/neverResolvedBreakpoint.ts
+++ b/src/adapter/breakpoints/neverResolvedBreakpoint.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { BreakpointManager } from '../breakpoints';
+import { UserDefinedBreakpoint } from './userDefinedBreakpoint';
+import { HitCondition } from './hitCondition';
+import Dap from '../../dap/api';
+
+/**
+ * A breakpoint that's never resolved or hit. This is used to place an invalid
+ * condition or hit count breakpoint; DAP does not have a representation for
+ * a single breakpoint failing to set, so on a failure we show an error as
+ * standard out and place one of these virtual breakpoints.
+ *
+ * In CDP they do end up being 'real' breakpoints so the aren't the most
+ * efficient construct, but they do the job without additional work or special
+ * casing.
+ */
+export class NeverResolvedBreakpoint extends UserDefinedBreakpoint {
+  constructor(
+    manager: BreakpointManager,
+    dapId: number,
+    source: Dap.Source,
+    dapParams: Dap.SourceBreakpoint,
+  ) {
+    super(manager, dapId, source, dapParams, new HitCondition(() => false));
+  }
+
+  /**
+   * @override
+   */
+  protected getResolvedUiLocation() {
+    return undefined;
+  }
+}

--- a/src/adapter/breakpoints/userDefinedBreakpoint.ts
+++ b/src/adapter/breakpoints/userDefinedBreakpoint.ts
@@ -149,7 +149,7 @@ export class UserDefinedBreakpoint extends Breakpoint {
   /**
    * Gets the location whether this breakpoint is resolved, if any.
    */
-  private getResolvedUiLocation() {
+  protected getResolvedUiLocation() {
     for (const bp of this.cdpBreakpoints) {
       if (bp.state === CdpReferenceState.Applied && bp.uiLocations.length) {
         return bp.uiLocations[0];

--- a/src/test/breakpoints/breakpoints-hit-count-can-change-breakpoint-after-being-set.txt
+++ b/src/test/breakpoints/breakpoints-hit-count-can-change-breakpoint-after-being-set.txt
@@ -1,0 +1,32 @@
+{
+    breakpoints : [
+        [0] : {
+            column : 13
+            id : <number>
+            line : 4
+            source : {
+                name : VM<xx>
+                path : <eval>/VM<xx>
+                sourceReference : <number>
+            }
+            verified : true
+        }
+    ]
+}
+{
+    breakpoints : [
+        [0] : {
+            column : 13
+            id : <number>
+            line : 4
+            source : {
+                name : VM<xx>
+                path : <eval>/VM<xx>
+                sourceReference : <number>
+            }
+            verified : true
+        }
+    ]
+}
+Evaluating#1: foo();
+result: 7

--- a/src/test/breakpoints/breakpoints-hit-count-does-not-validate-or-hit-invalid-breakpoint.txt
+++ b/src/test/breakpoints/breakpoints-hit-count-does-not-validate-or-hit-invalid-breakpoint.txt
@@ -1,0 +1,14 @@
+{
+    breakpoints : [
+        [0] : {
+            id : <number>
+            message : Unbound breakpoint
+            verified : false
+        }
+    ]
+}
+{
+    category : stderr
+    output : Invalid hit condition "potato". Expected an expression like "> 42" or "== 2".
+}
+Evaluating#1: foo();

--- a/src/test/breakpoints/breakpoints-hit-count-works-for-valid.txt
+++ b/src/test/breakpoints/breakpoints-hit-count-works-for-valid.txt
@@ -1,0 +1,17 @@
+{
+    breakpoints : [
+        [0] : {
+            column : 13
+            id : <number>
+            line : 4
+            source : {
+                name : VM<xx>
+                path : <eval>/VM<xx>
+                sourceReference : <number>
+            }
+            verified : true
+        }
+    ]
+}
+Evaluating#1: foo();
+result: 4


### PR DESCRIPTION
See: https://github.com/microsoft/vscode-js-debug/issues/300#issuecomment-582654597

This simply uses a new subtype "never resolved breakpoint" which has
an always-false hit condition and overrides the resolved location to
always return undefined. We use that to keep the invalid hit count
breakpoints around. Perhaps not the most efficient way since the
breakpoint still exists in the debugee, but definitely the simplest way
that doesn't involve a ton of refactoring and special casing.

Also, noticed I never wrote unit test for hit count breakpoints, so I
added some of those.