### PR TITLE
Quick fix for disconnect hanged issue

### DIFF
--- a/src/binder.ts
+++ b/src/binder.ts
@@ -235,12 +235,17 @@ export class Binder implements IDisposable {
     }
 
     ++this._terminationCount;
+    let firstCall = true;
     launcher.onTerminated(
       result => {
-        this._detachOrphanThreads(this.targetList(), { restart: result.restart });
-        this._onTargetListChangedEmitter.fire();
-        if (!--this._terminationCount) {
-          this._dap.then(dap => dap.terminated({ restart: result.restart }));
+        if (firstCall) {
+          this._detachOrphanThreads(this.targetList(), { restart: result.restart });
+          this._onTargetListChangedEmitter.fire();
+          if (!--this._terminationCount) {
+            this._dap.then(dap => dap.terminated({ restart: result.restart }));
+          }
+
+          firstCall = false;
         }
       },
       undefined,


### PR DESCRIPTION
On VS when we close the Node.js application instead of stopping debugging in the debugger, the connection gets hanged because the disconnect request never returns.

This happens because the launcher.onTerminated gets called twice from different places and this._terminationCount ends up valuing -1