### PR TITLE
fix: TypeError serializing BigInt

### DIFF
--- a/src/common/logging/fileLogSink.ts
+++ b/src/common/logging/fileLogSink.ts
@@ -16,6 +16,10 @@ const replacer = (_key: string, value: unknown): unknown => {
     };
   }
 
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
   return value;
 };
 


### PR DESCRIPTION
When using the flatSessionConnection with verbose logging enabled
an error would occur when Message.__receivedTime, which is a bigint,
was logged.

```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at FileLogSink.write (fileLogSink.js:52:36)
    at Logger.log (logger.js:139:18)
    at logger.js:185:48
    at Array.forEach (<anonymous>)
    at Logger.setup (logger.js:185:30)
    at processTicksAndRejections (internaltask_queues.js:94:5
```

Example message:

```
{
  tag: 'dap.receive',
  timestamp: 1581435305862,
  message: undefined,
  metadata: {
    connectionId: 0,
    message: {
      type: 'request',
      command: 'initialize',
      arguments: [Object],
      seq: 1,
      __receivedTime: 23614425135986n
    }
  },
  level: 0
}
```