### PR TITLE
Delay the thread started event until we get the 'initialized' request from vscode

### DIFF
--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -120,6 +120,7 @@ export class DebugAdapter {
     console.assert(params.columnsStartAt1);
     const capabilities = DebugAdapter.capabilities();
     setTimeout(() => this.dap.initialized({}), 0);
+    setTimeout(() => this._thread?.dapInitialized(), 0);
     return capabilities;
   }
 

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -4,7 +4,7 @@
 
 import * as nls from 'vscode-nls';
 import Cdp from '../cdp/api';
-import { delay, getDeferred } from '../common/promiseUtil';
+import { delay, getDeferred, IDeferred } from '../common/promiseUtil';
 import * as sourceUtils from '../common/sourceUtils';
 import * as urlUtils from '../common/urlUtils';
 import { AnyLaunchConfiguration, OutputSource } from '../configuration';
@@ -85,10 +85,27 @@ export type RawLocation = {
   scriptId?: Cdp.Runtime.ScriptId;
 };
 
+class DeferredContainer<T> {
+  private _dapDeferred: IDeferred<T> = getDeferred();
+
+  constructor(private readonly _obj: T) {}
+
+  resolve(): void {
+    this._dapDeferred.resolve(this._obj);
+  }
+
+  with<Return>(callback: (obj: T) => Return): Return | Promise<Return> {
+    if (this._dapDeferred.hasSettled()) {
+      return callback(this._obj);
+    } else {
+      return this._dapDeferred.promise.then(obj => callback(obj));
+    }
+  }
+}
+
 export class Thread implements IVariableStoreDelegate {
   private static _lastThreadId = 0;
   public readonly id: number;
-  private _dap: Dap.Api;
   private _cdp: Cdp.Api;
   private _name: string;
   private _pausedDetails?: IPausedDetails;
@@ -114,6 +131,8 @@ export class Thread implements IVariableStoreDelegate {
   private readonly _sourceScripts = new WeakMap<Source, Set<Script>>();
   private readonly _pausedDetailsEvent = new WeakMap<IPausedDetails, Cdp.Debugger.PausedEvent>();
 
+  private _dap: DeferredContainer<Dap.Api>;
+
   constructor(
     sourceContainer: SourceContainer,
     threadName: string,
@@ -123,15 +142,16 @@ export class Thread implements IVariableStoreDelegate {
     private readonly launchConfig: AnyLaunchConfiguration,
     private readonly _breakpointManager: BreakpointManager,
   ) {
+    this._dap = new DeferredContainer(dap);
     this._delegate = delegate;
     this._sourceContainer = sourceContainer;
     this._cdp = cdp;
-    this._dap = dap;
     this._name = threadName;
     this.id = Thread._lastThreadId++;
     this.replVariables = new VariableStore(this._cdp, this);
     this._serializedOutput = Promise.resolve();
     this._smartStepper = new SmartStepper(this.launchConfig);
+    this._initialize();
   }
 
   cdp(): Cdp.Api {
@@ -402,7 +422,7 @@ export class Thread implements IVariableStoreDelegate {
     }
   }
 
-  dapInitialized() {
+  _initialize() {
     this._cdp.Runtime.on('executionContextCreated', event => {
       this._executionContextCreated(event.context);
     });
@@ -441,10 +461,16 @@ export class Thread implements IVariableStoreDelegate {
     this._delegate.initialize();
     this._pauseOnScheduledAsyncCall();
 
-    this._dap.thread({
-      reason: 'started',
-      threadId: this.id,
-    });
+    this._dap.with(dap =>
+      dap.thread({
+        reason: 'started',
+        threadId: this.id,
+      }),
+    );
+  }
+
+  dapInitialized() {
+    this._dap.resolve();
   }
 
   async refreshStackTrace() {
@@ -484,7 +510,7 @@ export class Thread implements IVariableStoreDelegate {
         const isClearConsole = payload.output === '\x1b[2J';
         const noop = isClearConsole && !this._consoleIsDirty;
         if (!noop) {
-          this._dap.output(payload);
+          this._dap.with(dap => dap.output(payload));
           this._consoleIsDirty = !isClearConsole;
         }
       }
@@ -612,10 +638,12 @@ export class Thread implements IVariableStoreDelegate {
     this._executionContextsCleared();
 
     // Send 'exited' after all other thread-releated events
-    this._dap.thread({
-      reason: 'exited',
-      threadId: this.id,
-    });
+    this._dap.with(dap =>
+      dap.thread({
+        reason: 'exited',
+        threadId: this.id,
+      }),
+    );
   }
 
   rawLocation(
@@ -1019,7 +1047,9 @@ export class Thread implements IVariableStoreDelegate {
           ? event.sourceMapURL
           : event.url && urlUtils.completeUrl(event.url, event.sourceMapURL);
         if (!resolvedSourceMapUrl) {
-          errors.reportToConsole(this._dap, `Could not load source map from ${event.sourceMapURL}`);
+          this._dap.with(dap =>
+            errors.reportToConsole(dap, `Could not load source map from ${event.sourceMapURL}`),
+          );
         }
       }
 
@@ -1145,7 +1175,9 @@ export class Thread implements IVariableStoreDelegate {
 
   async _copyObjectToClipboard(object: Cdp.Runtime.RemoteObject) {
     if (!object.objectId) {
-      this._dap.copyRequested({ text: objectPreview.previewRemoteObject(object, 'copy') });
+      this._dap.with(dap =>
+        dap.copyRequested({ text: objectPreview.previewRemoteObject(object, 'copy') }),
+      );
       return;
     }
 
@@ -1158,7 +1190,7 @@ export class Thread implements IVariableStoreDelegate {
         returnByValue: true,
       });
 
-      this._dap.copyRequested({ text: result.value });
+      this._dap.with(dap => dap.copyRequested({ text: result.value }));
     } catch (e) {
       // ignored
     } finally {
@@ -1222,20 +1254,24 @@ export class Thread implements IVariableStoreDelegate {
       ]);
     }
 
-    this._dap.stopped({
-      reason: details.reason,
-      description: details.description,
-      threadId: this.id,
-      text: details.text,
-      allThreadsStopped: false,
-    });
+    this._dap.with(dap =>
+      dap.stopped({
+        reason: details.reason,
+        description: details.description,
+        threadId: this.id,
+        text: details.text,
+        allThreadsStopped: false,
+      }),
+    );
   }
 
   _onThreadResumed() {
-    this._dap.continued({
-      threadId: this.id,
-      allThreadsContinued: false,
-    });
+    this._dap.with(dap =>
+      dap.continued({
+        threadId: this.id,
+        allThreadsContinued: false,
+      }),
+    );
   }
 
   async setScriptSourceMapHandler(

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -422,7 +422,7 @@ export class Thread implements IVariableStoreDelegate {
     }
   }
 
-  _initialize() {
+  private _initialize() {
     this._cdp.Runtime.on('executionContextCreated', event => {
       this._executionContextCreated(event.context);
     });

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -441,7 +441,9 @@ export class Thread implements IVariableStoreDelegate {
     this._ensureDebuggerEnabledAndRefreshDebuggerId();
     this._delegate.initialize();
     this._pauseOnScheduledAsyncCall();
+  }
 
+  dapInitialized() {
     this._dap.thread({
       reason: 'started',
       threadId: this.id,

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -132,7 +132,6 @@ export class Thread implements IVariableStoreDelegate {
     this.replVariables = new VariableStore(this._cdp, this);
     this._serializedOutput = Promise.resolve();
     this._smartStepper = new SmartStepper(this.launchConfig);
-    this._initialize();
   }
 
   cdp(): Cdp.Api {
@@ -403,7 +402,7 @@ export class Thread implements IVariableStoreDelegate {
     }
   }
 
-  private _initialize() {
+  dapInitialized() {
     this._cdp.Runtime.on('executionContextCreated', event => {
       this._executionContextCreated(event.context);
     });
@@ -441,9 +440,7 @@ export class Thread implements IVariableStoreDelegate {
     this._ensureDebuggerEnabledAndRefreshDebuggerId();
     this._delegate.initialize();
     this._pauseOnScheduledAsyncCall();
-  }
 
-  dapInitialized() {
     this._dap.thread({
       reason: 'started',
       threadId: this.id,

--- a/src/telemetry/telemetryReporter.ts
+++ b/src/telemetry/telemetryReporter.ts
@@ -43,6 +43,10 @@ export class TelemetryReporter implements IDisposable {
    */
   public readonly onFlush = this.flushEmitter.event;
 
+  private enabled(): boolean {
+    return !process.env['DA_TEST_DISABLE_TELEMETRY'];
+  }
+
   /**
    * Reports a telemetry event.
    */
@@ -105,6 +109,10 @@ export class TelemetryReporter implements IDisposable {
   }
 
   private pushOutput(event: Dap.OutputEventParams) {
+    if (!this.enabled()) {
+      return;
+    }
+
     event.data = mapOutput(event.data) as object;
     if (this.target instanceof Array) {
       this.target.push(event);


### PR DESCRIPTION
@connor4312 you are more familiar with the startup than I am, but basically the `acquireDap` call is resolved as soon as the client tries to attach, then there is no guarantee that we will wait for 'initialize' before the Thread sends its started event. This is an easy fix to delay that until 'initialize' happens, but you might have a better idea?

Fix #281