### PR TITLE
When making websocket connection, enable "follow redirects"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -581,12 +581,11 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
-      "integrity": "sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.2.tgz",
+      "integrity": "sha512-oqnI3DbGCVI9zJ/WHdFo3CUE8jQ8CVQDUIKaDtlTcNeT4zs6UCg9Gvk5QrFx2QPkRszpM6yc8o0p4aGjCsTi+w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@types/split2": "^2.1.6",
     "@types/stream-buffers": "^3.0.3",
     "@types/tmp": "^0.1.0",
-    "@types/ws": "^6.0.1",
+    "@types/ws": "^7.2.2",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",
     "chai": "^4.2.0",

--- a/src/cdp/transport.ts
+++ b/src/cdp/transport.ts
@@ -120,6 +120,7 @@ export class WebSocketTransport implements ITransport {
       perMessageDeflate: false,
       maxPayload: 256 * 1024 * 1024, // 256Mb
       rejectUnauthorized: !(isSecure && targetAddressIsLoopback),
+      followRedirects: true,
     });
 
     return timeoutPromise(


### PR DESCRIPTION
This makes it possible for the Blazor debugging middleware to redirect the connection to an external process

... which in turn is necessary to avoid blocking the debug proxy while breakpoints are being hit

... which in turn is necessary for things like the "locals" window to be able to obtain values.