### PR TITLE
feat: allow usage of $returnValue

### DIFF
--- a/src/adapter/completions.ts
+++ b/src/adapter/completions.ts
@@ -8,12 +8,14 @@ import Cdp from '../cdp/api';
 import { StackFrame } from './stackTrace';
 import { positionToOffset } from '../common/sourceUtils';
 import { enumerateProperties, enumeratePropertiesTemplate } from './templates/enumerateProperties';
+import { injectable, inject } from 'inversify';
+import { IEvaluator, returnValueStr } from './evaluator';
+import { ICdpApi } from '../cdp/connection';
 
 /**
  * Context in which a completion is being evaluated.
  */
 export interface ICompletionContext {
-  cdp: Cdp.Api;
   executionContextId: number | undefined;
   stackFrame: StackFrame | undefined;
 }
@@ -96,210 +98,6 @@ const inferCompletionKindForDeclaration = (node: ts.Declaration) => {
   }
 };
 
-export async function completions(
-  options: ICompletionContext & ICompletionExpression,
-): Promise<Dap.CompletionItem[]> {
-  const sourceFile = ts.createSourceFile(
-    'test.js',
-    options.expression,
-    ts.ScriptTarget.ESNext,
-    /*setParentNodes */ true,
-  );
-
-  const offset = positionToOffset(options.expression, options.line, options.column);
-  let candidate: () => Promise<ICompletionWithSort[]> = () => Promise.resolve([]);
-
-  ts.forEachChild(sourceFile, function traverse(node: ts.Node) {
-    if (node.pos < offset && offset <= node.end) {
-      if (ts.isIdentifier(node)) {
-        candidate = () => identifierCompleter(options, sourceFile, node, offset);
-      } else if (ts.isPropertyAccessExpression(node)) {
-        candidate = () => propertyAccessCompleter(options, node, offset);
-      } else if (ts.isElementAccessExpression(node)) {
-        candidate = () => elementAccessCompleter(options, node, offset);
-      }
-    }
-
-    ts.forEachChild(node, traverse);
-  });
-
-  return candidate().then(v => v.sort((a, b) => (a.sortText > b.sortText ? 1 : -1)));
-}
-
-const isDeclarationStatement = (node: ts.Node): node is ts.DeclarationStatement => 'name' in node;
-
-/**
- * Completer for a TS element access, via bracket syntax.
- */
-const elementAccessCompleter = async (
-  options: ICompletionContext,
-  node: ts.ElementAccessExpression,
-  offset: number,
-) => {
-  if (!ts.isStringLiteralLike(node.argumentExpression)) {
-    // If this is not a string literal, either they're typing a number (where
-    // autocompletion would be quite silly) or a complex expression where
-    // trying to complete by property name is inappropriate.
-    return [];
-  }
-
-  const prefix = node.argumentExpression
-    .getText()
-    .slice(1, offset - node.argumentExpression.getStart());
-
-  const completions = await defaultCompletions(options, prefix);
-
-  // Filter out the array access, adjust replacement ranges
-  return completions
-    .filter(c => c.sortText !== '~~[')
-    .map(item => ({
-      ...item,
-      text: JSON.stringify(item.text ?? item.label) + ']',
-      start: node.argumentExpression.getStart(),
-      length: node.argumentExpression.getWidth() + 1,
-    }));
-};
-
-/**
- * Completer for an arbitrary identifier.
- */
-const identifierCompleter = async (
-  options: ICompletionContext,
-  source: ts.SourceFile,
-  node: ts.Identifier,
-  offset: number,
-) => {
-  // Walk through the expression and look for any locally-declared variables or identifiers.
-  const localIdentifiers: ICompletionWithSort[] = [];
-  ts.forEachChild(source, function transverse(node: ts.Node) {
-    if (!isDeclarationStatement(node)) {
-      ts.forEachChild(node, transverse);
-      return;
-    }
-
-    if (node.name && ts.isIdentifier(node.name)) {
-      localIdentifiers.push({
-        label: node.name.text,
-        type: inferCompletionKindForDeclaration(node),
-        sortText: node.name.text,
-      });
-    }
-  });
-
-  return [
-    ...localIdentifiers,
-    ...(await defaultCompletions(options, node.getText().substring(0, offset - node.getStart()))),
-  ];
-};
-
-/**
- * Completes a property access on an object.
- */
-const propertyAccessCompleter = async (
-  options: ICompletionContext,
-  node: ts.PropertyAccessExpression,
-  offset: number,
-): Promise<ICompletionWithSort[]> => {
-  const { result, isArray } = await completePropertyAccess({
-    cdp: options.cdp,
-    executionContextId: options.executionContextId,
-    stackFrame: options.stackFrame,
-    expression: node.expression.getText(),
-    prefix: node.name.text.substring(0, offset - node.name.getStart()),
-    // If we see the expression might have a side effect, still try to get
-    // completions, but tell V8 to throw if it sees a side effect. This is a
-    // fairly conservative checker, we don't enable it if not needed.
-    throwOnSideEffect: maybeHasSideEffects(node.expression),
-  });
-
-  if (isArray) {
-    const start = node.name.getStart() - 1;
-    result.unshift({
-      label: '[index]',
-      text: '[',
-      type: 'property',
-      sortText: '~~[',
-      start,
-      length: 1,
-    });
-  }
-
-  return result;
-};
-
-async function completePropertyAccess({
-  cdp,
-  executionContextId,
-  stackFrame,
-  expression,
-  prefix,
-  isInGlobalScope = false,
-  throwOnSideEffect = false,
-}: {
-  cdp: Cdp.Api;
-  executionContextId?: number;
-  stackFrame?: StackFrame;
-  expression: string;
-  prefix: string;
-  throwOnSideEffect?: boolean;
-  isInGlobalScope?: boolean;
-}): Promise<{ result: ICompletionWithSort[]; isArray: boolean }> {
-  const params = {
-    expression: `(${expression})`,
-    objectGroup: 'console',
-    silent: true,
-    throwOnSideEffect,
-  };
-
-  const callFrameId = stackFrame && stackFrame.callFrameId();
-  const objRefResult = callFrameId
-    ? await cdp.Debugger.evaluateOnCallFrame({ ...params, callFrameId })
-    : await cdp.Runtime.evaluate({ ...params, contextId: executionContextId });
-  if (!objRefResult || objRefResult.exceptionDetails) {
-    return { result: [], isArray: false };
-  }
-
-  // No object ID indicates a primitive. Call enumeration on the value
-  // directly. We don't do this all the time, since our enumeration logic
-  // triggers Chrome's side-effect detect and fails.
-  if (!objRefResult.result.objectId) {
-    const primitiveParams = {
-      ...params,
-      returnByValue: true,
-      throwOnSideEffect: false,
-      expression: enumeratePropertiesTemplate(
-        `(${expression})`,
-        JSON.stringify(prefix),
-        JSON.stringify(isInGlobalScope),
-      ),
-    };
-
-    const propsResult = callFrameId
-      ? await cdp.Debugger.evaluateOnCallFrame({ ...primitiveParams, callFrameId })
-      : await cdp.Runtime.evaluate({ ...primitiveParams, contextId: executionContextId });
-
-    return !propsResult || propsResult.exceptionDetails
-      ? { result: [], isArray: false }
-      : propsResult.result.value;
-  }
-
-  // Otherwise, invoke the property enumeration on the returned object ID.
-  try {
-    const propsResult = await enumerateProperties({
-      cdp,
-      args: [undefined, prefix, isInGlobalScope],
-      objectId: objRefResult.result.objectId,
-      returnByValue: true,
-    });
-
-    return propsResult.value;
-  } catch {
-    return { result: [], isArray: false };
-  } finally {
-    cdp.Runtime.releaseObject({ objectId: objRefResult.result.objectId }); // no await
-  }
-}
-
 function maybeHasSideEffects(node: ts.Node): boolean {
   let result = false;
   traverse(node);
@@ -320,40 +118,296 @@ function maybeHasSideEffects(node: ts.Node): boolean {
   return result;
 }
 
+const isDeclarationStatement = (node: ts.Node): node is ts.DeclarationStatement => 'name' in node;
+
+export const ICompletions = Symbol('ICompletions');
+
 /**
- * Returns completion for globally scoped variables. Used for a fallback
- * if we can't find anything more specific to complete.
+ * Gets autocompletion results for an expression.
  */
-async function defaultCompletions(
-  options: ICompletionContext,
-  prefix = '',
-): Promise<ICompletionWithSort[]> {
-  for (const global of ['self', 'global', 'this']) {
-    const { result: items } = await completePropertyAccess({
-      cdp: options.cdp,
-      executionContextId: options.executionContextId,
-      stackFrame: options.stackFrame,
-      expression: global,
-      prefix,
-      isInGlobalScope: true,
-    });
+export interface ICompletions {
+  completions(options: ICompletionContext & ICompletionExpression): Promise<Dap.CompletionItem[]>;
+}
 
-    if (!items.length) {
-      continue;
-    }
+/**
+ * Provides REPL completions for the debug session.
+ */
+@injectable()
+export class Completions {
+  constructor(
+    @inject(IEvaluator) private readonly evaluator: IEvaluator,
+    @inject(ICdpApi) private readonly cdp: Cdp.Api,
+  ) {}
 
-    if (options.stackFrame) {
-      // When evaluating on a call frame, also autocomplete with scope variables.
-      const names = new Set(items.map(item => item.label));
-      for (const completion of await options.stackFrame.completions()) {
-        if (names.has(completion.label)) continue;
-        names.add(completion.label);
-        items.push(completion as ICompletionWithSort);
+  async completions(
+    options: ICompletionContext & ICompletionExpression,
+  ): Promise<Dap.CompletionItem[]> {
+    const sourceFile = ts.createSourceFile(
+      'test.js',
+      options.expression,
+      ts.ScriptTarget.ESNext,
+      /*setParentNodes */ true,
+    );
+
+    const offset = positionToOffset(options.expression, options.line, options.column);
+    let candidate: () => Promise<ICompletionWithSort[]> = () => Promise.resolve([]);
+
+    const traverse = (node: ts.Node) => {
+      if (node.pos < offset && offset <= node.end) {
+        if (ts.isIdentifier(node)) {
+          candidate = () => this.identifierCompleter(options, sourceFile, node, offset);
+        } else if (ts.isPropertyAccessExpression(node)) {
+          candidate = () => this.propertyAccessCompleter(options, node, offset);
+        } else if (ts.isElementAccessExpression(node)) {
+          candidate = () => this.elementAccessCompleter(options, node, offset);
+        }
       }
-    }
 
-    return items;
+      ts.forEachChild(node, traverse);
+    };
+
+    traverse(sourceFile);
+
+    return candidate().then(v => v.sort((a, b) => (a.sortText > b.sortText ? 1 : -1)));
   }
 
-  return [];
+  /**
+   * Completer for a TS element access, via bracket syntax.
+   */
+  async elementAccessCompleter(
+    options: ICompletionContext,
+    node: ts.ElementAccessExpression,
+    offset: number,
+  ) {
+    if (!ts.isStringLiteralLike(node.argumentExpression)) {
+      // If this is not a string literal, either they're typing a number (where
+      // autocompletion would be quite silly) or a complex expression where
+      // trying to complete by property name is inappropriate.
+      return [];
+    }
+
+    const prefix = node.argumentExpression
+      .getText()
+      .slice(1, offset - node.argumentExpression.getStart());
+
+    const completions = await this.defaultCompletions(options, prefix);
+
+    // Filter out the array access, adjust replacement ranges
+    return completions
+      .filter(c => c.sortText !== '~~[')
+      .map(item => ({
+        ...item,
+        text: JSON.stringify(item.text ?? item.label) + ']',
+        start: node.argumentExpression.getStart(),
+        length: node.argumentExpression.getWidth() + 1,
+      }));
+  }
+
+  /**
+   * Completer for an arbitrary identifier.
+   */
+  private async identifierCompleter(
+    options: ICompletionContext,
+    source: ts.SourceFile,
+    node: ts.Identifier,
+    offset: number,
+  ) {
+    // Walk through the expression and look for any locally-declared variables or identifiers.
+    const localIdentifiers: ICompletionWithSort[] = [];
+    ts.forEachChild(source, function transverse(node: ts.Node) {
+      if (!isDeclarationStatement(node)) {
+        ts.forEachChild(node, transverse);
+        return;
+      }
+
+      if (node.name && ts.isIdentifier(node.name)) {
+        localIdentifiers.push({
+          label: node.name.text,
+          type: inferCompletionKindForDeclaration(node),
+          sortText: node.name.text,
+        });
+      }
+    });
+
+    const prefix = node.getText().substring(0, offset - node.getStart());
+    const completions = [...localIdentifiers, ...(await this.defaultCompletions(options, prefix))];
+
+    if (
+      this.evaluator.hasReturnValue &&
+      options.executionContextId !== undefined &&
+      returnValueStr.startsWith(prefix)
+    ) {
+      completions.push({
+        sortText: `~${returnValueStr}`,
+        label: returnValueStr,
+        type: 'variable',
+      });
+    }
+
+    return completions;
+  }
+
+  /**
+   * Completes a property access on an object.
+   */
+  async propertyAccessCompleter(
+    options: ICompletionContext,
+    node: ts.PropertyAccessExpression,
+    offset: number,
+  ): Promise<ICompletionWithSort[]> {
+    const { result, isArray } = await this.completePropertyAccess({
+      executionContextId: options.executionContextId,
+      stackFrame: options.stackFrame,
+      expression: node.expression.getText(),
+      prefix: node.name.text.substring(0, offset - node.name.getStart()),
+      // If we see the expression might have a side effect, still try to get
+      // completions, but tell V8 to throw if it sees a side effect. This is a
+      // fairly conservative checker, we don't enable it if not needed.
+      throwOnSideEffect: maybeHasSideEffects(node.expression),
+    });
+
+    if (isArray) {
+      const start = node.name.getStart() - 1;
+      result.unshift({
+        label: '[index]',
+        text: '[',
+        type: 'property',
+        sortText: '~~[',
+        start,
+        length: 1,
+      });
+    }
+
+    return result;
+  }
+
+  private async completePropertyAccess({
+    executionContextId,
+    stackFrame,
+    expression,
+    prefix,
+    isInGlobalScope = false,
+    throwOnSideEffect = false,
+  }: {
+    executionContextId?: number;
+    stackFrame?: StackFrame;
+    expression: string;
+    prefix: string;
+    throwOnSideEffect?: boolean;
+    isInGlobalScope?: boolean;
+  }): Promise<{ result: ICompletionWithSort[]; isArray: boolean }> {
+    const params = {
+      expression: `(${expression})`,
+      objectGroup: 'console',
+      silent: true,
+      throwOnSideEffect,
+    };
+
+    const callFrameId = stackFrame && stackFrame.callFrameId();
+    const objRefResult = await this.evaluator.evaluate(
+      callFrameId ? { ...params, callFrameId } : { ...params, contextId: executionContextId },
+    );
+
+    if (!objRefResult || objRefResult.exceptionDetails) {
+      return { result: [], isArray: false };
+    }
+
+    // No object ID indicates a primitive. Call enumeration on the value
+    // directly. We don't do this all the time, since our enumeration logic
+    // triggers Chrome's side-effect detect and fails.
+    if (!objRefResult.result.objectId) {
+      const primitiveParams = {
+        ...params,
+        returnByValue: true,
+        throwOnSideEffect: false,
+        expression: enumeratePropertiesTemplate(
+          `(${expression})`,
+          JSON.stringify(prefix),
+          JSON.stringify(isInGlobalScope),
+        ),
+      };
+
+      const propsResult = await this.evaluator.evaluate(
+        callFrameId
+          ? { ...primitiveParams, callFrameId }
+          : { ...primitiveParams, contextId: executionContextId },
+      );
+
+      return !propsResult || propsResult.exceptionDetails
+        ? { result: [], isArray: false }
+        : propsResult.result.value;
+    }
+
+    // Otherwise, invoke the property enumeration on the returned object ID.
+    try {
+      const propsResult = await enumerateProperties({
+        cdp: this.cdp,
+        args: [undefined, prefix, isInGlobalScope],
+        objectId: objRefResult.result.objectId,
+        returnByValue: true,
+      });
+
+      return propsResult.value;
+    } catch {
+      return { result: [], isArray: false };
+    } finally {
+      this.cdp.Runtime.releaseObject({ objectId: objRefResult.result.objectId }); // no await
+    }
+  }
+
+  /**
+   * Returns completion for globally scoped variables. Used for a fallback
+   * if we can't find anything more specific to complete.
+   */
+  private async defaultCompletions(
+    options: ICompletionContext,
+    prefix = '',
+  ): Promise<ICompletionWithSort[]> {
+    for (const global of ['self', 'global', 'this']) {
+      const { result: items } = await this.completePropertyAccess({
+        executionContextId: options.executionContextId,
+        stackFrame: options.stackFrame,
+        expression: global,
+        prefix,
+        isInGlobalScope: true,
+      });
+
+      if (!items.length) {
+        continue;
+      }
+
+      if (options.stackFrame) {
+        // When evaluating on a call frame, also autocomplete with scope variables.
+        const names = new Set(items.map(item => item.label));
+        for (const completion of await options.stackFrame.completions()) {
+          if (names.has(completion.label)) continue;
+          names.add(completion.label);
+          items.push(completion as ICompletionWithSort);
+        }
+      }
+
+      items.push(...this.syntheticCompletions(options, prefix));
+
+      return items;
+    }
+
+    return this.syntheticCompletions(options, prefix);
+  }
+
+  private syntheticCompletions(
+    _options: ICompletionContext,
+    prefix: string,
+  ): ICompletionWithSort[] {
+    if (this.evaluator.hasReturnValue && returnValueStr.startsWith(prefix)) {
+      return [
+        {
+          sortText: `~${returnValueStr}`,
+          label: returnValueStr,
+          type: 'variable',
+        },
+      ];
+    }
+
+    return [];
+  }
 }

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -25,6 +25,8 @@ import { Container } from 'inversify';
 import { ISourceMapRepository } from '../common/sourceMaps/sourceMapRepository';
 import { IBreakpointsPredictor } from './breakpointPredictor';
 import { disposeContainer } from '../ioc-extras';
+import { ICompletions } from './completions';
+import { IEvaluator } from './evaluator';
 
 const localize = nls.loadMessageBundle();
 
@@ -269,6 +271,8 @@ export class DebugAdapter implements IDisposable {
       this.dap,
       delegate,
       this._services.get(ILogger),
+      this._services.get(IEvaluator),
+      this._services.get(ICompletions),
       this.launchConfig,
       this.breakpointManager,
     );

--- a/src/adapter/evaluator.ts
+++ b/src/adapter/evaluator.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import Cdp from '../cdp/api';
+import * as ts from 'typescript';
+import { randomBytes } from 'crypto';
+import { inject, injectable } from 'inversify';
+import { ICdpApi } from '../cdp/connection';
+
+export const returnValueStr = '$returnValue';
+
+const hoistedPrefix = '__js_debug_hoisted_';
+
+export const IEvaluator = Symbol('IEvaluator');
+
+/**
+ * Evaluation wraps CDP evaluation requests with additional functionality.
+ */
+export interface IEvaluator {
+  /**
+   * Evaluates the expression on a call frame. This allows
+   * referencing the $returnValue
+   */
+  evaluate(
+    params: Cdp.Debugger.EvaluateOnCallFrameParams,
+  ): Promise<Cdp.Debugger.EvaluateOnCallFrameResult>;
+
+  /**
+   * Evaluates the expression the runtime.
+   */
+  evaluate(params: Cdp.Runtime.EvaluateParams): Promise<Cdp.Runtime.EvaluateResult>;
+
+  /**
+   * Evaluates the expression the runtime or call frame.
+   */
+  evaluate(
+    params: Cdp.Runtime.EvaluateParams | Cdp.Debugger.EvaluateOnCallFrameParams,
+  ): Promise<Cdp.Runtime.EvaluateResult | Cdp.Debugger.EvaluateOnCallFrameResult>;
+
+  /**
+   * Sets or unsets the last stackframe returned value.
+   */
+  setReturnedValue(value?: Cdp.Runtime.RemoteObject): void;
+
+  /**
+   * Gets whether a return value is currently set.
+   */
+  readonly hasReturnValue: boolean;
+}
+
+/**
+ * Evaluation wraps CDP evaluation requests with additional functionality.
+ */
+@injectable()
+export class Evaluator implements IEvaluator {
+  private returnValue: Cdp.Runtime.RemoteObject | undefined;
+
+  /**
+   * @inheritdoc
+   */
+  public get hasReturnValue() {
+    return !!this.returnValue;
+  }
+
+  constructor(@inject(ICdpApi) private readonly cdp: Cdp.Api) {}
+
+  /**
+   * @inheritdoc
+   */
+  public setReturnedValue(value?: Cdp.Runtime.RemoteObject) {
+    this.returnValue = value;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public evaluate(
+    params: Cdp.Debugger.EvaluateOnCallFrameParams,
+  ): Promise<Cdp.Debugger.EvaluateOnCallFrameResult>;
+  public evaluate(params: Cdp.Runtime.EvaluateParams): Promise<Cdp.Runtime.EvaluateResult>;
+  public async evaluate(
+    params: Cdp.Debugger.EvaluateOnCallFrameParams | Cdp.Runtime.EvaluateParams,
+  ) {
+    // no call frame means there will not be any relevant $returnValue to reference
+    if (!('callFrameId' in params)) {
+      return this.cdp.Runtime.evaluate(params);
+    }
+
+    // CDP gives us a way to evaluate a function in the context of a given
+    // object ID. What we do to make returnValue work is to hoist the return
+    // object onto `globalThis`, replace reference in the expression, then
+    // evalute the expression and unhoist it from the globals.
+    const hoistedVar = hoistedPrefix + randomBytes(8).toString('hex');
+    const modified = this.hasReturnValue && this.replaceReturnValue(params.expression, hoistedVar);
+    if (!modified) {
+      return this.cdp.Debugger.evaluateOnCallFrame(params);
+    }
+
+    await this.hoistReturnValue(params, hoistedVar);
+    return this.cdp.Debugger.evaluateOnCallFrame({ ...params, expression: modified });
+  }
+
+  /**
+   * Hoists the return value of the expression to the `globalThis`.
+   */
+  private async hoistReturnValue(params: Cdp.Runtime.EvaluateParams, hoistedVar: string) {
+    const objectId = this.returnValue?.objectId;
+    const dehoist = `setTimeout(() => { delete globalThis.${hoistedVar} }, 0)`;
+
+    if (objectId) {
+      await this.cdp.Runtime.callFunctionOn({
+        executionContextId: params.contextId,
+        objectId,
+        functionDeclaration: `function() { globalThis.${hoistedVar} = this; ${dehoist}; }`,
+      });
+    } else {
+      await this.cdp.Runtime.evaluate({
+        contextId: params.contextId,
+        expression: `
+          globalThis.${hoistedVar} = ${JSON.stringify(this.returnValue?.value)};
+          ${dehoist};
+        `,
+      });
+    }
+  }
+
+  /**
+   * Replaces $returnValue in the given expression with the `hoisted` variable,
+   * returning the modified expression if it was found.
+   */
+  private replaceReturnValue(expr: string, hoistedVar: string): string | undefined {
+    const sourceFile = ts.createSourceFile(
+      'test.js',
+      expr,
+      ts.ScriptTarget.ESNext,
+      /*setParentNodes */ true,
+    );
+
+    let adjust = 0;
+    let found = false;
+
+    const replacement = `(typeof ${hoistedVar} !== 'undefined' ? ${hoistedVar} : undefined)`;
+    const replace = (node: ts.Node) => {
+      if (ts.isIdentifier(node) && node.text === returnValueStr) {
+        expr = expr.slice(0, node.getStart() + adjust) + replacement + expr.slice(node.getEnd());
+        adjust += node.getEnd() - node.getStart() - replacement.length;
+        found = true;
+      }
+
+      ts.forEachChild(node, replace);
+    };
+
+    replace(sourceFile);
+
+    return found ? expr : undefined;
+  }
+}

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -56,6 +56,8 @@ import { IDebugConfigurationProvider } from './ui/configuration/configurationPro
 import execa from 'execa';
 import { promises as fsPromises } from 'fs';
 import { RemoteBrowserLauncher } from './targets/browser/remoteBrowserLauncher';
+import { ICompletions, Completions } from './adapter/completions';
+import { IEvaluator, Evaluator } from './adapter/evaluator';
 
 /**
  * Contains IOC container factories for the extension. We use Inverisfy, which
@@ -93,6 +95,16 @@ export const createTargetContainer = (
   container
     .bind(IScriptSkipper)
     .to(ScriptSkipper)
+    .inSingletonScope();
+
+  container
+    .bind(ICompletions)
+    .to(Completions)
+    .inSingletonScope();
+
+  container
+    .bind(IEvaluator)
+    .to(Evaluator)
     .inSingletonScope();
 
   // first/parent target

--- a/src/test/evaluate/evaluate-returnvalue.txt
+++ b/src/test/evaluate/evaluate-returnvalue.txt
@@ -1,0 +1,11 @@
+return 42:
+
+result: 42
+return { a: { b: true } }:
+
+> result: {a: {…}}
+    > a: {b: true}
+    > __proto__: Object
+return undefined:
+
+result: undefined

--- a/src/test/extension/nodeConfigurationProvidersTests.ts
+++ b/src/test/extension/nodeConfigurationProvidersTests.ts
@@ -50,6 +50,7 @@ describe('NodeDebugConfigurationProvider', () => {
       expect(result!.trace).to.deep.equal({
         console: false,
         level: 'fatal',
+        stdio: false,
         logFile: null,
         tags: [],
       });
@@ -63,6 +64,7 @@ describe('NodeDebugConfigurationProvider', () => {
       expect(result!.trace).to.containSubset({
         console: false,
         level: 'verbose',
+        stdio: true,
         logFile: join(testFixturesDir, 'vscode-debugadapter-0.json'),
         tags: [],
       });
@@ -79,6 +81,7 @@ describe('NodeDebugConfigurationProvider', () => {
       expect(result!.trace).to.deep.equal({
         console: false,
         level: 'warn',
+        stdio: true,
         logFile: join(testFixturesDir, 'vscode-debugadapter-0.json'),
         tags: ['cdp'],
       });


### PR DESCRIPTION
Although the return value is not normally accessible to code, from the
CDP perspective it's just an object reference which can be addressed
like any other reference. So with a little bit of legwork, we can make
it work.

In this PR, we preprocess evaluated code looking for the special
$returnValue identifier. When we get it, we trigger logic to 'hoist' the
return value into the global scope by evaluating `globalThis[var] =
this` in the context of the return object, and then replace $returnValue
in the code. We include a timeout to clear the global reference to avoid
polluting the namespace (which could leak memory).

One interesting thing that arises is that we can technically do this for
any internal object. So, for instance, we could similarly allow
accessing the settled value or error on promises.

![](https://memes.peet.io/img/20-03-fb95efb9-d0cb-46d0-acf3-dd5d8e921666.png)

Fixes https://github.com/microsoft/vscode-js-debug/issues/323