### PR TITLE
support edge launch config types in tests

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -435,6 +435,11 @@ interface IChromiumLaunchConfiguration extends IChromiumBaseConfiguration {
    * The debug adapter is running elevated. Launch Chrome unelevated to avoid the security restrictions of running Chrome elevated
    */
   launchUnelevated?: boolean;
+
+  /**
+   * Internal use only. Do not include in contrib.
+   */
+  skipNavigateForTest?: boolean;
 }
 
 /**

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -14,7 +14,6 @@ import { EventEmitter } from '../common/events';
 import * as utils from '../common/urlUtils';
 import {
   chromeLaunchConfigDefaults,
-  IChromeLaunchConfiguration,
   INodeAttachConfiguration,
   INodeLaunchConfiguration,
   nodeAttachConfigDefaults,
@@ -410,7 +409,10 @@ export class TestRoot {
     return result as TestP;
   }
 
-  async _launch(url: string, options: Partial<IChromeLaunchConfiguration> = {}): Promise<TestP> {
+  async _launch(
+    url: string,
+    options: Partial<AnyChromiumLaunchConfiguration> = {},
+  ): Promise<TestP> {
     await this.initialize;
     this._launchUrl = url;
 
@@ -425,7 +427,7 @@ export class TestRoot {
       trace: { logFile: tmpLogPath },
       outFiles: [`${this._workspaceRoot}/**/*.js`, '!**/node_modules/**'],
       ...options,
-    } as IChromeLaunchConfiguration);
+    } as AnyChromiumLaunchConfiguration);
 
     const result = await new Promise(f => (this._launchCallback = f));
     return result as TestP;
@@ -471,14 +473,17 @@ export class TestRoot {
     return result as NodeTestHandle;
   }
 
-  async launch(content: string, options: Partial<IChromeLaunchConfiguration> = {}): Promise<TestP> {
+  async launch(
+    content: string,
+    options: Partial<AnyChromiumLaunchConfiguration> = {},
+  ): Promise<TestP> {
     const url = 'data:text/html;base64,' + Buffer.from(content).toString('base64');
     return this._launch(url, options);
   }
 
   async launchAndLoad(
     content: string,
-    options: Partial<IChromeLaunchConfiguration> = {},
+    options: Partial<AnyChromiumLaunchConfiguration> = {},
   ): Promise<TestP> {
     const url = 'data:text/html;base64,' + Buffer.from(content).toString('base64');
     const p = await this._launch(url, options);
@@ -486,14 +491,17 @@ export class TestRoot {
     return p;
   }
 
-  async launchUrl(url: string, options: Partial<IChromeLaunchConfiguration> = {}): Promise<TestP> {
+  async launchUrl(
+    url: string,
+    options: Partial<AnyChromiumLaunchConfiguration> = {},
+  ): Promise<TestP> {
     url = utils.completeUrl('http://localhost:8001/', url) || url;
     return await this._launch(url, options);
   }
 
   async launchUrlAndLoad(
     url: string,
-    options: Partial<IChromeLaunchConfiguration> = {},
+    options: Partial<AnyChromiumLaunchConfiguration> = {},
   ): Promise<TestP> {
     url = utils.completeUrl('http://localhost:8001/', url) || url;
     const p = await this._launch(url, options);

--- a/src/test/webview/webview.breakpoints.test.win.ts
+++ b/src/test/webview/webview.breakpoints.test.win.ts
@@ -5,7 +5,6 @@
 import { ITestHandle } from '../test';
 import Dap from '../../dap/api';
 import { itIntegrates } from '../testIntegrationUtils';
-import { IChromeLaunchConfiguration } from '../../configuration';
 import { DebugType } from '../../common/contributionUtils';
 
 describe('webview breakpoints', () => {
@@ -18,14 +17,13 @@ describe('webview breakpoints', () => {
 
   itIntegrates('launched script', async ({ r }) => {
     // Breakpoint in separate script set after launch.
-    const p = await r.launchUrl('script.html', ({
+    const p = await r.launchUrl('script.html', {
       type: DebugType.Edge,
       runtimeExecutable: r.workspacePath('webview/win/WebView2Sample.exe'),
       useWebView: true,
       // WebView2Sample.exe launches about:blank
       urlFilter: 'about:blank',
-      // TODO: Test.launchUrl should support AnyLaunchConfiguration
-    } as unknown) as IChromeLaunchConfiguration);
+    });
     p.load();
     await waitForPause(p, async () => {
       const source: Dap.Source = {


### PR DESCRIPTION
With this change the launch test helpers will now accept an `EdgeLaunchConfiguration`.

This cleans up a TODO introduced in #325.

Note: 
The property `skipNavigateForTest` was being allowed in `ChromiumLaunchConfiguration` even when it was not defined on the interface, because `AnyLaunchConfiguration` is a union type it must now be explicitly put on the base `ChromiumLaunchConfiguration` type.