### PR TITLE
Add support for custom inspect uri format for Blazor

### DIFF
--- a/src/cdp/transport.ts
+++ b/src/cdp/transport.ts
@@ -29,6 +29,7 @@ export class PipeTransport implements ITransport {
   constructor(pipeWrite: NodeJS.WritableStream, pipeRead: NodeJS.ReadableStream);
 
   constructor(pipeWrite: net.Socket | NodeJS.WritableStream, pipeRead?: NodeJS.ReadableStream) {
+    logger.info(LogTag.Internal, `Using pipe as transport layer`);
     this._pipeWrite = pipeWrite as NodeJS.WritableStream;
     if (!pipeRead) this._socket = pipeWrite as net.Socket;
 
@@ -106,6 +107,7 @@ export class WebSocketTransport implements ITransport {
   onend?: () => void;
 
   static create(url: string, cancellationToken: CancellationToken): Promise<WebSocketTransport> {
+    logger.info(LogTag.Internal, `Using websocket as transport layer`, url);
     const ws = new WebSocket(url, [], {
       perMessageDeflate: false,
       maxPayload: 256 * 1024 * 1024, // 256Mb

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -423,6 +423,19 @@ export interface IChromeLaunchConfiguration extends IChromeBaseConfiguration {
    * The debug adapter is running elevated. Launch Chrome unelevated to avoid the security restrictions of running Chrome elevated
    */
   launchUnelevated?: boolean;
+
+  /**
+   * WebSocket (`ws://`) address of the inspector. It's a template string that
+   * interpolates keys in `{curlyBraces}`. Available keys are:
+   *
+   *  - `url.*` is the parsed address of the running application. For instance,
+   *    `{url.port}`, `{url.hostname}`
+   *  - `port` is the debug port that Chrome is listening on.
+   *  - `browserInspectUri` is the inspector URI on the launched browser
+   *  - `wsProtocol` is the hinted websocket protocol. This is set to `wss` if
+   *    the original URL is `https`, or `ws` otherwise.
+   */
+  inspectUri?: string;
 }
 
 /**

--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -79,6 +79,7 @@ export class BrowserLauncher implements ILauncher {
       cwd,
       port,
       url,
+      inspectUri,
       webRoot,
       launchUnelevated: launchUnelevated,
     }: IChromeLaunchConfiguration,
@@ -145,8 +146,10 @@ export class BrowserLauncher implements ILauncher {
         env: EnvironmentVars.merge(process.env, { ELECTRON_RUN_AS_NODE: null }, env),
         args: runtimeArgs || [],
         userDataDir: resolvedDataDir,
-        connection: port || 'pipe',
+        connection: port || (inspectUri ? 0 : 'pipe'), // We don't default to pipe if we are using an inspectUri
         launchUnelevated: launchUnelevated,
+        url,
+        inspectUri,
         promisedPort,
       },
     );

--- a/src/targets/browser/constructInspectorWSUri.ts
+++ b/src/targets/browser/constructInspectorWSUri.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { URL } from 'url';
+
+/**
+ * Returns WebSocket (`ws(s)://`) address of the inspector to use. This function interpolates the inspect uri from the browser inspect uri and other values. Available keys are:
+ *
+ *  - `url.*` is the parsed address of the running application. For instance,
+ *    `{url.port}`, `{url.hostname}`
+ *  - `port` is the debug port that Chrome is listening on.
+ *  - `browserInspectUri` is the inspector URI on the launched browser
+ *  - `wsProtocol` is the hinted websocket protocol. This is set to `wss` if the original URL is `https`, or `ws` otherwise.
+ */
+export function constructInspectorWSUri(
+  inspectUriFormat: string,
+  urlText: string | null | undefined,
+  browserInspectUri: string,
+): string {
+  const url = new URL(urlText || '');
+  const replacements: { [key: string]: string } = {
+    'url.hostname': url.hostname,
+    'url.port': url.port,
+    browserInspectUri: browserInspectUri,
+    wsProtocol: url.protocol === 'https' ? 'wss' : 'ws',
+  };
+
+  const inspectUri = inspectUriFormat.replace(/{([^\}]+)}/g, (match, key: string) =>
+    replacements.hasOwnProperty(key) ? replacements[key] : match,
+  );
+
+  return inspectUri;
+}


### PR DESCRIPTION
Add support for custom inspect uri format for Blazor

See https://github.com/microsoft/vscode-js-debug/issues/302 for more details

Added some extra logging that I used while debugging this feature

cc @connor4312 @SteveSandersonMS @roblourens