### PR TITLE
Use ripgrep for outFiles search

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "description": "An extension for debugging Node.js programs and Chrome.",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.30.0-insider",
+    "vscode": "^1.44.0-insider",
     "node": "^8.9.3"
   },
   "icon": "resources/logo.png",

--- a/src/common/sourceMaps/codeSearchSourceMapRepository.ts
+++ b/src/common/sourceMaps/codeSearchSourceMapRepository.ts
@@ -20,19 +20,16 @@ export class CodeSearchSourceMapRepository implements ISourceMapRepository {
   constructor(private readonly _vscode: vscode, private readonly logger: ILogger) {}
 
   public static createOrFallback(logger: ILogger) {
-    /*
-    todo(connor4312): disabled until https://github.com/microsoft/vscode/issues/85946
     try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const code: typeof import('vscode') = require('vscode');
-      if (code.workspace.findTextInFiles) {
-        return new CodeSearchSourceMapRepository(
-          code.workspace.findTextInFiles.bind(code.workspace),
-        );
+      if (code.workspace.findTextInFiles as unknown) {
+        return new CodeSearchSourceMapRepository(code, logger);
       }
     } catch {
       // ignored -- VS won't have vscode as a viable import, fall back to the memory/node.js version
     }
-    */
+
     return new NodeSourceMapRepository(logger);
   }
 
@@ -66,6 +63,7 @@ export class CodeSearchSourceMapRepository implements ISourceMapRepository {
           .filter(p => p.startsWith('!'))
           .map(p => forceForwardSlashes(p.slice(1)))
           .join(','),
+        useDefaultExcludes: false,
         useIgnoreFiles: false,
         useGlobalIgnoreFiles: false,
         followSymlinks: true,
@@ -87,6 +85,8 @@ export class CodeSearchSourceMapRepository implements ISourceMapRepository {
         );
       },
     );
+
+    this.logger.info(LogTag.SourceMapParsing, `findTextInFiles search found ${todo.length} files`);
 
     return (await Promise.all(todo)).filter((t): t is T => t !== undefined);
   }

--- a/src/common/sourceMaps/nodeSourceMapRepository.ts
+++ b/src/common/sourceMaps/nodeSourceMapRepository.ts
@@ -63,6 +63,8 @@ export class NodeSourceMapRepository implements ISourceMapRepository {
         .on('error', reject),
     );
 
+    this.logger.info(LogTag.SourceMapParsing, `node search found ${todo.length} files`);
+
     return (await Promise.all(todo)).filter((t): t is T => t !== undefined);
   }
 }

--- a/src/typings/vscode.proposed.d.ts
+++ b/src/typings/vscode.proposed.d.ts
@@ -258,6 +258,11 @@ declare module 'vscode' {
 	 */
 	export interface DocumentSemanticTokensProvider {
 		/**
+		 * An optional event to signal that the semantic tokens from this provider have changed.
+		 */
+		onDidChangeSemanticTokens?: Event<void>;
+
+		/**
 		 * A file can contain many tokens, perhaps even hundreds of thousands of tokens. Therefore, to improve
 		 * the memory consumption around describing semantic tokens, we have decided to avoid allocating an object
 		 * for each token and we represent tokens from a file as an array of integers. Furthermore, the position
@@ -314,6 +319,9 @@ declare module 'vscode' {
 		 *    // 1st token,  2nd token,  3rd token
 		 *    [  2,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
 		 * ```
+		 *
+		 * *NOTE*: When doing edits, it is possible that multiple edits occur until VS Code decides to invoke the semantic tokens provider.
+		 * *NOTE*: If the provider cannot temporarily compute semantic tokens, it can indicate this by throwing an error with the message 'Busy'.
 		 */
 		provideDocumentSemanticTokens(document: TextDocument, token: CancellationToken): ProviderResult<SemanticTokens>;
 
@@ -366,7 +374,6 @@ declare module 'vscode' {
 		 *    edit: { start: 10, deleteCount: 1, data: [1,3,5,0,2,2] } // replace integer at offset 10 with [1,3,5,0,2,2]
 		 * ```
 		 *
-		 * *NOTE*: When doing edits, it is possible that multiple edits occur until VS Code decides to invoke the semantic tokens provider.
 		 * *NOTE*: If the provider cannot compute `SemanticTokensEdits`, it can "give up" and return all the tokens in the document again.
 		 * *NOTE*: All edits in `SemanticTokensEdits` contain indices in the old integers array, so they all refer to the previous result state.
 		 */
@@ -749,10 +756,15 @@ declare module 'vscode' {
 
 		/**
 		 * A [glob pattern](#GlobPattern) that defines files and folders to exclude. The glob pattern
-		 * will be matched against the file paths of resulting matches relative to their workspace. When `undefined` only default excludes will
-		 * apply, when `null` no excludes will apply.
+		 * will be matched against the file paths of resulting matches relative to their workspace. When `undefined`, default excludes will
+		 * apply.
 		 */
-		exclude?: GlobPattern | null;
+		exclude?: GlobPattern;
+
+		/**
+		 * Whether to use the default and user-configured excludes. Defaults to true.
+		 */
+		useDefaultExcludes?: boolean;
 
 		/**
 		 * The maximum number of results to search for
@@ -1600,7 +1612,7 @@ declare module 'vscode' {
 		/**
 		 * The maximum number or the ending cursor of timeline items that should be returned.
 		 */
-		limit?: number | string;
+		limit?: number | { cursor: string };
 	}
 
 	export interface TimelineProvider {


### PR DESCRIPTION
Since this requires bumping the vscode engine version, we will want to wait a bit before merging this, otherwise people using stable will not be able to use the extension. I guess we can wait a whole month or dynamically figure out whether Insiders is being used.