### PR TITLE
feat: allow pointing to a node source file to execute

### DIFF
--- a/demos/extension/.vscode/launch.json
+++ b/demos/extension/.vscode/launch.json
@@ -1,0 +1,17 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+      "preLaunchTask": "npm: watch"
+    }
+  ]
+}

--- a/demos/extension/.vscode/tasks.json
+++ b/demos/extension/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": ["$tsc-watch"],
+      "isBackground": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -356,6 +356,12 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/expect": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
+      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
@@ -396,6 +402,17 @@
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/gulp": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-4.0.6.tgz",
+      "integrity": "sha512-0E8/iV/7FKWyQWSmi7jnUvgXXgaw+pfAzEB06Xu+l0iXVJppLbpOye5z7E2klw5akXd+8kPtYuk65YBcZPM4ow==",
+      "dev": true,
+      "requires": {
+        "@types/undertaker": "*",
+        "@types/vinyl-fs": "*",
+        "chokidar": "^2.1.2"
       }
     },
     "@types/http-server": {
@@ -579,6 +596,42 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
       "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
       "dev": true
+    },
+    "@types/undertaker": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/undertaker/-/undertaker-1.2.2.tgz",
+      "integrity": "sha512-j4iepCSuY2JGW/hShVtUBagic0klYNFIXP7VweavnYnNC2EjiKxJFeaS9uaJmAT0ty9sQSqTS1aagWMZMV0HyA==",
+      "dev": true,
+      "requires": {
+        "@types/undertaker-registry": "*"
+      }
+    },
+    "@types/undertaker-registry": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+      "integrity": "sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==",
+      "dev": true
+    },
+    "@types/vinyl": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.4.tgz",
+      "integrity": "sha512-2o6a2ixaVI2EbwBPg1QYLGQoHK56p/8X/sGfKbFC8N6sY9lfjsMf/GprtkQkSya0D4uRiutRZ2BWj7k3JvLsAQ==",
+      "dev": true,
+      "requires": {
+        "@types/expect": "^1.20.4",
+        "@types/node": "*"
+      }
+    },
+    "@types/vinyl-fs": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
+      "integrity": "sha512-2OzQSfIr9CqqWMGqmcERE6Hnd2KY3eBVtFaulVo3sJghplUcaeMdL9ZjEiljcQQeHjheWY9RlNmumjIAvsBNaA==",
+      "dev": true,
+      "requires": {
+        "@types/glob-stream": "*",
+        "@types/node": "*",
+        "@types/vinyl": "*"
+      }
     },
     "@types/ws": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/express": "^4.17.0",
     "@types/glob": "^7.1.1",
     "@types/glob-stream": "^6.1.0",
+    "@types/gulp": "^4.0.6",
     "@types/http-server": "^0.10.0",
     "@types/js-beautify": "^1.8.1",
     "@types/json-schema": "^7.0.3",

