### PR TITLE
fix: keep <node_internals> and path data in module names

### DIFF
--- a/src/adapter/breakpointPredictor.ts
+++ b/src/adapter/breakpointPredictor.ts
@@ -103,6 +103,10 @@ export class BreakpointsPredictor implements IBreakpointsPredictor {
       return new Map();
     }
 
+    if (!this.rootPath) {
+      return new Map();
+    }
+
     const sourcePathToCompiled: MetadataMap = new MapUsingProjection(
       urlUtils.lowerCaseInsensitivePath,
     );

--- a/src/common/pathUtils.ts
+++ b/src/common/pathUtils.ts
@@ -187,6 +187,14 @@ export const splitWithDriveLetter = (inputPath: string) => {
 };
 
 /**
+ * Gets whether the child is a subdirectory of its parent.
+ */
+export const isSubdirectoryOf = (parent: string, child: string) => {
+  const rel = path.relative(parent, child);
+  return !path.isAbsolute(rel) && !rel.startsWith('..');
+};
+
+/**
  * Returns whether the path looks like a UNC path.
  */
 export const isUncPath = (path: string) => path.startsWith('\\\\');

--- a/src/targets/node/nodeSourcePathResolver.ts
+++ b/src/targets/node/nodeSourcePathResolver.ts
@@ -29,6 +29,10 @@ export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
       return this.rebaseRemoteToLocal(absolutePath);
     }
 
+    if (!path.isAbsolute(url)) {
+      return `<node_internals>/${url}`;
+    }
+
     if (!this.options.basePath) {
       return '';
     }

--- a/src/test/breakpoints/breakpoints-hit-count-can-change-after-set.txt
+++ b/src/test/breakpoints/breakpoints-hit-count-can-change-after-set.txt
@@ -5,7 +5,7 @@
             id : <number>
             line : 4
             source : {
-                name : VM<xx>
+                name : <eval>/VM<xx>
                 path : <eval>/VM<xx>
                 sourceReference : <number>
             }
@@ -20,7 +20,7 @@
             id : <number>
             line : 4
             source : {
-                name : VM<xx>
+                name : <eval>/VM<xx>
                 path : <eval>/VM<xx>
                 sourceReference : <number>
             }

--- a/src/test/breakpoints/breakpoints-hit-count-can-change-breakpoint-after-being-set.txt
+++ b/src/test/breakpoints/breakpoints-hit-count-can-change-breakpoint-after-being-set.txt
@@ -5,7 +5,7 @@
             id : <number>
             line : 4
             source : {
-                name : VM<xx>
+                name : <eval>/VM<xx>
                 path : <eval>/VM<xx>
                 sourceReference : <number>
             }
@@ -20,7 +20,7 @@
             id : <number>
             line : 4
             source : {
-                name : VM<xx>
+                name : <eval>/VM<xx>
                 path : <eval>/VM<xx>
                 sourceReference : <number>
             }

--- a/src/test/breakpoints/breakpoints-hit-count-works-for-valid.txt
+++ b/src/test/breakpoints/breakpoints-hit-count-works-for-valid.txt
@@ -5,7 +5,7 @@
             id : <number>
             line : 4
             source : {
-                name : VM<xx>
+                name : <eval>/VM<xx>
                 path : <eval>/VM<xx>
                 sourceReference : <number>
             }

