### PR TITLE
Add inspectUri parameter to Node target

### DIFF
--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -358,6 +358,11 @@ const nodeAttachConfig: IDebugger<INodeAttachConfiguration> = {
       markdownDescription: refString('node.attach.continueOnAttach'),
       default: true,
     },
+    inspectUri: {
+      type: ['string', 'null'],
+      description: refString('node.inspectUri.description'),
+      default: null,
+    },
   },
 };
 

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -174,6 +174,12 @@ const strings = {
   'node.stopOnEntry.description': 'Automatically stop program after launch.',
   'node.timeout.description':
     'Retry for this number of milliseconds to connect to Node.js. Default is 10000 ms.',
+  'node.inspectUri.description':
+    "Format to use to rewrite the inspectUri: It's a template string that interpolates keys in `{curlyBraces}`. Available keys are:\n" +
+    ' - `url.*` is the parsed address of the running application. For instance, `{url.port}`, `{url.hostname}`\n' +
+    ' - `port` is the debug port that Node.js is listening on.\n' +
+    ' - `browserInspectUri` is the inspector URI on the launched browser\n' +
+    ' - `wsProtocol` is the hinted websocket protocol. This is set to `wss` if the original URL is `https`, or `ws` otherwise.\n',
 
   'longPredictionWarning.message':
     "It's taking a while to configure your breakpoints. You can speed this up by updating the 'outFiles' in your launch.json.",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -389,7 +389,7 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
 
   /**
    * Whether to automatically resume processes if we see they were launched
-   * with `--inpect-brk`.
+   * with `--inspect-brk`.
    */
   continueOnAttach: boolean;
 
@@ -399,7 +399,7 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
    *
    *  - `url.*` is the parsed address of the running application. For instance,
    *    `{url.port}`, `{url.hostname}`
-   *  - `port` is the debug port that Chrome is listening on.
+   *  - `port` is the debug port that Node.js is listening on.
    *  - `browserInspectUri` is the inspector URI on the launched browser
    *  - `wsProtocol` is the hinted websocket protocol. This is set to `wss` if
    *    the original URL is `https`, or `ws` otherwise.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -392,6 +392,19 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
    * with `--inpect-brk`.
    */
   continueOnAttach: boolean;
+
+  /**
+   * WebSocket (`ws://`) address of the inspector. It's a template string that
+   * interpolates keys in `{curlyBraces}`. Available keys are:
+   *
+   *  - `url.*` is the parsed address of the running application. For instance,
+   *    `{url.port}`, `{url.hostname}`
+   *  - `port` is the debug port that Chrome is listening on.
+   *  - `browserInspectUri` is the inspector URI on the launched browser
+   *  - `wsProtocol` is the hinted websocket protocol. This is set to `wss` if
+   *    the original URL is `https`, or `ws` otherwise.
+   */
+  inspectUri?: string | null;
 }
 
 interface IChromiumLaunchConfiguration extends IChromiumBaseConfiguration {

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -20,6 +20,7 @@ import { NodePathProvider } from './nodePathProvider';
 import { IStopMetadata } from '../targets';
 import { injectable } from 'inversify';
 import { retryGetWSEndpoint } from '../browser/spawn/endpoints';
+import { constructInspectorWSUri } from '../browser/constructInspectorWSUri';
 
 const localize = nls.loadMessageBundle();
 
@@ -68,11 +69,19 @@ export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
         }
       }
 
+      let inspectWs = "";
+      if (runData.params.inspectUri) {
+        inspectWs = constructInspectorWSUri(
+          runData.params.inspectUri,
+          `http://localhost:${runData.params.port}`,
+          inspectorURL);
+      }
+
       const program = (this.program = new SubprocessProgram(
         spawnWatchdog(await this.resolveNodePath(runData.params), {
           ipcAddress: runData.serverAddress,
           scriptName: 'Remote Process',
-          inspectorURL,
+          inspectorURL: inspectWs || inspectorURL,
           waitForDebugger: true,
           dynamicAttach: true,
         }),

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -69,12 +69,13 @@ export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
         }
       }
 
-      let inspectWs = "";
+      let inspectWs = '';
       if (runData.params.inspectUri) {
         inspectWs = constructInspectorWSUri(
           runData.params.inspectUri,
           `http://localhost:${runData.params.port}`,
-          inspectorURL);
+          inspectorURL,
+        );
       }
 
       const program = (this.program = new SubprocessProgram(


### PR DESCRIPTION
#345 
This is a probable implementation of support of `inspectUri` parameter for Node attach scenario.
It can be used the following way:
```
{
    "type": "pwa-node",
    "request": "attach",
    "name": "Attach",
    "port": 40324,
    "inspectUri": "ws://127.0.0.1:13602?browser={browserInspectUri}"
}
```