### PR TITLE
fix process names in vs

### DIFF
--- a/src/dap/connection.ts
+++ b/src/dap/connection.ts
@@ -9,6 +9,7 @@ import { ILogger } from '../common/logging';
 import { isDapError, isExternalError, ProtocolError } from './errors';
 import { Message, IDapTransport } from './transport';
 import { IDisposable } from '../common/disposable';
+import { getDeferred } from '../common/promiseUtil';
 
 const requestSuffix = 'Request';
 export const isRequest = (req: string) => req.endsWith('Request');
@@ -27,6 +28,9 @@ export default class Connection {
   private _eventListeners = new Map<string, Set<(params: object) => void>>();
   private _dap: Promise<Dap.Api>;
   private disposables: IDisposable[] = [];
+
+  private _initialized = getDeferred<Connection>();
+  public initialized = this._initialized.promise;
 
   constructor(
     protected readonly transport: IDapTransport,
@@ -163,6 +167,9 @@ export default class Connection {
             });
           } else {
             this._send({ ...response, body: result });
+            if (response.command === 'initialize') {
+              this._initialized.resolve(this);
+            }
           }
         }
         this.telemetryReporter?.reportOperation(

--- a/src/dap/connection.ts
+++ b/src/dap/connection.ts
@@ -30,7 +30,12 @@ export default class Connection {
   private disposables: IDisposable[] = [];
 
   private _initialized = getDeferred<Connection>();
-  public initialized = this._initialized.promise;
+  /**
+   * Get a promise which will resolve with this connection after the session has responded to initialize
+   */
+  public get initializedBlocker() {
+    return this._initialized.promise;
+  }
 
   constructor(
     protected readonly transport: IDapTransport,

--- a/src/flatSessionLauncher.ts
+++ b/src/flatSessionLauncher.ts
@@ -27,7 +27,6 @@ class VSDebugSession implements IDebugSessionLike {
     public id: string,
     name: string,
     private readonly childConnection: Promise<DapConnection>,
-    private readonly mockProcessId: number,
   ) {
     this._name = name;
   }
@@ -36,9 +35,10 @@ class VSDebugSession implements IDebugSessionLike {
   set name(newName: string) {
     this._name = newName;
     this.childConnection
-      .then(x => x.dap())
+      .then(conn => conn.initialized)
+      .then(conn => conn.dap())
       .then(dap => {
-        dap.process({ systemProcessId: this.mockProcessId, name: newName });
+        dap.process({ name: newName });
       });
   }
   get name() {
@@ -50,7 +50,6 @@ class VSSessionManager {
   private services = createGlobalContainer({ storagePath, isVsCode: false });
   private sessionManager: SessionManager<VSDebugSession>;
   private rootTransport: IDapTransport;
-  private mockProcessId = 1;
 
   constructor(inputStream: Readable, outputStream: Writable) {
     this.sessionManager = new SessionManager<VSDebugSession>(
@@ -58,7 +57,8 @@ class VSSessionManager {
       this.buildVSSessionLauncher(),
     );
     this.rootTransport = new StreamDapTransport(inputStream, outputStream);
-    this.createSession(undefined, 'rootSession', {});
+    const root = this.createSession(undefined, 'rootSession', {});
+    root.debugSession.name = 'javascript debugger root session';
   }
 
   buildVSSessionLauncher(): SessionLauncher<VSDebugSession> {
@@ -82,16 +82,12 @@ class VSSessionManager {
   createSession(sessionId: string | undefined, name: string, config: any) {
     const deferredConnection = getDeferred<DapConnection>();
     const newSession = this.sessionManager.createNewSession(
-      new VSDebugSession(
-        sessionId || 'root',
-        name,
-        deferredConnection.promise,
-        this.mockProcessId++,
-      ),
+      new VSDebugSession(sessionId || 'root', name, deferredConnection.promise),
       config,
       new SessionIdDapTransport(sessionId, this.rootTransport),
     );
     deferredConnection.resolve(newSession.connection);
+    return newSession;
   }
 }
 

--- a/src/flatSessionLauncher.ts
+++ b/src/flatSessionLauncher.ts
@@ -35,7 +35,7 @@ class VSDebugSession implements IDebugSessionLike {
   set name(newName: string) {
     this._name = newName;
     this.childConnection
-      .then(conn => conn.initialized)
+      .then(conn => conn.initializedBlocker)
       .then(conn => conn.dap())
       .then(dap => {
         dap.process({ name: newName });


### PR DESCRIPTION
Debugged process names were blank in Visual Studio. Added fixes to make sure we send the initial target name, and subsequent name updates.