--- a/src/adapter/breakpointPredictor.ts
+++ b/src/adapter/breakpointPredictor.ts
@@ -42,6 +42,11 @@ export const IBreakpointsPredictor = Symbol('IBreakpointsPredictor');
  */
 export interface IBreakpointsPredictor {
   /**
+   * Gets prediction data for the given source file path, if it exists.
+   */
+  getPredictionForSource(sourceFile: string): Promise<ReadonlySet<DiscoveredMetadata> | undefined>;
+
+  /**
    * Returns a promise that resolves once maps in the root are predicted.
    */
   prepareToPredict(): Promise<void>;
@@ -238,6 +243,17 @@ export class BreakpointsPredictor implements IBreakpointsPredictor {
         this.predictedLocations.push(predicted);
       }
     }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async getPredictionForSource(sourcePath: string) {
+    if (!this.sourcePathToCompiled) {
+      this.sourcePathToCompiled = this.createInitialMapping();
+    }
+
+    return (await this.sourcePathToCompiled).get(sourcePath);
   }
 
   /**

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -635,7 +635,11 @@ export class SourceContainer {
     // of internal prefixes. If we see a duplicate entries for an absolute path,
     // take the shorter of them.
     const existingByPath = this._sourceByAbsolutePath.get(source._absolutePath);
-    if (existingByPath === undefined || existingByPath.url.length >= source.url.length) {
+    if (
+      existingByPath === undefined ||
+      existingByPath.url.length >= source.url.length ||
+      source._compiledToSourceUrl?.has(existingByPath)
+    ) {
       this._sourceByAbsolutePath.set(source._absolutePath, source);
     }
 

--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -10,6 +10,7 @@ import { IPreferredUiLocation } from './sources';
 import { RawLocation, Thread } from './threads';
 import { IExtraProperty, IScopeRef } from './variables';
 import { LogPointCompiler } from './breakpoints/conditions/logPoint';
+import { asyncScopesNotAvailable, ProtocolError } from '../dap/errors';
 
 const localize = nls.loadMessageBundle();
 
@@ -184,7 +185,9 @@ export class StackFrame {
   }
 
   async scopes(): Promise<Dap.ScopesResult> {
-    if (!this._scope) return { scopes: [] };
+    if (!this._scope) {
+      throw new ProtocolError(asyncScopesNotAvailable());
+    }
 
     const scopes: Dap.Scope[] = [];
     for (let scopeNumber = 0; scopeNumber < this._scope.chain.length; scopeNumber++) {

--- a/src/common/logging/fileLogSink.ts
+++ b/src/common/logging/fileLogSink.ts
@@ -12,7 +12,6 @@ const replacer = (_key: string, value: unknown): unknown => {
     return {
       message: value.message,
       stack: value.stack,
-      ...value,
     };
   }
 

--- a/src/common/sourcePathResolver.ts
+++ b/src/common/sourcePathResolver.ts
@@ -26,6 +26,17 @@ export const ISourcePathResolver = Symbol('ISourcePathResolver');
  */
 export interface ISourcePathResolver {
   /**
+   * Rebases a remote path to a local one using the remote and local roots.
+   * The path should should given as a filesystem path, not a URI.
+   */
+  rebaseRemoteToLocal(remotePath: string): string;
+  /**
+   * Rebases a local path to a remote one using the remote and local roots.
+   * The path should should given as a filesystem path, not a URI.
+   */
+  rebaseLocalToRemote(localPath: string): string;
+
+  /**
    * Returns whether the source map should be used to resolve a local path,
    * following the `resolveSourceMapPaths`
    */

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -129,12 +129,10 @@ export async function fetch(
     return result;
   }
 
-  if (url.startsWith('file://')) {
-    const path = fileUrlToAbsolutePath(url);
-    if (!path) throw new Error(`Can't fetch from '${url}'`);
-
+  const absolutePath = isAbsolute(url) ? url : fileUrlToAbsolutePath(url);
+  if (absolutePath) {
     return new Promise<string>((fulfill, reject) => {
-      fs.readFile(path, (err, data) => {
+      fs.readFile(absolutePath, (err, data) => {
         if (err) reject(err);
         else fulfill(data.toString());
       });

--- a/src/dap/connection.ts
+++ b/src/dap/connection.ts
@@ -183,7 +183,6 @@ export default class Connection {
           Number(process.hrtime.bigint() - receivedTime) / 1e6,
         );
       } catch (e) {
-        console.error(e);
         const format = isExternalError(e)
           ? e.message
           : `Error processing ${msg.command}: ${e.stack || e.message}`;
@@ -195,6 +194,7 @@ export default class Connection {
             body: { error: e.cause },
           });
         } else {
+          console.error(e);
           this._send({
             ...response,
             success: false,

--- a/src/dap/errors.ts
+++ b/src/dap/errors.ts
@@ -19,6 +19,7 @@ export const enum ErrorCodes {
   InvalidHitCondition,
   InvalidLogPointBreakpointSyntax,
   BrowserNotFound,
+  AsyncScopesNotAvailable,
 }
 
 export function reportToConsole(dap: Dap.Api, error: string) {
@@ -28,11 +29,11 @@ export function reportToConsole(dap: Dap.Api, error: string) {
   });
 }
 
-export function createSilentError(text: string): Dap.Error {
+export function createSilentError(text: string, code = ErrorCodes.SilentError): Dap.Error {
   return {
     __errorMarker: true,
     error: {
-      id: ErrorCodes.SilentError,
+      id: code,
       format: text,
       showUser: false,
     },
@@ -146,6 +147,15 @@ export const browserNotFound = (
 
 export const invalidLogPointSyntax = (error: string) =>
   createUserError(error, ErrorCodes.InvalidLogPointBreakpointSyntax);
+
+export const asyncScopesNotAvailable = () =>
+  createSilentError(
+    localize(
+      'asyncScopesNotAvailable',
+      'Variables not available in async stacks',
+      ErrorCodes.AsyncScopesNotAvailable,
+    ),
+  );
 
 export class ProtocolError extends Error {
   public readonly cause: Dap.Message;

--- a/src/ioc-extras.ts
+++ b/src/ioc-extras.ts
@@ -12,6 +12,11 @@ import { promises as fsPromises } from 'fs';
 export const StoragePath = Symbol('StoragePath');
 
 /**
+ * Key for the Dap.InitializeParams.
+ */
+export const IInitializeParams = Symbol('IInitializeParams');
+
+/**
  * Key for whether vs code services are available here.
  */
 export const IsVSCode = Symbol('IsVSCode');

--- a/src/targets/browser/chromeLauncher.ts
+++ b/src/targets/browser/chromeLauncher.ts
@@ -6,12 +6,14 @@ import { DebugType } from '../../common/contributionUtils';
 import { IChromeLaunchConfiguration, AnyLaunchConfiguration } from '../../configuration';
 import { injectable, inject, tagged } from 'inversify';
 import { BrowserLauncher } from './browserLauncher';
-import { StoragePath, FS, FsPromises, BrowserFinder } from '../../ioc-extras';
+import { StoragePath, FS, FsPromises, BrowserFinder, IInitializeParams } from '../../ioc-extras';
 import { ILogger } from '../../common/logging';
 import { once } from '../../common/objUtils';
 import { canAccess } from '../../common/fsUtils';
 import { ProtocolError, browserNotFound } from '../../dap/errors';
 import { IBrowserFinder, isQuality } from 'vscode-js-debug-browsers';
+import { ISourcePathResolver } from '../../common/sourcePathResolver';
+import Dap from '../../dap/api';
 
 @injectable()
 export class ChromeLauncher extends BrowserLauncher<IChromeLaunchConfiguration> {
@@ -23,8 +25,10 @@ export class ChromeLauncher extends BrowserLauncher<IChromeLaunchConfiguration> 
     protected readonly browserFinder: IBrowserFinder,
     @inject(FS)
     private readonly fs: FsPromises,
+    @inject(ISourcePathResolver) pathResolver: ISourcePathResolver,
+    @inject(IInitializeParams) initializeParams: Dap.InitializeParams,
   ) {
-    super(storagePath, logger);
+    super(storagePath, logger, pathResolver, initializeParams);
   }
 
   /**

--- a/src/targets/node/nodeSourcePathResolver.ts
+++ b/src/targets/node/nodeSourcePathResolver.ts
@@ -61,7 +61,7 @@ export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
     }
 
     if (!path.isAbsolute(url)) {
-      return properResolve(
+      url = properResolve(
         await getComputedSourceRoot(
           map.sourceRoot,
           map.metadata.compiledPath,
@@ -73,6 +73,6 @@ export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
       );
     }
 
-    return url;
+    return this.rebaseRemoteToLocal(url) || url;
   }
 }

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -99,7 +99,7 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
    * Rebases a remote path to a local one using the remote and local roots.
    * The path should should given as a filesystem path, not a URI.
    */
-  protected rebaseRemoteToLocal(remotePath: string) {
+  public rebaseRemoteToLocal(remotePath: string) {
     if (!this.options.remoteRoot || !this.options.localRoot || !this.canMapPath(remotePath)) {
       return path.resolve(remotePath);
     }
@@ -123,7 +123,7 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
    * Rebases a local path to a remote one using the remote and local roots.
    * The path should should given as a filesystem path, not a URI.
    */
-  protected rebaseLocalToRemote(localPath: string) {
+  public rebaseLocalToRemote(localPath: string) {
     if (!this.options.remoteRoot || !this.options.localRoot || !this.canMapPath(localPath)) {
       return localPath;
     }

--- a/src/targets/sourcePathResolverFactory.ts
+++ b/src/targets/sourcePathResolverFactory.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { injectable, inject } from 'inversify';
+import { AnyLaunchConfiguration } from '../configuration';
+import { ILogger } from '../common/logging';
+import { DebugType } from '../common/contributionUtils';
+import { NodeSourcePathResolver } from './node/nodeSourcePathResolver';
+import { baseURL } from './browser/browserLaunchParams';
+import { BrowserSourcePathResolver } from './browser/browserPathResolver';
+import { IInitializeParams } from '../ioc-extras';
+import Dap from '../dap/api';
+
+@injectable()
+export class SourcePathResolverFactory {
+  constructor(
+    @inject(AnyLaunchConfiguration) private readonly config: AnyLaunchConfiguration,
+    @inject(IInitializeParams) private readonly initializeParams: Dap.InitializeParams,
+    @inject(ILogger) private readonly logger: ILogger,
+  ) {}
+
+  public create() {
+    const c = this.config;
+    if (
+      c.type === DebugType.Node ||
+      c.type === DebugType.Terminal ||
+      c.type === DebugType.ExtensionHost
+    ) {
+      return new NodeSourcePathResolver(
+        {
+          resolveSourceMapLocations: c.resolveSourceMapLocations,
+          basePath: c.cwd,
+          sourceMapOverrides: c.sourceMapPathOverrides,
+          remoteRoot: c.remoteRoot,
+          localRoot: c.localRoot,
+        },
+        this.logger,
+      );
+    } else {
+      return new BrowserSourcePathResolver(
+        {
+          resolveSourceMapLocations: c.resolveSourceMapLocations,
+          baseUrl: baseURL(c),
+          localRoot: null,
+          remoteRoot: null,
+          pathMapping: { '/': c.webRoot, ...c.pathMapping },
+          sourceMapOverrides: c.sourceMapPathOverrides,
+          clientID: this.initializeParams.clientID,
+        },
+        this.logger,
+      );
+    }
+  }
+}

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -94,11 +94,7 @@ export interface ILauncher extends IDisposable {
    * result `{ blockSessionTermination: false }` if it's unable to launch
    * the given configuration, or return an error/true value as appropriate.
    */
-  launch(
-    params: AnyLaunchConfiguration,
-    context: ILaunchContext,
-    clientCapabilities: Dap.InitializeParams,
-  ): Promise<ILaunchResult>;
+  launch(params: AnyLaunchConfiguration, context: ILaunchContext): Promise<ILaunchResult>;
 
   /**
    * Terminates the debugged process. This should be idempotent.

--- a/src/test/breakpoints/breakpoints-hot-transpiled-works-in-remote-workspaces.txt
+++ b/src/test/breakpoints/breakpoints-hot-transpiled-works-in-remote-workspaces.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+triple @ ${workspaceFolder}/tsNode/double.ts:5:3

--- a/src/test/breakpoints/breakpointsTest.ts
+++ b/src/test/breakpoints/breakpointsTest.ts
@@ -621,6 +621,21 @@ describe('breakpoints', () => {
       handle.assertLog({ substring: true });
     });
 
+    itIntegrates('works in remote workspaces', async ({ r }) => {
+      await r.initialize;
+
+      const cwd = join(testWorkspace, 'tsNode');
+      const handle = await r.runScriptAsRemote(join(cwd, 'index.js'));
+      await handle.dap.setBreakpoints({
+        source: { path: join(cwd, 'double.ts') },
+        breakpoints: [{ line: 5, column: 1 }],
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      handle.assertLog({ substring: true });
+    });
+
     itIntegrates('does not adjust already correct', async ({ r }) => {
       await r.initialize;
 

--- a/src/test/logger.ts
+++ b/src/test/logger.ts
@@ -161,23 +161,27 @@ export class Logger {
       );
       if (!withScopes) continue;
       const scopes = await this._dap.scopes({ frameId: frame.id });
-      for (let i = 0; i < scopes.scopes.length; i++) {
-        const scope = scopes.scopes[i];
-        if (scope.expensive) {
-          this._log(`  scope #${i}: ${scope.name} [expensive]`);
-          continue;
+      if (typeof scopes === 'string') {
+        this._log(`  scope error: ${scopes}`);
+      } else {
+        for (let i = 0; i < scopes.scopes.length; i++) {
+          const scope = scopes.scopes[i];
+          if (scope.expensive) {
+            this._log(`  scope #${i}: ${scope.name} [expensive]`);
+            continue;
+          }
+          await this.logVariable(
+            {
+              name: 'scope #' + i,
+              value: scope.name,
+              variablesReference: scope.variablesReference,
+              namedVariables: scope.namedVariables,
+              indexedVariables: scope.indexedVariables,
+            },
+            {},
+            '  ',
+          );
         }
-        await this.logVariable(
-          {
-            name: 'scope #' + i,
-            value: scope.name,
-            variablesReference: scope.variablesReference,
-            namedVariables: scope.namedVariables,
-            indexedVariables: scope.indexedVariables,
-          },
-          {},
-          '  ',
-        );
       }
     }
 

--- a/src/test/node/node-runtime-adjusts-to-compiles-file-if-it-exists.txt
+++ b/src/test/node/node-runtime-adjusts-to-compiles-file-if-it-exists.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${workspaceFolder}/web/basic.ts:21:1

--- a/src/test/node/node-runtime.test.ts
+++ b/src/test/node/node-runtime.test.ts
@@ -113,6 +113,20 @@ describe('node runtime', () => {
     });
   });
 
+  itIntegrates('adjusts to compiles file if it exists', async ({ r }) => {
+    await r.initialize;
+
+    const handle = await r.runScript(join(testWorkspace, 'web/basic.ts'));
+    await handle.dap.setBreakpoints({
+      source: { path: handle.workspacePath('web/basic.ts') },
+      breakpoints: [{ line: 21, column: 0 }],
+    });
+    handle.load();
+
+    await waitForPause(handle);
+    handle.assertLog({ substring: true });
+  });
+
   describe('inspect flag handling', () => {
     itIntegrates('does not break with inspect flag', async ({ r }) => {
       createFileTree(testFixturesDir, { 'test.js': ['console.log("hello world");', 'debugger;'] });

--- a/src/test/stacks/stacks-async.txt
+++ b/src/test/stacks/stacks-async.txt
@@ -13,8 +13,12 @@ bar @ <eval>/VM<xx>:13:15
 
 ----async function----
 <anonymous> @ <eval>/VM<xx>:8:11
+  scope error: Variables not available in async stacks
 ----setTimeout----
 foo @ <eval>/VM<xx>:7:9
+  scope error: Variables not available in async stacks
 bar @ <eval>/VM<xx>:13:15
+  scope error: Variables not available in async stacks
 ----async function----
 <anonymous> @ <eval>/VM<xx>:15:7
+  scope error: Variables not available in async stacks

--- a/src/test/stacks/stacks-cross-target.txt
+++ b/src/test/stacks/stacks-cross-target.txt
@@ -7,5 +7,7 @@
 
 ----postMessage----
 <anonymous> @ ${workspaceFolder}/web/worker.js:6:5
+  scope error: Variables not available in async stacks
 ----Worker.postMessage----
 <anonymous> @ <eval>/VM<xx>:1:10
+  scope error: Variables not available in async stacks

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -6,6 +6,8 @@ import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
 import * as path from 'path';
 import * as stream from 'stream';
+import * as gulp from 'gulp';
+import del from 'del';
 import { DebugAdapter } from '../adapter/debugAdapter';
 import { Binder } from '../binder';
 import Cdp from '../cdp/api';
@@ -32,6 +34,8 @@ import { ILogger } from '../common/logging';
 import { createTopLevelSessionContainer, createGlobalContainer } from '../ioc';
 import { BrowserLauncher } from '../targets/browser/browserLauncher';
 import { StreamDapTransport } from '../dap/transport';
+import { tmpdir } from 'os';
+import { forceForwardSlashes } from '../common/pathUtils';
 
 export const kStabilizeNames = ['id', 'threadId', 'sourceReference', 'variablesReference'];
 
@@ -460,6 +464,60 @@ export class TestRoot {
       __workspaceFolder: this._workspaceRoot,
       ...options,
     } as INodeLaunchConfiguration);
+    const result = await new Promise(f => (this._launchCallback = f));
+    return result as NodeTestHandle;
+  }
+
+  /**
+   * Runs a script in a separate workspace (i.e. a different 'remoteRoot')
+   * from the original file, by copying the containing folder of the file
+   * into a temporary directory.
+   */
+  async runScriptAsRemote(
+    filename: string,
+    options: Partial<INodeLaunchConfiguration> = {},
+  ): Promise<NodeTestHandle> {
+    await this.initialize;
+
+    filename = path.isAbsolute(filename) ? filename : path.join(testFixturesDir, filename);
+    let tmpPath = path.join(tmpdir(), 'js-debug-test');
+    if (process.platform === 'darwin' && tmpPath.startsWith('/var/folders')) {
+      // on OSX, tmpdir is 'virtually' inside /private. os.tmpdir() omits the
+      // private prefix, but Chrome sees it, so make sure it matches here.
+      tmpPath = `/private/${tmpPath}`;
+    }
+    after(() => del(`${forceForwardSlashes(tmpPath)}/**`, { force: true }));
+
+    await new Promise((resolve, reject) =>
+      gulp
+        .src('**/*.*', { cwd: path.dirname(filename) })
+        .pipe(gulp.dest(tmpPath))
+        .on('end', resolve)
+        .on('error', reject),
+    );
+
+    this._root.dap.launch({
+      ...nodeLaunchConfigDefaults,
+      cwd: path.dirname(testFixturesDir),
+      program: path.join(tmpPath, path.basename(filename)),
+      localRoot: path.dirname(filename),
+      remoteRoot: tmpPath,
+      trace: { logFile: getLogFileForTest(this._testTitlePath) },
+      outFiles: [],
+      resolveSourceMapLocations: ['**', '!**/node_modules/**'],
+      env: {
+        NODE_PATH: [
+          process.env.NODE_PATH,
+          path.resolve(path.dirname(filename), 'node_modules'),
+          path.resolve(workspaceFolder, 'node_modules'),
+        ]
+          .filter(Boolean)
+          .join(process.platform === 'win32' ? ';' : ':'),
+      },
+      __workspaceFolder: this._workspaceRoot,
+      ...options,
+    } as INodeLaunchConfiguration);
+
     const result = await new Promise(f => (this._launchCallback = f));
     return result as NodeTestHandle;
   }


### PR DESCRIPTION
Fixes #291. Involves some churn since I wanted to avoid having to run the
breakpoint predictor twice:

- The path resolver is now created by a separate, session-level factory, rather
  than each target. This is needed since the path resolver is used in the
  predictor, which is used before we launch Node or have any targets.
- The initialize params/client capabilities are now in IOC. Cleans up a
  decent amount of code.
- Then with these changes, using the breakpoint predictor in the Node launcher
  to look up the compiled path is quite simple :P