--- a/src/test/breakpoints/breakpoints-launched-source-map-set-compiled-2.txt
+++ b/src/test/breakpoints/breakpoints-launched-source-map-set-compiled-2.txt
@@ -3,7 +3,7 @@ Breakpoint resolved: {
     id : <number>
     line : 36
     source : {
-        name : bundle.js
+        name : localhost꞉8001/browserify/bundle.js
         path : ${workspaceFolder}/web/browserify/bundle.js
         sourceReference : <number>
     }

--- a/src/test/breakpoints/breakpoints-launched-source-map-set-compiled.txt
+++ b/src/test/breakpoints/breakpoints-launched-source-map-set-compiled.txt
@@ -3,7 +3,7 @@ Breakpoint resolved: {
     id : <number>
     line : 36
     source : {
-        name : bundle.js
+        name : localhost꞉8001/browserify/bundle.js
         path : ${workspaceFolder}/web/browserify/bundle.js
         sourceReference : <number>
     }

--- a/src/test/goldenText.ts
+++ b/src/test/goldenText.ts
@@ -12,6 +12,12 @@ import { forceForwardSlashes } from '../common/pathUtils';
 
 const kStabilizeNames = ['id', 'threadId', 'sourceReference', 'variablesReference'];
 
+const trimLineWhitespace = (str: string) =>
+  str
+    .split('\n')
+    .map(l => l.trimRight())
+    .join('\n');
+
 export class GoldenText {
   _results: string[];
   _testName: string;
@@ -54,7 +60,7 @@ export class GoldenText {
   }
 
   getOutput(): string {
-    return this._results.join('\n') + '\n';
+    return trimLineWhitespace(this._results.join('\n') + '\n');
   }
 
   /**
@@ -77,7 +83,7 @@ export class GoldenText {
     } else if (process.env.RESET_RESULTS) {
       fs.writeFileSync(goldenFilePath, output, { encoding: 'utf-8' });
     } else {
-      const expectations = fs.readFileSync(goldenFilePath).toString('utf-8');
+      const expectations = trimLineWhitespace(fs.readFileSync(goldenFilePath).toString('utf-8'));
 
       try {
         if (options.substring) {

--- a/src/test/node/node-source-path-resolver.test.ts
+++ b/src/test/node/node-source-path-resolver.test.ts
@@ -55,12 +55,25 @@ describe('node source path resolver', () => {
       );
     });
 
+    it('places relative paths in node_internals', async () => {
+      const r = new NodeSourcePathResolver(defaultOptions, await Logger.test());
+
+      expect(
+        await r.urlToAbsolutePath({
+          url: 'internal.js',
+        }),
+      ).to.equal('<node_internals>/internal.js');
+    });
+
     it('applies source map overrides', async () => {
       const r = new NodeSourcePathResolver(defaultOptions, await Logger.test());
 
-      expect(await r.urlToAbsolutePath({ url: 'webpack:///hello.js' })).to.equal(
-        join(__dirname, 'hello.js'),
-      );
+      expect(
+        await r.urlToAbsolutePath({
+          url: 'webpack:///hello.js',
+          map: { sourceRoot: '', metadata: { compiledPath: 'hello.js' } } as any,
+        }),
+      ).to.equal(join(__dirname, 'hello.js'));
     });
 
     describe('source map filtering', () => {

--- a/src/test/sources/sources-allows-module-wrapper-in-node-code.txt
+++ b/src/test/sources/sources-allows-module-wrapper-in-node-code.txt
@@ -1,7 +1,7 @@
 {
     reason : new
     source : {
-        name : index.js
+        name : moduleWrapper/index.js
         path : ${workspaceFolder}/moduleWrapper/index.js
         sourceReference : 0
     }

--- a/src/test/sources/sources-basic-source-map.txt
+++ b/src/test/sources/sources-basic-source-map.txt
@@ -1,9 +1,9 @@
 
-Source event for 
+Source event for
 {
     reason : new
     source : {
-        name : index.ts
+        name : web/browserify/index.ts
         path : ${workspaceFolder}/web/browserify/index.ts
         sourceReference : <number>
     }
@@ -23,11 +23,11 @@ window['logSome'] = function logSome() {
 
 ---------
 
-Source event for 
+Source event for
 {
     reason : new
     source : {
-        name : module1.ts
+        name : web/browserify/module1.ts
         path : ${workspaceFolder}/web/browserify/module1.ts
         sourceReference : <number>
     }
@@ -47,11 +47,11 @@ export function throwValue(v) {
 
 ---------
 
-Source event for 
+Source event for
 {
     reason : new
     source : {
-        name : module2.ts
+        name : web/browserify/module2.ts
         path : ${workspaceFolder}/web/browserify/module2.ts
         sourceReference : <number>
     }

--- a/src/test/sources/sources-basic-sources.txt
+++ b/src/test/sources/sources-basic-sources.txt
@@ -3,7 +3,7 @@ Source event for inline
 {
     reason : new
     source : {
-        name : inlinescript.html꞉2:11
+        name : localhost꞉8001/inlinescript.html꞉2:11
         path : ${workspaceFolder}/web/inlinescript.html
         sourceReference : <number>
     }
@@ -12,14 +12,14 @@ text/javascript
 ---------
 
     console.log('inline script');
-  
+
 ---------
 
 Source event for empty.js
 {
     reason : new
     source : {
-        name : empty.js
+        name : localhost꞉8001/empty.js
         path : ${workspaceFolder}/web/empty.js
         sourceReference : <number>
     }
@@ -35,7 +35,7 @@ Source event for does not exist
 {
     reason : new
     source : {
-        name : doesnotexist.js
+        name : localhost꞉8001/doesnotexist.js
         path : localhost꞉8001/doesnotexist.js
         sourceReference : <number>
     }
@@ -50,7 +50,7 @@ Source event for dir/helloworld
 {
     reason : new
     source : {
-        name : helloworld.js
+        name : localhost꞉8001/dir/helloworld.js
         path : ${workspaceFolder}/web/dir/helloworld.js
         sourceReference : <number>
     }
@@ -66,7 +66,7 @@ Source event for eval
 {
     reason : new
     source : {
-        name : VM<xx>
+        name : <eval>/VM<xx>
         path : <eval>/VM<xx>
         sourceReference : <number>
     }
@@ -80,37 +80,37 @@ text/javascript
 Loaded sources: {
     sources : [
         [0] : {
-            name : inlinescript.html꞉2:11
+            name : localhost꞉8001/inlinescript.html꞉2:11
             path : ${workspaceFolder}/web/inlinescript.html
             sourceReference : <number>
         }
         [1] : {
-            name : VM<xx>
+            name : <eval>/VM<xx>
             path : <eval>/VM<xx>
             sourceReference : <number>
         }
         [2] : {
-            name : empty.js
+            name : localhost꞉8001/empty.js
             path : ${workspaceFolder}/web/empty.js
             sourceReference : <number>
         }
         [3] : {
-            name : doesnotexist.js
+            name : localhost꞉8001/doesnotexist.js
             path : localhost꞉8001/doesnotexist.js
             sourceReference : <number>
         }
         [4] : {
-            name : VM<xx>
+            name : <eval>/VM<xx>
             path : <eval>/VM<xx>
             sourceReference : <number>
         }
         [5] : {
-            name : helloworld.js
+            name : localhost꞉8001/dir/helloworld.js
             path : ${workspaceFolder}/web/dir/helloworld.js
             sourceReference : <number>
         }
         [6] : {
-            name : VM<xx>
+            name : <eval>/VM<xx>
             path : <eval>/VM<xx>
             sourceReference : <number>
         }

--- a/src/test/sources/sources-updated-content.txt
+++ b/src/test/sources/sources-updated-content.txt
@@ -3,7 +3,7 @@ Source event for test.js
 {
     reason : new
     source : {
-        name : test.js
+        name : localhost꞉8001/test.js
         path : localhost꞉8001/test.js
         sourceReference : <number>
     }
@@ -17,7 +17,7 @@ Source event for test.js updated
 {
     reason : new
     source : {
-        name : test.js
+        name : localhost꞉8001/test.js
         path : localhost꞉8001/test.js
         sourceReference : <number>
     }
@@ -30,12 +30,12 @@ content2//# sourceURL=test.js
 Loaded sources: {
     sources : [
         [0] : {
-            name : test.js
+            name : localhost꞉8001/test.js
             path : localhost꞉8001/test.js
             sourceReference : <number>
         }
         [1] : {
-            name : test.js
+            name : localhost꞉8001/test.js
             path : localhost꞉8001/test.js
             sourceReference : <number>
         }

--- a/src/test/sources/sources-url-and-hash.txt
+++ b/src/test/sources/sources-url-and-hash.txt
@@ -3,7 +3,7 @@ Source event for foo.js
 {
     reason : new
     source : {
-        name : foo.js
+        name : localhost꞉8001/foo.js
         path : localhost꞉8001/foo.js
         sourceReference : <number>
     }
@@ -18,7 +18,7 @@ Source event for foo.js
 {
     reason : new
     source : {
-        name : foo.js
+        name : localhost꞉8001/foo.js
         path : localhost꞉8001/foo.js
         sourceReference : <number>
     }
@@ -33,7 +33,7 @@ Source event for empty.js
 {
     reason : new
     source : {
-        name : empty.js
+        name : localhost꞉8001/empty.js
         path : ${workspaceFolder}/web/empty.js
         sourceReference : <number>
     }
@@ -48,7 +48,7 @@ Source event for empty2.js
 {
     reason : new
     source : {
-        name : empty2.js
+        name : localhost꞉8001/empty2.js
         path : localhost꞉8001/empty2.js
         sourceReference : <number>
     }
@@ -61,32 +61,32 @@ text/javascript
 Loaded sources: {
     sources : [
         [0] : {
-            name : foo.js
+            name : localhost꞉8001/foo.js
             path : localhost꞉8001/foo.js
             sourceReference : <number>
         }
         [1] : {
-            name : foo.js
+            name : localhost꞉8001/foo.js
             path : localhost꞉8001/foo.js
             sourceReference : <number>
         }
         [2] : {
-            name : VM<xx>
+            name : <eval>/VM<xx>
             path : <eval>/VM<xx>
             sourceReference : <number>
         }
         [3] : {
-            name : empty.js
+            name : localhost꞉8001/empty.js
             path : ${workspaceFolder}/web/empty.js
             sourceReference : <number>
         }
         [4] : {
-            name : VM<xx>
+            name : <eval>/VM<xx>
             path : <eval>/VM<xx>
             sourceReference : <number>
         }
         [5] : {
-            name : empty2.js
+            name : localhost꞉8001/empty2.js
             path : localhost꞉8001/empty2.js
             sourceReference : <number>
         }


### PR DESCRIPTION
Previously we didn't prefix node_internals in the DAP source, and we
also only included the basename in the source `name`, which led to
pretty ugly file trees. Now, the name will be the relative path from
the rootPath, keeping the `<eval>` or `<node_internals>` name if present.

Fixes #329