### PR TITLE
feat: improve completions for debug console objects

### DIFF
--- a/src/adapter/templates/enumerateProperties.ts
+++ b/src/adapter/templates/enumerateProperties.ts
@@ -2,66 +2,77 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import Dap from '../../dap/api';
-import { templateFunction } from './index';
-import { CompletionKind } from '../completions';
+import { remoteFunction, templateFunction } from './index';
+import { ICompletionWithSort, CompletionKind } from '../completions';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
  * Enumerates completion items of the property.
  */
-export const enumeratePropertiesTemplate = templateFunction(
-  (expression: unknown, prefix: string, isGlobal: boolean) => {
-    const getCompletionKind = (name: string, dtype: string | undefined, value: unknown) => {
-      if (dtype !== 'function') {
-        return isGlobal ? CompletionKind.Variable : CompletionKind.Property;
-      }
-
-      // Say this value is a class if either it stringifies into a native ES6
-      // class declaration, or it's native that starts with a capital letter.
-      // No, there's not really a better way to do this.
-      // https://stackoverflow.com/questions/30758961/how-to-check-if-a-variable-is-an-es6-class-declaration
-      const stringified = String(value);
-      if (
-        stringified.startsWith('class ') ||
-        (stringified.includes('[native code]') && name[0].toUpperCase() === name[0])
-      ) {
-        return CompletionKind.Class;
-      }
-
-      return isGlobal ? CompletionKind.Function : CompletionKind.Method;
-    };
-
-    const result: Dap.CompletionItem[] = [];
-    const discovered = new Set<string>();
-    let sortPrefix = '~';
-
-    for (let object = expression; object != null; object = (object as any).__proto__) {
-      sortPrefix += '~';
-      const props = Object.getOwnPropertyNames(object).filter(
-        l => l.startsWith(prefix) && !l.match(/^\d+$/),
-      );
-
-      for (const name of props) {
-        if (discovered.has(name)) {
-          continue;
-        }
-
-        discovered.add(name);
-        const descriptor = Object.getOwnPropertyDescriptor(object, name);
-        result.push({
-          label: name,
-          sortText: sortPrefix + name,
-          type: getCompletionKind(name, typeof descriptor?.value, (object as any)[name]),
-        });
-      }
-
-      // After we go through the first level of properties and into the
-      // prototype chain, we'll never be in the global scope.
-      isGlobal = false;
+export const enumerateProperties = remoteFunction(function(
+  this: unknown,
+  target: unknown,
+  prefix: string,
+  isGlobal: boolean,
+) {
+  const getCompletionKind = (name: string, dtype: string | undefined, value: unknown) => {
+    if (dtype !== 'function') {
+      return isGlobal ? CompletionKind.Variable : CompletionKind.Property;
     }
 
-    return { result, isArray: expression instanceof Array };
-  },
+    // Say this value is a class if either it stringifies into a native ES6
+    // class declaration, or it's native that starts with a capital letter.
+    // No, there's not really a better way to do this.
+    // https://stackoverflow.com/questions/30758961/how-to-check-if-a-variable-is-an-es6-class-declaration
+    const stringified = String(value);
+    if (
+      stringified.startsWith('class ') ||
+      (stringified.includes('[native code]') && name[0].toUpperCase() === name[0])
+    ) {
+      return CompletionKind.Class;
+    }
+
+    return isGlobal ? CompletionKind.Function : CompletionKind.Method;
+  };
+
+  const result: ICompletionWithSort[] = [];
+  const discovered = new Set<string>();
+  let sortPrefix = '~';
+
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let object = target === undefined ? this : target;
+  for (; object != null; object = (object as any).__proto__) {
+    sortPrefix += '~';
+    const props = Object.getOwnPropertyNames(object).filter(
+      l => l.startsWith(prefix) && !l.match(/^\d+$/),
+    );
+
+    for (const name of props) {
+      if (discovered.has(name)) {
+        continue;
+      }
+
+      discovered.add(name);
+      const descriptor = Object.getOwnPropertyDescriptor(object, name);
+      result.push({
+        label: name,
+        sortText: sortPrefix + name,
+        type: getCompletionKind(name, typeof descriptor?.value, (object as any)[name]),
+      });
+    }
+
+    // After we go through the first level of properties and into the
+    // prototype chain, we'll never be in the global scope.
+    isGlobal = false;
+  }
+
+  return { result, isArray: this instanceof Array };
+});
+
+/**
+ * Enumerates completion items of a primitive expression.
+ */
+export const enumeratePropertiesTemplate = templateFunction<[string, string, string]>(
+  enumerateProperties.source,
 );

--- a/src/test/completion/completion.test.ts
+++ b/src/test/completion/completion.test.ts
@@ -80,6 +80,29 @@ describe('completion', () => {
     ['MyCoolCl|', [{ label: 'MyCoolClass', sortText: '~~MyCoolClass', type: 'class' }]],
     ['Strin|', [{ label: 'String', sortText: '~~String', type: 'class' }]],
     ['myNeatFun|', [{ label: 'myNeatFunction', sortText: '~~myNeatFunction', type: 'function' }]],
+    [
+      'new Array(42).|',
+      [
+        {
+          label: '[index]',
+          length: 1,
+          sortText: '~~[',
+          start: 13,
+          text: '[',
+          type: 'property',
+        },
+        {
+          label: 'length',
+          sortText: '~~length',
+          type: 'property',
+        },
+        {
+          label: 'concat',
+          sortText: '~~~concat',
+          type: 'method',
+        },
+      ],
+    ],
   ];
 
   itIntegrates('completion', async ({ r }) => {


### PR DESCRIPTION
Previously, we were making sure an expression didn't have side effects,
then sending the whole thing over an evaluating it. But the side effect
check was super aggressive, and we wanted to losen it. Chrome can
actually check expressions for side effects, so it would be cool if it
could do it for us. The property enumeration process has potential
side effects, though, so we need to split it out.

In this change, we now first evaluate the expression, with the
`throwOnSideEffect` flag if we think it might have side effects. If it
returns an object reference, then we invoke the enumeration function on
that. If it doesn't, the expression is probably a primitive type, so
enumerate on the expression directory.

Fixes #251