### PR TITLE
fix: source handling with remoteRoot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -356,6 +356,12 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/expect": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
+      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
@@ -396,6 +402,17 @@
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/gulp": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-4.0.6.tgz",
+      "integrity": "sha512-0E8/iV/7FKWyQWSmi7jnUvgXXgaw+pfAzEB06Xu+l0iXVJppLbpOye5z7E2klw5akXd+8kPtYuk65YBcZPM4ow==",
+      "dev": true,
+      "requires": {
+        "@types/undertaker": "*",
+        "@types/vinyl-fs": "*",
+        "chokidar": "^2.1.2"
       }
     },
     "@types/http-server": {
@@ -579,6 +596,42 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
       "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
       "dev": true
+    },
+    "@types/undertaker": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/undertaker/-/undertaker-1.2.2.tgz",
+      "integrity": "sha512-j4iepCSuY2JGW/hShVtUBagic0klYNFIXP7VweavnYnNC2EjiKxJFeaS9uaJmAT0ty9sQSqTS1aagWMZMV0HyA==",
+      "dev": true,
+      "requires": {
+        "@types/undertaker-registry": "*"
+      }
+    },
+    "@types/undertaker-registry": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+      "integrity": "sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==",
+      "dev": true
+    },
+    "@types/vinyl": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.4.tgz",
+      "integrity": "sha512-2o6a2ixaVI2EbwBPg1QYLGQoHK56p/8X/sGfKbFC8N6sY9lfjsMf/GprtkQkSya0D4uRiutRZ2BWj7k3JvLsAQ==",
+      "dev": true,
+      "requires": {
+        "@types/expect": "^1.20.4",
+        "@types/node": "*"
+      }
+    },
+    "@types/vinyl-fs": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
+      "integrity": "sha512-2OzQSfIr9CqqWMGqmcERE6Hnd2KY3eBVtFaulVo3sJghplUcaeMdL9ZjEiljcQQeHjheWY9RlNmumjIAvsBNaA==",
+      "dev": true,
+      "requires": {
+        "@types/glob-stream": "*",
+        "@types/node": "*",
+        "@types/vinyl": "*"
+      }
     },
     "@types/ws": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/express": "^4.17.0",
     "@types/glob": "^7.1.1",
     "@types/glob-stream": "^6.1.0",
