### PR TITLE
refactor: stronger types in obj preview, fix unescaped lines

### DIFF
--- a/src/adapter/messageFormat.ts
+++ b/src/adapter/messageFormat.ts
@@ -4,6 +4,7 @@
 
 import Color from 'color';
 import { BudgetStringBuilder } from '../common/budgetStringBuilder';
+import { IPreviewContext } from './objectPreview/contexts';
 
 export type FormatToken =
   | { type: 'string'; value: string }
@@ -11,7 +12,7 @@ export type FormatToken =
 
 const maxMessageFormatLength = 10000;
 
-export type Formatters<T> = Map<string, (a: T, characterBudget: number) => string>;
+export type Formatters<T> = Map<string, (a: T, context: IPreviewContext) => string>;
 
 function tokenizeFormatString(format: string, formatterNames: string[]): FormatToken[] {
   const tokens: FormatToken[] = [];
@@ -90,7 +91,7 @@ export function formatMessage<T>(
     usedSubstitutionIndexes.add(index);
     if (token.specifier === 'c') cssFormatApplied = true;
     const formatter = formatters.get(token.specifier) || defaultFormatter;
-    builder.append(formatter(substitutions[index], builder.budget()));
+    builder.append(formatter(substitutions[index], { budget: builder.budget(), quoted: false }));
   }
 
   if (cssFormatApplied) builder.append('\x1b[0m'); // clear format
@@ -101,7 +102,7 @@ export function formatMessage<T>(
     if (format || i)
       // either we are second argument or we had format.
       builder.append(' ');
-    builder.append(defaultFormatter(substitutions[i], builder.budget()));
+    builder.append(defaultFormatter(substitutions[i], { budget: builder.budget(), quoted: false }));
   }
 
   return {

--- a/src/adapter/objectPreview/betterTypes.ts
+++ b/src/adapter/objectPreview/betterTypes.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import Cdp from '../../cdp/api';
+
+/**
+ * A collection of more strongly defined types. Derived from experimenting
+ * in Chrome devtools.
+ */
+
+export type TArray = {
+  type: 'object';
+  subtype: 'array' | 'typedarray';
+  description: string;
+};
+export type ArrayPreview = TArray & {
+  properties: (AnyPreview & Cdp.Runtime.PropertyPreview)[];
+  overflow: boolean;
+};
+export type ArrayObj = Cdp.Runtime.RemoteObject & TArray & { preview: ArrayPreview };
+
+export type TFunction = {
+  type: 'function';
+  subtype: undefined;
+  className: string;
+  description: string;
+};
+export type FunctionPreview = { type: 'function'; subtype: undefined; value: string };
+export type FunctionObj = TFunction;
+
+export type TNode = {
+  type: 'object';
+  subtype: 'node';
+  description: string;
+};
+export type NodePreview = TNode & ObjectPreview;
+export type NodeObj = TNode & { preview: NodePreview };
+
+export type TString = {
+  type: 'string';
+  value: string;
+  subtype: undefined;
+  description?: string;
+};
+export type StringPreview = TString;
+export type StringObj = TString;
+
+export type TObject = {
+  type: 'object';
+  subtype: undefined;
+  className: string;
+  description: string;
+};
+export type ObjectPreview = TObject & {
+  properties?: PropertyPreview[];
+  entries?: { key: AnyPreview; value: AnyPreview }[];
+};
+export type ObjectObj = TObject & { preview: ObjectPreview };
+
+export type TRegExp = {
+  type: 'object';
+  subtype: 'regexp';
+  className: 'RegExp';
+  description: string;
+};
+export type RegExpPreview = TRegExp & { overflow: boolean; properties: PropertyPreview[] };
+export type RegExpObj = TRegExp & { preview: RegExpPreview };
+
+export type TError = {
+  type: 'object';
+  subtype: 'error';
+  className: string;
+  description: string;
+};
+export type ErrorPreview = TError & { overflow: boolean };
+export type ErrorObj = TError & { preview: ErrorPreview };
+
+export type TNull = { type: 'object'; subtype: 'null' };
+export type NullPreview = TNull;
+export type NullObj = TNull;
+
+export type TUndefined = { type: 'undefined'; subtype: undefined };
+export type UndefinedPreview = TUndefined;
+export type UndefinedObj = TUndefined;
+
+export type TNumber = { type: 'number'; subtype: undefined; value: number; description: string };
+export type NumberPreview = TNumber;
+export type NumberObj = TNumber;
+
+export type TBigint = {
+  type: 'bigint';
+  subtype: undefined;
+  unserializableValue: string;
+  description: string;
+};
+export type BigintPreview = TBigint;
+export type BigintObj = TBigint;
+
+export type AnyObject =
+  | ObjectObj
+  | NodeObj
+  | ArrayObj
+  | ErrorObj
+  | RegExpObj
+  | FunctionObj
+  | StringObj
+  | BigintObj
+  | UndefinedObj
+  | NullObj;
+export type AnyPreview =
+  | ObjectPreview
+  | NodePreview
+  | ArrayPreview
+  | ErrorPreview
+  | RegExpPreview
+  | FunctionPreview
+  | StringPreview
+  | BigintPreview
+  | UndefinedPreview
+  | NullPreview;
+
+export type PreviewAsObjectType = NodePreview | FunctionPreview | ObjectPreview;
+export type Numeric = NumberPreview | BigintPreview;
+export type Primitive =
+  | NullPreview
+  | UndefinedPreview
+  | StringPreview
+  | NumberPreview
+  | BigintPreview
+  | RegExpPreview
+  | ErrorPreview;
+
+export type PropertyPreview = {
+  name: string;
+  type: AnyPreview['type'];
+  value?: string;
+} & AnyPreview;

--- a/src/adapter/objectPreview/contexts.ts
+++ b/src/adapter/objectPreview/contexts.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export interface IPreviewContext {
+  /**
+   * Max number of characters.
+   */
+  budget: number;
+
+  /**
+   * Whether strings should be quoted.
+   */
+  quoted: boolean;
+
+  /**
+   * Post-processes the object preview.
+   */
+  postProcess?(result: string): string;
+}
+
+/**
+ * Known REPL preview types.
+ */
+export const enum PreviewContextType {
+  Repl = 'repl',
+  Hover = 'hover',
+  PropertyValue = 'propertyValue',
+  Copy = 'copy',
+}
+
+const repl: IPreviewContext = { budget: 1000, quoted: true };
+const hover: IPreviewContext = {
+  budget: 1000,
+  quoted: true,
+  postProcess: str =>
+    str
+      .replace(/\n/gm, '\\n')
+      .replace(/\r/gm, '\\r')
+      .replace(/\t/gm, '\\t'),
+};
+const copy: IPreviewContext = { budget: Infinity, quoted: false };
+const fallback: IPreviewContext = { budget: 100, quoted: true };
+
+export const getContextForType = (type: PreviewContextType | string | undefined) => {
+  switch (type) {
+    case PreviewContextType.Repl:
+      return repl;
+    case PreviewContextType.Hover:
+      return hover;
+    case PreviewContextType.PropertyValue:
+      return hover;
+    case PreviewContextType.Copy:
+      return copy;
+    default:
+      // the type is received straight from the DAP, so it's possible we might
+      // get unknown types in the future. Fallback rather than e.g. throwing.
+      return fallback;
+  }
+};

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -23,6 +23,7 @@ import { toStringForClipboard } from './templates/toStringForClipboard';
 import { previewThis } from './templates/previewThis';
 import { UserDefinedBreakpoint } from './breakpoints/userDefinedBreakpoint';
 import { ILogger } from '../common/logging';
+import { AnyObject } from './objectPreview/betterTypes';
 
 const localize = nls.loadMessageBundle();
 
@@ -920,7 +921,7 @@ export class Thread implements IVariableStoreDelegate {
       const formatString = useMessageFormat ? (event.args[0].value as string) : '';
       const formatResult = messageFormat.formatMessage(
         formatString,
-        useMessageFormat ? event.args.slice(1) : event.args,
+        (useMessageFormat ? event.args.slice(1) : event.args) as AnyObject[],
         objectPreview.messageFormatters,
       );
       messageText = formatResult.result;

--- a/src/test/goldenText.ts
+++ b/src/test/goldenText.ts
@@ -16,7 +16,8 @@ const trimLineWhitespace = (str: string) =>
   str
     .split('\n')
     .map(l => l.trimRight())
-    .join('\n');
+    .join('\n')
+    .replace(/\\r\\n/g, '\\n');
 
 export class GoldenText {
   _results: string[];

--- a/src/test/stacks/stacks-source-map.txt
+++ b/src/test/stacks/stacks-source-map.txt
@@ -6,10 +6,7 @@ foo @ ${workspaceFolder}/web/browserify/module1.ts:3:3
 
 bar @ ${workspaceFolder}/web/browserify/module2.ts:3:3
   > scope #0: Local: bar
-      
-> callback: ƒ foo() {
-    debugger;
-}
+      > callback: ƒ foo() {\n    debugger;\n}
       > this: Object
   scope #1: Global [expensive]
 
@@ -34,11 +31,11 @@ o @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
   > scope #1: Closure (r)
       > e: {1: Array(2), 2: Array(2), 3: Array(2)}
       > n: {1: {…}, 2: {…}, 3: {…}}
-      > o: ƒ o(i,f)
+      > o: ƒ o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}
       > t: (1) [3]
       u: false
   > scope #2: Closure
-      > r: ƒ r(e,n,t)
+      > r: ƒ r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}
   scope #3: Global [expensive]
 
 r @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
@@ -46,12 +43,12 @@ r @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
       > e: {1: Array(2), 2: Array(2), 3: Array(2)}
       i: 0
       > n: {1: {…}, 2: {…}, 3: {…}}
-      > o: ƒ o(i,f)
+      > o: ƒ o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}
       > t: (1) [3]
       u: false
       > this: Window
   > scope #1: Closure
-      > r: ƒ r(e,n,t)
+      > r: ƒ r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}
   scope #2: Global [expensive]
 
 <anonymous> @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1


### PR DESCRIPTION
Previously we had a lot of linting errors in the object preview code for
null assertions, since we relied on generic types return from CDP where
most properties were optional. In this PR we write some better
interfaces for various types of objects in order to elimiate these
assertions and have more durable code.

I only found one bug while doing there, where we weren't handling
certain function previews correctly :)

Fixes #319, reduces some debt.