+    "@types/gulp": "^4.0.6",
     "@types/http-server": "^0.10.0",
     "@types/js-beautify": "^1.8.1",
     "@types/json-schema": "^7.0.3",

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -635,7 +635,11 @@ export class SourceContainer {
     // of internal prefixes. If we see a duplicate entries for an absolute path,
     // take the shorter of them.
     const existingByPath = this._sourceByAbsolutePath.get(source._absolutePath);
-    if (existingByPath === undefined || existingByPath.url.length >= source.url.length) {
+    if (
+      existingByPath === undefined ||
+      existingByPath.url.length >= source.url.length ||
+      source._compiledToSourceUrl?.has(existingByPath)
+    ) {
       this._sourceByAbsolutePath.set(source._absolutePath, source);
     }
 

--- a/src/common/logging/fileLogSink.ts
+++ b/src/common/logging/fileLogSink.ts
@@ -12,7 +12,6 @@ const replacer = (_key: string, value: unknown): unknown => {
     return {
       message: value.message,
       stack: value.stack,
-      ...value,
     };
   }
 

--- a/src/common/sourcePathResolver.ts
+++ b/src/common/sourcePathResolver.ts
@@ -26,6 +26,12 @@ export const ISourcePathResolver = Symbol('ISourcePathResolver');
  */
 export interface ISourcePathResolver {
   /**
+   * Rebases a remote path to a local one using the remote and local roots.
+   * The path should should given as a filesystem path, not a URI.
+   */
+  rebaseRemoteToLocal(remotePath: string): string | undefined;
+
+  /**
    * Returns whether the source map should be used to resolve a local path,
    * following the `resolveSourceMapPaths`
    */

--- a/src/common/sourcePathResolver.ts
+++ b/src/common/sourcePathResolver.ts
@@ -29,7 +29,12 @@ export interface ISourcePathResolver {
    * Rebases a remote path to a local one using the remote and local roots.
    * The path should should given as a filesystem path, not a URI.
    */
-  rebaseRemoteToLocal(remotePath: string): string | undefined;
+  rebaseRemoteToLocal(remotePath: string): string;
+  /**
+   * Rebases a local path to a remote one using the remote and local roots.
+   * The path should should given as a filesystem path, not a URI.
+   */
+  rebaseLocalToRemote(localPath: string): string;
 
   /**
    * Returns whether the source map should be used to resolve a local path,

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -129,12 +129,10 @@ export async function fetch(
     return result;
   }
 
-  if (url.startsWith('file://')) {
-    const path = fileUrlToAbsolutePath(url);
-    if (!path) throw new Error(`Can't fetch from '${url}'`);
-
+  const absolutePath = isAbsolute(url) ? url : fileUrlToAbsolutePath(url);
+  if (absolutePath) {
     return new Promise<string>((fulfill, reject) => {
-      fs.readFile(path, (err, data) => {
+      fs.readFile(absolutePath, (err, data) => {
         if (err) reject(err);
         else fulfill(data.toString());
       });

--- a/src/targets/node/nodeSourcePathResolver.ts
+++ b/src/targets/node/nodeSourcePathResolver.ts
@@ -61,7 +61,7 @@ export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
     }
 
     if (!path.isAbsolute(url)) {
-      return properResolve(
+      url = properResolve(
         await getComputedSourceRoot(
           map.sourceRoot,
           map.metadata.compiledPath,
@@ -73,6 +73,6 @@ export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
       );
     }
 
-    return url;
+    return this.rebaseRemoteToLocal(url) || url;
   }
 }

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -123,7 +123,7 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
    * Rebases a local path to a remote one using the remote and local roots.
    * The path should should given as a filesystem path, not a URI.
    */
-  protected rebaseLocalToRemote(localPath: string) {
+  public rebaseLocalToRemote(localPath: string) {
     if (!this.options.remoteRoot || !this.options.localRoot || !this.canMapPath(localPath)) {
       return localPath;
     }

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -99,7 +99,7 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
    * Rebases a remote path to a local one using the remote and local roots.
    * The path should should given as a filesystem path, not a URI.
    */
-  protected rebaseRemoteToLocal(remotePath: string) {
+  public rebaseRemoteToLocal(remotePath: string) {
     if (!this.options.remoteRoot || !this.options.localRoot || !this.canMapPath(remotePath)) {
       return path.resolve(remotePath);
     }

--- a/src/test/breakpoints/breakpoints-hot-transpiled-works-in-remote-workspaces.txt
+++ b/src/test/breakpoints/breakpoints-hot-transpiled-works-in-remote-workspaces.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+triple @ ${workspaceFolder}/tsNode/double.ts:5:3

--- a/src/test/breakpoints/breakpointsTest.ts
+++ b/src/test/breakpoints/breakpointsTest.ts
@@ -621,6 +621,21 @@ describe('breakpoints', () => {
       handle.assertLog({ substring: true });
     });
 
+    itIntegrates.only('works in remote workspaces', async ({ r }) => {
+      await r.initialize;
+
+      const cwd = join(testWorkspace, 'tsNode');
+      const handle = await r.runScriptAsRemote(join(cwd, 'index.js'));
+      await handle.dap.setBreakpoints({
+        source: { path: join(cwd, 'double.ts') },
+        breakpoints: [{ line: 5, column: 1 }],
+      });
+
+      handle.load();
+      await waitForPause(handle);
+      handle.assertLog({ substring: true });
+    });
+
     itIntegrates('does not adjust already correct', async ({ r }) => {
       await r.initialize;
 

--- a/src/test/breakpoints/breakpointsTest.ts
+++ b/src/test/breakpoints/breakpointsTest.ts
@@ -621,7 +621,7 @@ describe('breakpoints', () => {
       handle.assertLog({ substring: true });
     });
 
-    itIntegrates.only('works in remote workspaces', async ({ r }) => {
+    itIntegrates('works in remote workspaces', async ({ r }) => {
       await r.initialize;
 
       const cwd = join(testWorkspace, 'tsNode');

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -480,7 +480,12 @@ export class TestRoot {
     await this.initialize;
 
     filename = path.isAbsolute(filename) ? filename : path.join(testFixturesDir, filename);
-    const tmpPath = path.join(tmpdir(), 'js-debug-test');
+    let tmpPath = path.join(tmpdir(), 'js-debug-test');
+    if (process.platform === 'darwin' && tmpPath.startsWith('/var/folders')) {
+      // on OSX, tmpdir is 'virtually' inside /private. os.tmpdir() omits the
+      // private prefix, but Chrome sees it, so make sure it matches here.
+      tmpPath = `/private/${tmpPath}`;
+    }
     after(() => del(`${forceForwardSlashes(tmpPath)}/**`, { force: true }));
 
     await new Promise((resolve, reject) =>


### PR DESCRIPTION
Fixes #383. There were a two things that caused issues attaching to
remote processes:

1. We requested sourcemaps from their remote location, which doesn't
   exist locally. This PR rebases the path correctly.
2. We used url length as the heuristic for which to narrow the 'correct'
   file at an absolute path. With a different remote root, though, the
   urls might be totally different. We now also check whether the
   original path is the sourcemap parent of the generated path. This was
   the problem in the linked issue, where ts-node was used.