### PR TITLE
feat: initial work on profiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,9 @@
     "onCommand:extension.NAMESPACE(chrome-debug).removeAllCustomBreakpoints",
     "onCommand:extension.NAMESPACE(chrome-debug).removeCustomBreakpoint",
     "onDebugResolve:NAMESPACE(msedge)",
-    "onDebugResolve:NAMESPACE(extensionHost)"
+    "onDebugResolve:NAMESPACE(extensionHost)",
+    "onCommand:extension.NAMESPACE(node-debug).startProfile",
+    "onCommand:extension.NAMESPACE(node-debug).stopProfile"
   ],
   "extensionKind": [
     "workspace"
@@ -231,6 +233,16 @@
         "command": "extension.NAMESPACE(node-debug).createDebuggerTerminal",
         "title": "%debug.terminal.label%",
         "category": "Debug"
+      },
+      {
+        "command": "extension.NAMESPACE(node-debug).startProfile",
+        "title": "%profile.start%",
+        "category": "Debug"
+      },
+      {
+        "command": "extension.NAMESPACE(node-debug).stopProfile",
+        "title": "%profile.stop%",
+        "category": "Debug"
       }
     ],
     "menus": {
@@ -239,6 +251,16 @@
           "command": "extension.NAMESPACE(node-debug).prettyPrint",
           "title": "%pretty.print.script%",
           "when": "inDebugMode && debugType == NAMESPACE(chrome) && editorLangId == javascript"
+        },
+        {
+          "command": "extension.NAMESPACE(node-debug).startProfile",
+          "title": "%profile.start%",
+          "when": "inDebugMode && debugType == NAMESPACE(chrome)"
+        },
+        {
+          "command": "extension.NAMESPACE(node-debug).stopProfile",
+          "title": "%profile.stop%",
+          "when": "inDebugMode && debugType == NAMESPACE(chrome)"
         }
       ],
       "debug/callstack/context": [
@@ -250,7 +272,12 @@
         {
           "command": "extension.NAMESPACE(node-debug).toggleSkippingFile",
           "group": "navigation",
-          "when": "inDebugMode && debugType == NAMESPACE(chrome) && callStackItemType == 'stackFrame'"
+          "when": "inDebugMode && debugType == NAMESPACE(chrome) && callStackItemType == 'session'"
+        },
+        {
+          "command": "extension.NAMESPACE(node-debug).startProfile",
+          "icon": "watch",
+          "group": "navigation"
         }
       ],
       "view/title": [

--- a/scripts/dap-custom.json
+++ b/scripts/dap-custom.json
@@ -386,6 +386,116 @@
           "required": ["event", "body"]
         }
       ]
+    },
+
+    "StartProfileRequest": {
+      "allOf": [
+        { "$ref": "#/definitions/Request" },
+        {
+          "type": "object",
+          "description": "Starts taking a profile of the target.",
+          "properties": {
+            "command": {
+              "type": "string",
+              "enum": ["startProfile"]
+            },
+            "arguments": {
+              "$ref": "#/definitions/StartProfileArguments"
+            }
+          },
+          "required": ["command", "arguments"]
+        }
+      ]
+    },
+    "StartProfileArguments": {
+      "type": "object",
+      "description": "Arguments for 'StartProfile' request.",
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Location where the profile should be saved."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of profile that should be taken"
+        },
+        "params": {
+          "type": "object",
+          "description": "Additional arguments for the type of profiler"
+        }
+      },
+      "required": ["file", "type"]
+    },
+    "StartProfileResponse": {
+      "allOf": [
+        { "$ref": "#/definitions/Response" },
+        {
+          "type": "object",
+          "description": "Response to 'StartProfile' request."
+        }
+      ]
+    },
+
+    "StopProfileRequest": {
+      "allOf": [
+        { "$ref": "#/definitions/Request" },
+        {
+          "type": "object",
+          "description": "Stops a running profile.",
+          "properties": {
+            "command": {
+              "type": "string",
+              "enum": ["stopProfile"]
+            },
+            "arguments": {
+              "$ref": "#/definitions/StopProfileArguments"
+            }
+          },
+          "required": ["command", "arguments"]
+        }
+      ]
+    },
+    "StopProfileArguments": {
+      "type": "object",
+      "description": "Arguments for 'StopProfile' request.",
+      "properties": {}
+    },
+    "StopProfileResponse": {
+      "allOf": [
+        { "$ref": "#/definitions/Response" },
+        {
+          "type": "object",
+          "description": "Response to 'StopProfile' request."
+        }
+      ]
+    },
+
+    "ProfilerStateUpdateEvent": {
+      "allOf": [
+        { "$ref": "#/definitions/Event" },
+        {
+          "type": "object",
+          "description": "Fired when a profiling state changes.",
+          "properties": {
+            "event": {
+              "type": "string",
+              "enum": ["profilerStateUpdate"]
+            },
+            "body": {
+              "type": "object",
+              "description": "Body for 'ProfilerStateUpdateEvent' event.",
+              "required": ["label"],
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Description of the current state"
+                }
+              }
+            }
+          },
+          "required": ["event", "body"]
+        }
+      ]
     }
   }
 }

--- a/scripts/generate-cdp-api.js
+++ b/scripts/generate-cdp-api.js
@@ -2,6 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+const prettier = require('prettier');
 const path = require('path');
 const fs = require('fs');
 
@@ -15,22 +16,30 @@ function fetch(url) {
   const request = driver.get(url, response => {
     let data = '';
     response.setEncoding('utf8');
-    response.on('data', chunk => data += chunk);
+    response.on('data', chunk => (data += chunk));
     response.on('end', () => fulfill(data));
     response.on('error', reject);
   });
   request.on('error', reject);
   return promise;
-};
+}
 
 function toTitleCase(s) {
   return s[0].toUpperCase() + s.substr(1);
 }
 
 async function generate() {
-  const jsProtocol = JSON.parse(await fetch('https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/master/json/js_protocol.json'));
-  const browserProtocol = JSON.parse(await fetch('https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/master/json/browser_protocol.json'));
-  const compareDomains = (a, b) => a.domain.toUpperCase() < b.domain.toUpperCase() ? -1 : 1;
+  const jsProtocol = JSON.parse(
+    await fetch(
+      'https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/master/json/js_protocol.json',
+    ),
+  );
+  const browserProtocol = JSON.parse(
+    await fetch(
+      'https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/master/json/browser_protocol.json',
+    ),
+  );
+  const compareDomains = (a, b) => (a.domain.toUpperCase() < b.domain.toUpperCase() ? -1 : 1);
   const domains = jsProtocol.domains.concat(browserProtocol.domains).sort(compareDomains);
   const result = [];
   const interfaceSeparator = createSeparator();
@@ -45,47 +54,54 @@ async function generate() {
   result.push(`import { IDisposable } from '../common/disposable'; `);
   result.push(``);
   result.push(`export namespace Cdp {`);
-  result.push(`  export type integer = number;`);
+  result.push(`export type integer = number;`);
   interfaceSeparator();
 
-  function appendText(text, indent) {
-    if (!text)
-      return;
-    result.push(`${indent}/**`);
-    for (const line of text.split('\n'))
-      result.push(`${indent} * ${line}`);
-    result.push(`${indent} */`);
+  function appendText(text, tags = {}) {
+    for (const key of Object.keys(tags)) {
+      const value = tags[key];
+      if (!value) {
+        continue;
+      }
+
+      text += `\n@${key}`;
+      if (typeof value === 'string') {
+        text += ` ${value}`;
+      }
+    }
+
+    if (!text) return;
+    result.push('/**');
+    for (const line of text.split('\n')) result.push(` * ${line}`);
+    result.push(' */');
   }
 
   function createSeparator() {
     let first = true;
     return function() {
-      if (!first)
-        result.push(``);
+      if (!first) result.push('');
       first = false;
-    }
+    };
   }
 
   function generateType(prop) {
     if (prop.type === 'string' && prop.enum)
       return `${prop.enum.map(value => `'${value}'`).join(' | ')}`;
-    if (prop['$ref'])
-      return prop['$ref'];
+    if (prop['$ref']) return prop['$ref'];
     if (prop.type === 'array') {
       const subtype = prop.items ? generateType(prop.items) : 'any';
       return `${subtype}[]`;
     }
-    if (prop.type === 'object')
-      return 'any';
+    if (prop.type === 'object') return 'any';
     return prop.type;
   }
 
-  function appendProps(props, indent) {
+  function appendProps(props) {
     const separator = createSeparator();
     for (const prop of props) {
       separator();
-      appendText(prop.description, indent);
-      result.push(`${indent}${prop.name}${prop.optional ? '?' : ''}: ${generateType(prop)};`);
+      appendText(prop.description, { deprecated: prop.deprecated });
+      result.push(`${prop.name}${prop.optional ? '?' : ''}: ${generateType(prop)};`);
     }
   }
 
@@ -96,79 +112,85 @@ async function generate() {
     const types = domain.types || [];
     const name = toTitleCase(domain.domain);
     interfaceSeparator();
-    appendText(`Methods and events of the '${name}' domain.`, '  ');
-    result.push(`  export interface ${name}Api {`);
+    appendText(`Methods and events of the '${name}' domain.`);
+    result.push(`export interface ${name}Api {`);
     for (const command of commands) {
       apiSeparator();
-      appendText(command.description, '    ');
-      result.push(`    ${command.name}(params: ${name}.${toTitleCase(command.name)}Params): Promise<${name}.${toTitleCase(command.name)}Result | undefined>;`);
+      appendText(command.description, { deprecated: command.deprecated });
+      result.push(
+        `${command.name}(params: ${name}.${toTitleCase(
+          command.name,
+        )}Params): Promise<${name}.${toTitleCase(command.name)}Result | undefined>;`,
+      );
     }
     for (const event of events) {
       apiSeparator();
-      appendText(event.description, '    ');
-      result.push(`    on(event: '${event.name}', listener: (event: ${name}.${toTitleCase(event.name)}Event) => void): IDisposable;`);
+      appendText(event.description, { deprecated: event.deprecated });
+      result.push(
+        `on(event: '${event.name}', listener: (event: ${name}.${toTitleCase(
+          event.name,
+        )}Event) => void): IDisposable;`,
+      );
     }
-    result.push(`  }`);
+    result.push(`}`);
 
     const typesSeparator = createSeparator();
     interfaceSeparator();
-    appendText(`Types of the '${name}' domain.`, '  ');
-    result.push(`  export namespace ${name} {`);
+    appendText(`Types of the '${name}' domain.`);
+    result.push(`export namespace ${name} {`);
     for (const command of commands) {
       typesSeparator();
-      appendText(`Parameters of the '${name}.${command.name}' method.`, '    ');
-      result.push(`    export interface ${toTitleCase(command.name)}Params {`);
+      appendText(`Parameters of the '${name}.${command.name}' method.`);
+      result.push(`export interface ${toTitleCase(command.name)}Params {`);
       appendProps(command.parameters || [], '      ');
-      result.push(`    }`);
+      result.push(`}`);
       typesSeparator();
-      appendText(`Return value of the '${name}.${command.name}' method.`, '    ');
-      result.push(`    export interface ${toTitleCase(command.name)}Result {`);
+      appendText(`Return value of the '${name}.${command.name}' method.`);
+      result.push(`export interface ${toTitleCase(command.name)}Result {`);
       appendProps(command.returns || [], '      ');
-      result.push(`    }`);
+      result.push(`}`);
     }
     for (const event of events) {
       typesSeparator();
-      appendText(`Parameters of the '${name}.${event.name}' event.`, '    ');
-      result.push(`    export interface ${toTitleCase(event.name)}Event {`);
+      appendText(`Parameters of the '${name}.${event.name}' event.`);
+      result.push(`export interface ${toTitleCase(event.name)}Event {`);
       appendProps(event.parameters || [], '      ');
-      result.push(`    }`);
+      result.push(`}`);
     }
     for (const type of types) {
       typesSeparator();
-      appendText(type.description, '    ');
+      appendText(type.description, { deprecated: type.deprecated });
       if (type.type === 'object') {
-        result.push(`    export interface ${toTitleCase(type.id)} {`);
-        if (type.properties)
-          appendProps(type.properties, '      ');
-        else
-          result.push(`      [key: string]: any;`);
-        result.push(`    }`);
+        result.push(`export interface ${toTitleCase(type.id)} {`);
+        if (type.properties) appendProps(type.properties, '      ');
+        else result.push(`[key: string]: any;`);
+        result.push(`}`);
       } else {
-        result.push(`    export type ${toTitleCase(type.id)} = ${generateType(type)};`);
+        result.push(`export type ${toTitleCase(type.id)} = ${generateType(type)};`);
       }
     }
-    result.push(`  }`);
+    result.push(`}`);
   }
 
   function appendPauseResume() {
-    result.push(`    /**`);
-    result.push(`     * Pauses events being sent through the aPI.`);
-    result.push(`     */`);
-    result.push(`    pause(): void;`);
-    result.push(`    /**`);
-    result.push(`     * Resumes previously-paused events`);
-    result.push(`     */`);
-    result.push(`    resume(): void;`);
+    result.push(`/**`);
+    result.push(` * Pauses events being sent through the aPI.`);
+    result.push(` */`);
+    result.push(`pause(): void;`);
+    result.push(`/**`);
+    result.push(` * Resumes previously-paused events`);
+    result.push(` */`);
+    result.push(`resume(): void;`);
   }
 
   interfaceSeparator();
-  appendText('Protocol API.', '  ');
-  result.push(`  export interface Api {`);
+  appendText('Protocol API.');
+  result.push(`export interface Api {`);
   appendPauseResume();
   domains.forEach(d => {
-    result.push(`    ${d.domain}: ${d.domain}Api;`)
+    result.push(`${d.domain}: ${d.domain}Api;`);
   });
-  result.push(`  }`);
+  result.push(`}`);
 
   domains.forEach(d => appendDomain(d));
 
@@ -178,8 +200,14 @@ async function generate() {
   result.push(``);
 
   const fileName = path.join(__dirname, '../src/cdp/api.d.ts');
-  fs.writeFileSync(fileName, result.join('\n'), {encoding: 'utf-8'});
+  fs.writeFileSync(
+    fileName,
+    prettier.format(result.join('\n'), {
+      parser: 'typescript',
+      ...require('../package.json').prettier,
+    }),
+    { encoding: 'utf-8' },
+  );
 }
 
 generate();
-

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -27,6 +27,7 @@ import { IBreakpointsPredictor } from './breakpointPredictor';
 import { disposeContainer } from '../ioc-extras';
 import { ICompletions } from './completions';
 import { IEvaluator } from './evaluator';
+import { IProfileController } from './profileController';
 
 const localize = nls.loadMessageBundle();
 
@@ -83,6 +84,8 @@ export class DebugAdapter implements IDisposable {
         breakpoints: await this.breakpointManager.getBreakpointLocations(thread, params),
       })),
     );
+
+    _services.get<IProfileController>(IProfileController).connect(this.dap);
 
     this.sourceContainer = new SourceContainer(
       this.dap,

--- a/src/adapter/profileController.ts
+++ b/src/adapter/profileController.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { injectable, inject } from 'inversify';
+import Cdp from '../cdp/api';
+import { ICdpApi } from '../cdp/connection';
+import Dap from '../dap/api';
+import { IProfilerFactory, IProfile } from './profiling';
+import { ProtocolError, invalidConcurrentProfile } from '../dap/errors';
+
+/**
+ * Provides profiling functionality for the debug adapter.
+ */
+export interface IProfileController {
+  connect(dap: Dap.Api): void;
+}
+
+export const IProfileController = Symbol('IProfileController');
+
+@injectable()
+export class ProfileController implements IProfileController {
+  private profile?: Promise<IProfile>;
+
+  constructor(
+    @inject(ICdpApi) private readonly cdp: Cdp.Api,
+    @inject(IProfilerFactory) private readonly factory: IProfilerFactory,
+  ) {}
+
+  connect(dap: Dap.Api) {
+    dap.on('startProfile', async params => {
+      if (this.profile) {
+        throw new ProtocolError(invalidConcurrentProfile());
+      }
+
+      this.profile = this.startProfile(dap, params).catch(err => {
+        this.profile = undefined;
+        throw err;
+      });
+
+      return this.profile;
+    });
+
+    dap.on('stopProfile', async () => {
+      const profile = await this.profile?.catch(() => undefined);
+      await profile?.stop();
+      this.profile = undefined;
+      return {};
+    });
+  }
+
+  private async startProfile(dap: Dap.Api, params: Dap.StartProfileParams) {
+    await this.cdp.Debugger.disable({});
+    const profile = await this.factory.get(params.type).start(params);
+    profile.onUpdate(label => dap.profilerStateUpdate({ label }));
+    profile.onStop(() => this.stopProfile(profile));
+    return profile;
+  }
+
+  private async stopProfile(profile: IProfile) {
+    await this.cdp.Debugger.enable({});
+    profile.dispose();
+  }
+}

--- a/src/adapter/profiling/basicProfiler.ts
+++ b/src/adapter/profiling/basicProfiler.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IProfiler, StartProfileParams, IProfile } from '.';
+import * as nls from 'vscode-nls';
+import { injectable, inject } from 'inversify';
+import Cdp from '../../cdp/api';
+import { ICdpApi } from '../../cdp/connection';
+import { EventEmitter } from '../../common/events';
+import { ProtocolError, profileCaptureError } from '../../dap/errors';
+import { FS, FsPromises } from '../../ioc-extras';
+
+const localize = nls.loadMessageBundle();
+
+export interface IBasicProfileParams {
+  precise: boolean;
+}
+
+/**
+ * Basic profiler that uses the stable CPU `Profiler` API available everywhere.
+ * In Chrome, and probably in Node, this will be superceded by the Tracing API.
+ */
+@injectable()
+export class BasicCpuProfiler implements IProfiler<IBasicProfileParams> {
+  public static readonly type = 'cpu';
+  public static readonly extension = '.cpuprofile';
+  public static readonly label = localize('profile.cpu.label', 'CPU Profile');
+  public static readonly description = localize(
+    'profile.cpu.description',
+    'Generates a .cpuprofile file you can open in the Chrome devtools',
+  );
+
+  public static canApplyTo() {
+    return true; // this API is stable in all targets
+  }
+
+  constructor(
+    @inject(ICdpApi) private readonly cdp: Cdp.Api,
+    @inject(FS) private readonly fs: FsPromises,
+  ) {}
+
+  /**
+   * @inheritdoc
+   */
+  public async start(options: StartProfileParams<IBasicProfileParams>) {
+    await this.cdp.Profiler.enable({});
+
+    if (!(await this.cdp.Profiler.start({}))) {
+      throw new ProtocolError(profileCaptureError());
+    }
+
+    return new BasicProfile(this.cdp, this.fs, options);
+  }
+}
+
+class BasicProfile implements IProfile {
+  private readonly stopEmitter = new EventEmitter<void>();
+  private disposed = false;
+
+  /**
+   * @inheritdoc
+   */
+  public readonly onUpdate = new EventEmitter<string>().event;
+
+  /**
+   * @inheritdoc
+   */
+  public readonly onStop = this.stopEmitter.event;
+
+  constructor(
+    private readonly cdp: Cdp.Api,
+    private readonly fs: FsPromises,
+    private readonly options: StartProfileParams<IBasicProfileParams>,
+  ) {}
+
+  /**
+   * @inheritdoc
+   */
+  public async dispose() {
+    if (!this.disposed) {
+      this.disposed = true;
+      await this.cdp.Profiler.disable({});
+      this.stopEmitter.fire();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async stop() {
+    const result = await this.cdp.Profiler.stop({});
+    if (!result) {
+      throw new ProtocolError(profileCaptureError());
+    }
+
+    await this.dispose();
+    await this.fs.writeFile(this.options.file, JSON.stringify(result.profile));
+  }
+}

--- a/src/adapter/profiling/index.ts
+++ b/src/adapter/profiling/index.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Event } from 'vscode';
+import { IDisposable } from '../../common/disposable';
+import Dap from '../../dap/api';
+import { AnyLaunchConfiguration } from '../../configuration';
+import { BasicCpuProfiler } from './basicProfiler';
+import { inject, Container, injectable } from 'inversify';
+import { IContainer } from '../../ioc-extras';
+
+/**
+ * Single profile returned from the IProfiler as a RAII.
+ */
+export interface IProfile extends IDisposable {
+  /**
+   * Event that fires to show profile information data to the user.
+   */
+  readonly onUpdate: Event<string>;
+
+  /**
+   * Event that fires when the profiling is stopped for any reason.
+   */
+  readonly onStop: Event<void>;
+
+  /**
+   * Gracefully stops the profiling operation.
+   */
+  stop(): Promise<void>;
+}
+
+export type StartProfileParams<T> = Dap.StartProfileParams & { params?: T };
+
+export interface IProfiler<T> {
+  /**
+   * Starts capturing a profile.
+   */
+  start(options: StartProfileParams<T>): Promise<IProfile>;
+}
+
+export interface IProfilerCtor {
+  new (...args: never[]): IProfiler<unknown>;
+
+  /**
+   * Profiler type given in the DAP API.
+   */
+  readonly type: string;
+
+  /**
+   * Default extension for profiles created from this profiler.
+   */
+  readonly extension: string;
+
+  /**
+   * User-readable profiler name.
+   */
+  readonly label: string;
+
+  /**
+   * Optional user-readable description of the profiler.
+   */
+  readonly description?: string;
+
+  /**
+   * Returns whether this profiler can apply to the given target,
+   */
+  canApplyTo(options: AnyLaunchConfiguration): boolean;
+}
+
+export const IProfilerFactory = Symbol('IProfilerFactory');
+
+export interface IProfilerFactory {
+  /**
+   * Gets an appropriate profiler for the start params.
+   * @throws Error if the type is unrecognized
+   */
+  get<T>(type: string): IProfiler<T>;
+}
+
+/**
+ * Simple class that gets profilers
+ */
+@injectable()
+export class ProfilerFactory implements IProfilerFactory {
+  public static readonly ctors: ReadonlyArray<IProfilerCtor> = [BasicCpuProfiler];
+
+  constructor(@inject(IContainer) private readonly container: Container) {}
+
+  public get<T>(type: string): IProfiler<T> {
+    const ctor = ProfilerFactory.ctors.find(p => p.type === type);
+    if (!ctor) {
+      throw new Error(`Invalid profilter type ${type}`);
+    }
+
+    return this.container.get(ctor);
+  }
+}

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1064,6 +1064,10 @@ export class Thread implements IVariableStoreDelegate {
   }
 
   private _onScriptParsed(event: Cdp.Debugger.ScriptParsedEvent) {
+    if (this._scripts.has(event.scriptId)) {
+      return;
+    }
+
     if (event.url) event.url = this._delegate.scriptUrlToUrl(event.url);
 
     let urlHashMap = this._scriptSources.get(event.url);

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -206,6 +206,9 @@ const strings = {
     'Whether to suggest pretty printing JavaScript code that looks minified when you step into it.',
   'configuration.automaticallyTunnelRemoteServer':
     'When debugging a remote web app, configures whether to automatically tunnel the remote server to your local machine.',
+
+  'profile.start': 'Take Performance Profile',
+  'profile.stop': 'Stop Performance Profile',
 };
 
 export default strings;

--- a/src/cdp/api.d.ts
+++ b/src/cdp/api.d.ts
@@ -1091,6 +1091,19 @@ export namespace Cdp {
     getEncodedResponse(
       params: Audits.GetEncodedResponseParams,
     ): Promise<Audits.GetEncodedResponseResult | undefined>;
+
+    /**
+     * Disables issues domain, prevents further issues from being reported to the client.
+     */
+    disable(params: Audits.DisableParams): Promise<Audits.DisableResult | undefined>;
+
+    /**
+     * Enables issues domain, sends the issues collected so far to the client by means of the
+     * `issueAdded` event.
+     */
+    enable(params: Audits.EnableParams): Promise<Audits.EnableResult | undefined>;
+
+    on(event: 'issueAdded', listener: (event: Audits.IssueAddedEvent) => void): IDisposable;
   }
 
   /**
@@ -1140,6 +1153,37 @@ export namespace Cdp {
        * Size after re-encoding.
        */
       encodedSize: integer;
+    }
+
+    /**
+     * Parameters of the 'Audits.disable' method.
+     */
+    export interface DisableParams {}
+
+    /**
+     * Return value of the 'Audits.disable' method.
+     */
+    export interface DisableResult {}
+
+    /**
+     * Parameters of the 'Audits.enable' method.
+     */
+    export interface EnableParams {}
+
+    /**
+     * Return value of the 'Audits.enable' method.
+     */
+    export interface EnableResult {}
+
+    /**
+     * Parameters of the 'Audits.issueAdded' event.
+     */
+    export interface IssueAddedEvent {
+      issue: Issue;
+    }
+
+    export interface Issue {
+      code: string;
     }
   }
 
@@ -3776,6 +3820,7 @@ export namespace Cdp {
 
     /**
      * This command is deprecated. Use getScriptSource instead.
+     * @deprecated
      */
     getWasmBytecode(
       params: Debugger.GetWasmBytecodeParams,
@@ -3793,6 +3838,10 @@ export namespace Cdp {
      */
     pause(params: Debugger.PauseParams): Promise<Debugger.PauseResult | undefined>;
 
+    /**
+     * undefined
+     * @deprecated
+     */
     pauseOnAsyncCall(
       params: Debugger.PauseOnAsyncCallParams,
     ): Promise<Debugger.PauseOnAsyncCallResult | undefined>;
@@ -4254,7 +4303,16 @@ export namespace Cdp {
     /**
      * Parameters of the 'Debugger.resume' method.
      */
-    export interface ResumeParams {}
+    export interface ResumeParams {
+      /**
+       * Set to true to terminate execution upon resuming execution. In contrast
+       * to Runtime.terminateExecution, this will allows to execute further
+       * JavaScript (i.e. via evaluation) until execution of the paused code
+       * is actually resumed, at which point termination is triggered.
+       * If execution is currently not paused, this parameter has no effect.
+       */
+      terminateOnResume?: boolean;
+    }
 
     /**
      * Return value of the 'Debugger.resume' method.
@@ -4713,6 +4771,7 @@ export namespace Cdp {
 
       /**
        * Never present, will be removed.
+       * @deprecated
        */
       asyncCallStackTraceId?: Runtime.StackTraceId;
     }
@@ -5115,6 +5174,15 @@ export namespace Cdp {
      * objects, can be used for automation.
      */
     describeNode(params: DOM.DescribeNodeParams): Promise<DOM.DescribeNodeResult | undefined>;
+
+    /**
+     * Scrolls the specified rect of the given node into view if not already visible.
+     * Note: exactly one between nodeId, backendNodeId and objectId should be passed
+     * to identify the node.
+     */
+    scrollIntoViewIfNeeded(
+      params: DOM.ScrollIntoViewIfNeededParams,
+    ): Promise<DOM.ScrollIntoViewIfNeededResult | undefined>;
 
     /**
      * Disables DOM agent for the given page.
@@ -5573,6 +5641,37 @@ export namespace Cdp {
        */
       node: Node;
     }
+
+    /**
+     * Parameters of the 'DOM.scrollIntoViewIfNeeded' method.
+     */
+    export interface ScrollIntoViewIfNeededParams {
+      /**
+       * Identifier of the node.
+       */
+      nodeId?: NodeId;
+
+      /**
+       * Identifier of the backend node.
+       */
+      backendNodeId?: BackendNodeId;
+
+      /**
+       * JavaScript object id of the node wrapper.
+       */
+      objectId?: Runtime.RemoteObjectId;
+
+      /**
+       * The rect to be scrolled into view, relative to the node's border box, in CSS pixels.
+       * When omitted, center of the node will be used, similar to Element.scrollIntoView.
+       */
+      rect?: Rect;
+    }
+
+    /**
+     * Return value of the 'DOM.scrollIntoViewIfNeeded' method.
+     */
+    export interface ScrollIntoViewIfNeededResult {}
 
     /**
      * Parameters of the 'DOM.disable' method.
@@ -7305,6 +7404,7 @@ export namespace Cdp {
      * template contents, and imported documents) in a flattened array, as well as layout and
      * white-listed computed style information for the nodes. Shadow DOM in the returned DOM tree is
      * flattened.
+     * @deprecated
      */
     getSnapshot(
       params: DOMSnapshot.GetSnapshotParams,
@@ -8208,6 +8308,13 @@ export namespace Cdp {
     ): Promise<Emulation.SetEmulatedMediaResult | undefined>;
 
     /**
+     * Emulates the given vision deficiency.
+     */
+    setEmulatedVisionDeficiency(
+      params: Emulation.SetEmulatedVisionDeficiencyParams,
+    ): Promise<Emulation.SetEmulatedVisionDeficiencyResult | undefined>;
+
+    /**
      * Overrides the Geolocation Position or Error. Omitting any of the parameters emulates position
      * unavailable.
      */
@@ -8217,6 +8324,7 @@ export namespace Cdp {
 
     /**
      * Overrides value returned by the javascript navigator object.
+     * @deprecated
      */
     setNavigatorOverrides(
       params: Emulation.SetNavigatorOverridesParams,
@@ -8252,6 +8360,13 @@ export namespace Cdp {
     ): Promise<Emulation.SetVirtualTimePolicyResult | undefined>;
 
     /**
+     * Overrides default host system locale with the specified one.
+     */
+    setLocaleOverride(
+      params: Emulation.SetLocaleOverrideParams,
+    ): Promise<Emulation.SetLocaleOverrideResult | undefined>;
+
+    /**
      * Overrides default host system timezone with the specified one.
      */
     setTimezoneOverride(
@@ -8262,6 +8377,7 @@ export namespace Cdp {
      * Resizes the frame/viewport of the page. Note that this does not affect the frame's container
      * (e.g. browser window). Can be used to produce screenshots of the specified size. Not supported
      * on Android.
+     * @deprecated
      */
     setVisibleSize(
       params: Emulation.SetVisibleSizeParams,
@@ -8521,6 +8637,31 @@ export namespace Cdp {
     export interface SetEmulatedMediaResult {}
 
     /**
+     * Parameters of the 'Emulation.setEmulatedVisionDeficiency' method.
+     */
+    export interface SetEmulatedVisionDeficiencyParams {
+      /**
+       * Vision deficiency to emulate.
+       */
+      type:
+        | 'none'
+        | 'achromatomaly'
+        | 'achromatopsia'
+        | 'blurredVision'
+        | 'deuteranomaly'
+        | 'deuteranopia'
+        | 'protanomaly'
+        | 'protanopia'
+        | 'tritanomaly'
+        | 'tritanopia';
+    }
+
+    /**
+     * Return value of the 'Emulation.setEmulatedVisionDeficiency' method.
+     */
+    export interface SetEmulatedVisionDeficiencyResult {}
+
+    /**
      * Parameters of the 'Emulation.setGeolocationOverride' method.
      */
     export interface SetGeolocationOverrideParams {
@@ -8649,6 +8790,22 @@ export namespace Cdp {
        */
       virtualTimeTicksBase: number;
     }
+
+    /**
+     * Parameters of the 'Emulation.setLocaleOverride' method.
+     */
+    export interface SetLocaleOverrideParams {
+      /**
+       * ICU style C locale (e.g. "en_US"). If not specified or empty, disables the override and
+       * restores default host system locale.
+       */
+      locale?: string;
+    }
+
+    /**
+     * Return value of the 'Emulation.setLocaleOverride' method.
+     */
+    export interface SetLocaleOverrideResult {}
 
     /**
      * Parameters of the 'Emulation.setTimezoneOverride' method.
@@ -9226,6 +9383,7 @@ export namespace Cdp {
      * Issued when the target starts or stops needing BeginFrames.
      * Deprecated. Issue beginFrame unconditionally instead and use result from
      * beginFrame to detect whether the frames were suppressed.
+     * @deprecated
      */
     on(
       event: 'needsBeginFramesChanged',
@@ -10979,8 +11137,14 @@ export namespace Cdp {
     export interface CompositingReasonsResult {
       /**
        * A list of strings specifying reasons for the given layer to become composited.
+       * @deprecated
        */
       compositingReasons: string[];
+
+      /**
+       * A list of strings specifying reason IDs for the given layer to become composited.
+       */
+      compositingReasonIds: string[];
     }
 
     /**
@@ -11643,7 +11807,7 @@ export namespace Cdp {
     /**
      * Break out events into different types
      */
-    export type PlayerEventType = 'playbackEvent' | 'systemEvent' | 'messageEvent';
+    export type PlayerEventType = 'errorEvent' | 'triggeredEvent' | 'messageEvent';
 
     export interface PlayerEvent {
       type: PlayerEventType;
@@ -11933,6 +12097,7 @@ export namespace Cdp {
   export interface NetworkApi {
     /**
      * Tells whether clearing browser cache is supported.
+     * @deprecated
      */
     canClearBrowserCache(
       params: Network.CanClearBrowserCacheParams,
@@ -11940,6 +12105,7 @@ export namespace Cdp {
 
     /**
      * Tells whether clearing browser cookies is supported.
+     * @deprecated
      */
     canClearBrowserCookies(
       params: Network.CanClearBrowserCookiesParams,
@@ -11947,6 +12113,7 @@ export namespace Cdp {
 
     /**
      * Tells whether emulation of network conditions is supported.
+     * @deprecated
      */
     canEmulateNetworkConditions(
       params: Network.CanEmulateNetworkConditionsParams,
@@ -11972,6 +12139,7 @@ export namespace Cdp {
      * fetch occurs as a result which encounters a redirect an additional Network.requestIntercepted
      * event will be sent with the same InterceptionId.
      * Deprecated, use Fetch.continueRequest, Fetch.fulfillRequest and Fetch.failRequest instead.
+     * @deprecated
      */
     continueInterceptedRequest(
       params: Network.ContinueInterceptedRequestParams,
@@ -12115,6 +12283,7 @@ export namespace Cdp {
     /**
      * Sets the requests to intercept that match the provided patterns and optionally resource types.
      * Deprecated, please use Fetch.enable instead.
+     * @deprecated
      */
     setRequestInterception(
       params: Network.SetRequestInterceptionParams,
@@ -12157,6 +12326,7 @@ export namespace Cdp {
      * Details of an intercepted HTTP request, which must be either allowed, blocked, modified or
      * mocked.
      * Deprecated, use Fetch.requestPaused instead.
+     * @deprecated
      */
     on(
       event: 'requestIntercepted',
@@ -13790,7 +13960,12 @@ export namespace Cdp {
       | 'inspector'
       | 'subresource-filter'
       | 'content-type'
-      | 'collapsed-by-client';
+      | 'collapsed-by-client'
+      | 'coep-frame-resource-needs-coep-header'
+      | 'coop-sandboxed-iframe-cannot-navigate-to-coop-page'
+      | 'corp-not-same-origin'
+      | 'corp-not-same-origin-after-defaulted-to-same-origin-by-coep'
+      | 'corp-not-same-site';
 
     /**
      * HTTP response data.
@@ -15030,6 +15205,7 @@ export namespace Cdp {
   export interface PageApi {
     /**
      * Deprecated, please use addScriptToEvaluateOnNewDocument instead.
+     * @deprecated
      */
     addScriptToEvaluateOnLoad(
       params: Page.AddScriptToEvaluateOnLoadParams,
@@ -15064,6 +15240,7 @@ export namespace Cdp {
 
     /**
      * Clears the overriden device metrics.
+     * @deprecated
      */
     clearDeviceMetricsOverride(
       params: Page.ClearDeviceMetricsOverrideParams,
@@ -15071,6 +15248,7 @@ export namespace Cdp {
 
     /**
      * Clears the overridden Device Orientation.
+     * @deprecated
      */
     clearDeviceOrientationOverride(
       params: Page.ClearDeviceOrientationOverrideParams,
@@ -15078,6 +15256,7 @@ export namespace Cdp {
 
     /**
      * Clears the overriden Geolocation Position and Error.
+     * @deprecated
      */
     clearGeolocationOverride(
       params: Page.ClearGeolocationOverrideParams,
@@ -15092,6 +15271,7 @@ export namespace Cdp {
 
     /**
      * Deletes browser cookie with given name, domain and path.
+     * @deprecated
      */
     deleteCookie(params: Page.DeleteCookieParams): Promise<Page.DeleteCookieResult | undefined>;
 
@@ -15120,6 +15300,7 @@ export namespace Cdp {
     /**
      * Returns all browser cookies. Depending on the backend support, will return detailed cookie
      * information in the `cookies` field.
+     * @deprecated
      */
     getCookies(params: Page.GetCookiesParams): Promise<Page.GetCookiesResult | undefined>;
 
@@ -15194,6 +15375,7 @@ export namespace Cdp {
 
     /**
      * Deprecated, please use removeScriptToEvaluateOnNewDocument instead.
+     * @deprecated
      */
     removeScriptToEvaluateOnLoad(
       params: Page.RemoveScriptToEvaluateOnLoadParams,
@@ -15236,6 +15418,7 @@ export namespace Cdp {
      * Overrides the values of device screen dimensions (window.screen.width, window.screen.height,
      * window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media
      * query results).
+     * @deprecated
      */
     setDeviceMetricsOverride(
       params: Page.SetDeviceMetricsOverrideParams,
@@ -15243,6 +15426,7 @@ export namespace Cdp {
 
     /**
      * Overrides the Device Orientation.
+     * @deprecated
      */
     setDeviceOrientationOverride(
       params: Page.SetDeviceOrientationOverrideParams,
@@ -15277,6 +15461,7 @@ export namespace Cdp {
     /**
      * Overrides the Geolocation Position or Error. Omitting any of the parameters emulates position
      * unavailable.
+     * @deprecated
      */
     setGeolocationOverride(
       params: Page.SetGeolocationOverrideParams,
@@ -15291,6 +15476,7 @@ export namespace Cdp {
 
     /**
      * Toggles mouse event-based touch event emulation.
+     * @deprecated
      */
     setTouchEmulationEnabled(
       params: Page.SetTouchEmulationEnabledParams,
@@ -15399,6 +15585,7 @@ export namespace Cdp {
 
     /**
      * Fired when frame no longer has a scheduled navigation.
+     * @deprecated
      */
     on(
       event: 'frameClearedScheduledNavigation',
@@ -15428,6 +15615,7 @@ export namespace Cdp {
 
     /**
      * Fired when frame schedules a potential navigation.
+     * @deprecated
      */
     on(
       event: 'frameScheduledNavigation',
@@ -15783,7 +15971,7 @@ export namespace Cdp {
      * Return value of the 'Page.getInstallabilityErrors' method.
      */
     export interface GetInstallabilityErrorsResult {
-      errors: string[];
+      installabilityErrors: InstallabilityError[];
     }
 
     /**
@@ -15972,6 +16160,11 @@ export namespace Cdp {
        * Frame id to navigate, if not specified navigates the top frame.
        */
       frameId?: FrameId;
+
+      /**
+       * Referrer-policy used for the navigation.
+       */
+      referrerPolicy?: ReferrerPolicy;
     }
 
     /**
@@ -16768,14 +16961,7 @@ export namespace Cdp {
       /**
        * The reason for the navigation.
        */
-      reason:
-        | 'formSubmissionGet'
-        | 'formSubmissionPost'
-        | 'httpHeaderRefresh'
-        | 'scriptInitiated'
-        | 'metaTagRefresh'
-        | 'pageBlockInterstitial'
-        | 'reload';
+      reason: ClientNavigationReason;
 
       /**
        * The destination URL for the scheduled navigation.
@@ -17408,7 +17594,48 @@ export namespace Cdp {
       | 'scriptInitiated'
       | 'metaTagRefresh'
       | 'pageBlockInterstitial'
-      | 'reload';
+      | 'reload'
+      | 'anchorClick';
+
+    export interface InstallabilityErrorArgument {
+      /**
+       * Argument name (e.g. name:'minimum-icon-size-in-pixels').
+       */
+      name: string;
+
+      /**
+       * Argument value (e.g. value:'64').
+       */
+      value: string;
+    }
+
+    /**
+     * The installability error
+     */
+    export interface InstallabilityError {
+      /**
+       * The error id (e.g. 'manifest-missing-suitable-icon').
+       */
+      errorId: string;
+
+      /**
+       * The list of error arguments (e.g. {name:'minimum-icon-size-in-pixels', value:'64'}).
+       */
+      errorArguments: InstallabilityErrorArgument[];
+    }
+
+    /**
+     * The referring-policy used for the navigation.
+     */
+    export type ReferrerPolicy =
+      | 'noReferrer'
+      | 'noReferrerWhenDowngrade'
+      | 'origin'
+      | 'originWhenCrossOrigin'
+      | 'sameOrigin'
+      | 'strictOrigin'
+      | 'strictOriginWhenCrossOrigin'
+      | 'unsafeUrl';
   }
 
   /**
@@ -17429,6 +17656,7 @@ export namespace Cdp {
      * Sets time domain to use for collecting and reporting duration metrics.
      * Note that this must be called before enabling metrics collection. Calling
      * this method while metrics collection is enabled returns an error.
+     * @deprecated
      */
     setTimeDomain(
       params: Performance.SetTimeDomainParams,
@@ -17464,7 +17692,12 @@ export namespace Cdp {
     /**
      * Parameters of the 'Performance.enable' method.
      */
-    export interface EnableParams {}
+    export interface EnableParams {
+      /**
+       * Time domain to use for collecting and reporting duration metrics.
+       */
+      timeDomain?: 'timeTicks' | 'threadTicks';
+    }
 
     /**
      * Return value of the 'Performance.enable' method.
@@ -17638,6 +17871,17 @@ export namespace Cdp {
       event: 'consoleProfileStarted',
       listener: (event: Profiler.ConsoleProfileStartedEvent) => void,
     ): IDisposable;
+
+    /**
+     * Reports coverage delta since the last poll (either from an event like this, or from
+     * `takePreciseCoverage` for the current isolate. May only be sent if precise code
+     * coverage has been started. This event can be trigged by the embedder to, for example,
+     * trigger collection of coverage data immediatelly at a certain point in time.
+     */
+    on(
+      event: 'preciseCoverageDeltaUpdate',
+      listener: (event: Profiler.PreciseCoverageDeltaUpdateEvent) => void,
+    ): IDisposable;
   }
 
   /**
@@ -17717,6 +17961,11 @@ export namespace Cdp {
        * Collect block-based coverage.
        */
       detailed?: boolean;
+
+      /**
+       * Allow the backend to send updates on its own initiative
+       */
+      allowTriggeredUpdates?: boolean;
     }
 
     /**
@@ -17878,6 +18127,26 @@ export namespace Cdp {
        * Profile title passed as an argument to console.profile().
        */
       title?: string;
+    }
+
+    /**
+     * Parameters of the 'Profiler.preciseCoverageDeltaUpdate' event.
+     */
+    export interface PreciseCoverageDeltaUpdateEvent {
+      /**
+       * Monotonically increasing time (in seconds) when the coverage update was taken in the backend.
+       */
+      timestamp: number;
+
+      /**
+       * Identifier for distinguishing coverage events.
+       */
+      occassion: string;
+
+      /**
+       * Coverage data for the current isolate.
+       */
+      result: ScriptCoverage[];
     }
 
     /**
@@ -18554,7 +18823,9 @@ export namespace Cdp {
       disableBreaks?: boolean;
 
       /**
-       * Reserved flag for future REPL mode support. Setting this flag has currently no effect.
+       * Setting this flag to true enables `let` re-declaration and top-level `await`.
+       * Note that `let` variables can only be re-declared if they originate from
+       * `replMode` themselves.
        */
       replMode?: boolean;
     }
@@ -19587,6 +19858,7 @@ export namespace Cdp {
 
     /**
      * Handles a certificate error that fired a certificateError event.
+     * @deprecated
      */
     handleCertificateError(
       params: Security.HandleCertificateErrorParams,
@@ -19595,6 +19867,7 @@ export namespace Cdp {
     /**
      * Enable/disable overriding certificate errors. If enabled, all certificate error events need to
      * be handled by the DevTools client and should be answered with `handleCertificateError` commands.
+     * @deprecated
      */
     setOverrideCertificateErrors(
       params: Security.SetOverrideCertificateErrorsParams,
@@ -19605,6 +19878,7 @@ export namespace Cdp {
      * handled with the `handleCertificateError` command. Note: this event does not fire if the
      * certificate error has been allowed internally. Only one client per target should override
      * certificate errors at the same time.
+     * @deprecated
      */
     on(
       event: 'certificateError',
@@ -19743,6 +20017,7 @@ export namespace Cdp {
 
       /**
        * True if the page was loaded over cryptographic transport such as HTTPS.
+       * @deprecated
        */
       schemeIsCryptographic: boolean;
 
@@ -19754,6 +20029,7 @@ export namespace Cdp {
 
       /**
        * Information about insecure content on the page.
+       * @deprecated
        */
       insecureContentStatus: InsecureContentStatus;
 
@@ -19961,6 +20237,7 @@ export namespace Cdp {
 
     /**
      * Information about insecure content on the page.
+     * @deprecated
      */
     export interface InsecureContentStatus {
       /**
@@ -21054,6 +21331,7 @@ export namespace Cdp {
      * Sends protocol message over session with given id.
      * Consider using flat mode instead; see commands attachToTarget, setAutoAttach,
      * and crbug.com/991325.
+     * @deprecated
      */
     sendMessageToTarget(
       params: Target.SendMessageToTargetParams,
@@ -21227,7 +21505,12 @@ export namespace Cdp {
     /**
      * Parameters of the 'Target.createBrowserContext' method.
      */
-    export interface CreateBrowserContextParams {}
+    export interface CreateBrowserContextParams {
+      /**
+       * If specified, disposes this context when debugging session disconnects.
+       */
+      disposeOnDetach?: boolean;
+    }
 
     /**
      * Return value of the 'Target.createBrowserContext' method.
@@ -21317,6 +21600,7 @@ export namespace Cdp {
 
       /**
        * Deprecated.
+       * @deprecated
        */
       targetId?: TargetID;
     }
@@ -21380,6 +21664,7 @@ export namespace Cdp {
 
       /**
        * Deprecated.
+       * @deprecated
        */
       targetId?: TargetID;
     }
@@ -21410,11 +21695,6 @@ export namespace Cdp {
        * and eventually retire it. See crbug.com/991325.
        */
       flatten?: boolean;
-
-      /**
-       * Auto-attach to the targets created via window.open from current target.
-       */
-      windowOpen?: boolean;
     }
 
     /**
@@ -21477,6 +21757,7 @@ export namespace Cdp {
 
       /**
        * Deprecated.
+       * @deprecated
        */
       targetId?: TargetID;
     }
@@ -21494,6 +21775,7 @@ export namespace Cdp {
 
       /**
        * Deprecated.
+       * @deprecated
        */
       targetId?: TargetID;
     }
@@ -21770,11 +22052,13 @@ export namespace Cdp {
     export interface StartParams {
       /**
        * Category/tag filter
+       * @deprecated
        */
       categories?: string;
 
       /**
        * Tracing options
+       * @deprecated
        */
       options?: string;
 

--- a/src/common/contributionUtils.ts
+++ b/src/common/contributionUtils.ts
@@ -23,6 +23,8 @@ export const enum Contributions {
   AddCustomBreakpointsCommand = 'extension.NAMESPACE(chrome-debug).addCustomBreakpoints',
   RemoveCustomBreakpointCommand = 'extension.NAMESPACE(chrome-debug).removeCustomBreakpoint',
   RemoveAllCustomBreakpointsCommand = 'extension.NAMESPACE(chrome-debug).removeAllCustomBreakpoints',
+  StartProfileCommand = 'extension.NAMESPACE(node-debug).startProfile',
+  StopProfileCommand = 'extension.NAMESPACE(node-debug).stopProfile',
 
   BrowserBreakpointsView = 'jsBrowserBreakpoints',
 }
@@ -78,6 +80,8 @@ export interface ICommandTypes {
   [Contributions.ToggleSkippingCommand]: { args: [string | number]; out: void };
   [Contributions.PrettyPrintCommand]: { args: []; out: void };
   [Contributions.EnlistExperimentCommand]: { args: []; out: void };
+  [Contributions.StartProfileCommand]: { args: [string | undefined]; out: void };
+  [Contributions.StopProfileCommand]: { args: [string | undefined]; out: void };
 }
 
 /**

--- a/src/common/datastructure/observableMap.ts
+++ b/src/common/datastructure/observableMap.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { EventEmitter } from '../common/events';
+import { EventEmitter } from '../events';
 
 /**
  * A wrapper around map that fires an event emitter when it's mutated. Used

--- a/src/dap/api.d.ts
+++ b/src/dap/api.d.ts
@@ -754,6 +754,35 @@ export namespace Dap {
      * Enable custom breakpoints.
      */
     killCompanionBrowser(params: KillCompanionBrowserEventParams): void;
+
+    /**
+     * Starts taking a profile of the target.
+     */
+    on(
+      request: 'startProfile',
+      handler: (params: StartProfileParams) => Promise<StartProfileResult | Error>,
+    ): () => void;
+    /**
+     * Starts taking a profile of the target.
+     */
+    startProfileRequest(params: StartProfileParams): Promise<StartProfileResult>;
+
+    /**
+     * Stops a running profile.
+     */
+    on(
+      request: 'stopProfile',
+      handler: (params: StopProfileParams) => Promise<StopProfileResult | Error>,
+    ): () => void;
+    /**
+     * Stops a running profile.
+     */
+    stopProfileRequest(params: StopProfileParams): Promise<StopProfileResult>;
+
+    /**
+     * Fired when a profiling state changes.
+     */
+    profilerStateUpdate(params: ProfilerStateUpdateEventParams): void;
   }
 
   export interface TestApi {
@@ -1234,6 +1263,32 @@ export namespace Dap {
       request: 'killCompanionBrowser',
       filter?: (event: KillCompanionBrowserEventParams) => boolean,
     ): Promise<KillCompanionBrowserEventParams>;
+
+    /**
+     * Starts taking a profile of the target.
+     */
+    startProfile(params: StartProfileParams): Promise<StartProfileResult>;
+
+    /**
+     * Stops a running profile.
+     */
+    stopProfile(params: StopProfileParams): Promise<StopProfileResult>;
+
+    /**
+     * Fired when a profiling state changes.
+     */
+    on(
+      request: 'profilerStateUpdate',
+      handler: (params: ProfilerStateUpdateEventParams) => void,
+    ): void;
+    off(
+      request: 'profilerStateUpdate',
+      handler: (params: ProfilerStateUpdateEventParams) => void,
+    ): void;
+    once(
+      request: 'profilerStateUpdate',
+      filter?: (event: ProfilerStateUpdateEventParams) => boolean,
+    ): Promise<ProfilerStateUpdateEventParams>;
   }
 
   export interface AttachParams {
@@ -2059,6 +2114,13 @@ export namespace Dap {
     pointerSize?: integer;
   }
 
+  export interface ProfilerStateUpdateEventParams {
+    /**
+     * Description of the current state
+     */
+    label: string;
+  }
+
   export interface ReadMemoryParams {
     /**
      * Memory reference to the base location from which data should be read.
@@ -2422,6 +2484,25 @@ export namespace Dap {
     totalFrames?: integer;
   }
 
+  export interface StartProfileParams {
+    /**
+     * Location where the profile should be saved.
+     */
+    file: string;
+
+    /**
+     * Type of profile that should be taken
+     */
+    type: string;
+
+    /**
+     * Additional arguments for the type of profiler
+     */
+    params?: object;
+  }
+
+  export interface StartProfileResult {}
+
   export interface StepBackParams {
     /**
      * Execute 'stepBack' for this thread.
@@ -2467,6 +2548,10 @@ export namespace Dap {
   }
 
   export interface StepOutResult {}
+
+  export interface StopProfileParams {}
+
+  export interface StopProfileResult {}
 
   export interface StoppedEventParams {
     /**

--- a/src/dap/errors.ts
+++ b/src/dap/errors.ts
@@ -20,6 +20,8 @@ export const enum ErrorCodes {
   InvalidLogPointBreakpointSyntax,
   BrowserNotFound,
   AsyncScopesNotAvailable,
+  ProfileCaptureError,
+  InvalidConcurrentProfile,
 }
 
 export function reportToConsole(dap: Dap.Api, error: string) {
@@ -121,6 +123,21 @@ export const invalidHitCondition = (expression: string) =>
       expression,
     ),
     ErrorCodes.InvalidHitCondition,
+  );
+
+export const profileCaptureError = () =>
+  createUserError(
+    localize('profile.error.generic', 'An error occurred taking a profile from the target.'),
+    ErrorCodes.ProfileCaptureError,
+  );
+
+export const invalidConcurrentProfile = () =>
+  createUserError(
+    localize(
+      'profile.error.concurrent',
+      'Please stop the running profile before starting a new one.',
+    ),
+    ErrorCodes.InvalidConcurrentProfile,
   );
 
 export const browserNotFound = (

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { registerCompanionBrowserLaunch } from './ui/companionBrowserLaunch';
 import { tmpdir } from 'os';
 import { PrettyPrintTrackerFactory } from './ui/prettyPrint';
 import { toggleOnExperiment } from './ui/experimentEnlist';
+import { registerProfilingCommand } from './ui/profiling';
 
 // eslint-disable-next-line
 const packageJson = require('../package.json');
@@ -63,7 +64,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(sessionManager);
 
-  const debugSessionTracker = new DebugSessionTracker();
+  const debugSessionTracker = services.get(DebugSessionTracker);
   debugSessionTracker.attach();
 
   context.subscriptions.push(PrettyPrintTrackerFactory.register(debugSessionTracker));
@@ -72,6 +73,7 @@ export function activate(context: vscode.ExtensionContext) {
   registerCustomBreakpointsUI(context, debugSessionTracker);
   registerDebugTerminalUI(context, services.get(DelegateLauncherFactory));
   registerNpmScriptLens(context);
+  registerProfilingCommand(context, services);
 }
 
 export function deactivate() {

--- a/src/ioc-extras.ts
+++ b/src/ioc-extras.ts
@@ -7,6 +7,11 @@ import { IDisposable } from './common/disposable';
 import { promises as fsPromises } from 'fs';
 
 /**
+ * The IOC container itself.
+ */
+export const IContainer = Symbol('IContainer');
+
+/**
  * Token for the string that points to a temporary storage directory.
  */
 export const StoragePath = Symbol('StoragePath');

--- a/src/targets/delegate/delegateLauncher.ts
+++ b/src/targets/delegate/delegateLauncher.ts
@@ -4,7 +4,7 @@
 import { ILauncher, ILaunchResult, ITarget, IStopMetadata, ILaunchContext } from '../targets';
 import { AnyLaunchConfiguration } from '../../configuration';
 import { DebugType } from '../../common/contributionUtils';
-import { ObservableMap } from '../targetList';
+import { ObservableMap } from '../../common/datastructure/observableMap';
 import { EventEmitter } from '../../common/events';
 import { IPendingDapApi } from '../../dap/pending-api';
 import { MutableTargetOrigin } from '../targetOrigin';

--- a/src/targets/delegate/delegateLauncherFactory.ts
+++ b/src/targets/delegate/delegateLauncherFactory.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 import { ITarget } from '../targets';
-import { ObservableMap } from '../targetList';
+import { ObservableMap } from '../../common/datastructure/observableMap';
 import { IDelegateRef, DelegateLauncher } from './delegateLauncher';
 import { IPendingDapApi } from '../../dap/pending-api';
 import { injectable } from 'inversify';

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -23,7 +23,7 @@ import { INodeTargetLifecycleHooks, NodeTarget } from './nodeTarget';
 import { NodeSourcePathResolver } from './nodeSourcePathResolver';
 import { IProgram } from './program';
 import { ProtocolError, cannotLoadEnvironmentVars } from '../../dap/errors';
-import { ObservableMap } from '../targetList';
+import { ObservableMap } from '../../common/datastructure/observableMap';
 import { findInPath } from '../../common/pathUtils';
 import { TelemetryReporter } from '../../telemetry/telemetryReporter';
 import { NodePathProvider, INodePathProvider } from './nodePathProvider';

--- a/src/ui/debugSessionTracker.ts
+++ b/src/ui/debugSessionTracker.ts
@@ -5,10 +5,12 @@
 import * as vscode from 'vscode';
 import Dap from '../dap/api';
 import { DebugType } from '../common/contributionUtils';
+import { injectable } from 'inversify';
 
 /**
  * Keeps a list of known js-debug sessions.
  */
+@injectable()
 export class DebugSessionTracker implements vscode.Disposable {
   private _onSessionAddedEmitter = new vscode.EventEmitter<vscode.DebugSession>();
   private _disposables: vscode.Disposable[] = [];

--- a/src/ui/profiling.ts
+++ b/src/ui/profiling.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Container } from 'inversify';
+import { registerCommand, Contributions } from '../common/contributionUtils';
+import { UiProfileManager } from './profiling/uiProfileManager';
+
+export const registerProfilingCommand = (
+  context: vscode.ExtensionContext,
+  container: Container,
+) => {
+  const manager = container.get(UiProfileManager);
+
+  context.subscriptions.push(
+    registerCommand(vscode.commands, Contributions.StartProfileCommand, sessionId =>
+      manager.start(sessionId),
+    ),
+    registerCommand(vscode.commands, Contributions.StopProfileCommand, sessionId =>
+      manager.stop(sessionId),
+    ),
+  );
+};

--- a/src/ui/profiling/uiProfileManager.ts
+++ b/src/ui/profiling/uiProfileManager.ts
@@ -1,0 +1,209 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
+import { DebugSessionTracker } from '../debugSessionTracker';
+import { injectable, inject } from 'inversify';
+import { ProfilerFactory } from '../../adapter/profiling';
+import { AnyLaunchConfiguration } from '../../configuration';
+import { UiProfileSession } from './uiProfileSession';
+import { Contributions } from '../../common/contributionUtils';
+import { basename } from 'path';
+import { FS, FsPromises } from '../../ioc-extras';
+import { IDisposable } from '../../common/disposable';
+
+const localize = nls.loadMessageBundle();
+
+const isProfileCandidate = (session: vscode.DebugSession) =>
+  '__pendingTargetId' in session.configuration;
+
+@injectable()
+export class UiProfileManager implements IDisposable {
+  private statusBarItem?: vscode.StatusBarItem;
+  private readonly activeSessions = new Set<UiProfileSession>();
+
+  constructor(
+    @inject(DebugSessionTracker) private readonly tracker: DebugSessionTracker,
+    @inject(FS) private readonly fs: FsPromises,
+  ) {}
+
+  /**
+   * Starts a profiling session.
+   */
+  public async start(sessionId?: string) {
+    let session: vscode.DebugSession | undefined;
+    const candidates = [...this.tracker.sessions.values()].filter(isProfileCandidate);
+    if (sessionId) {
+      session = candidates.find(s => s.id === sessionId);
+    } else {
+      session = await this.pickSession(candidates);
+    }
+
+    if (!session) {
+      return; // cancelled or invalid
+    }
+
+    const existing = [...this.activeSessions].find(s => s.session === session);
+    if (existing) {
+      if (!(await this.alreadyRunningSession(existing))) {
+        return;
+      }
+    }
+
+    const impl = await this.pickType(session);
+    if (!impl) {
+      return;
+    }
+
+    const uiSession = await UiProfileSession.start(session, impl);
+    if (!uiSession) {
+      return;
+    }
+
+    this.activeSessions.add(uiSession);
+    uiSession.onStatusChange(() => this.updateStatusBar());
+    uiSession.onStop(() => {
+      this.activeSessions.delete(uiSession);
+      this.updateStatusBar();
+    });
+    this.updateStatusBar();
+  }
+
+  /**
+   * Stops the profiling session if it exists.
+   */
+  public async stop(sessionId?: string) {
+    let session: vscode.DebugSession | undefined;
+    if (sessionId) {
+      session = [...this.activeSessions].find(s => s.session.id === sessionId)?.session;
+    } else {
+      session = await this.pickSession([...this.activeSessions].map(s => s.session));
+    }
+
+    if (!session) {
+      return;
+    }
+
+    const uiSession = [...this.activeSessions].find(s => s.session === session);
+    if (!uiSession) {
+      return;
+    }
+
+    const sourceFile = await uiSession.stop();
+    const targetFile = await vscode.window.showSaveDialog({
+      defaultUri: session.workspaceFolder?.uri.with({
+        path: session.workspaceFolder.uri.path + '/' + basename(sourceFile),
+      }),
+      filters: {
+        [uiSession.impl.label]: [uiSession.impl.extension.slice(1)],
+      },
+    });
+
+    if (targetFile) {
+      this.fs.rename(sourceFile, targetFile.fsPath);
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public dispose() {
+    for (const session of this.activeSessions) {
+      session.dispose();
+    }
+
+    this.activeSessions.clear();
+  }
+
+  /**
+   * Updates the status bar based on the state of current debug sessions.
+   */
+  private updateStatusBar() {
+    if (this.activeSessions.size === 0) {
+      this.statusBarItem?.hide();
+      return;
+    }
+
+    if (!this.statusBarItem) {
+      this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 500);
+      this.statusBarItem.command = Contributions.StopProfileCommand;
+    }
+
+    if (this.activeSessions.size === 1) {
+      const session: UiProfileSession = this.activeSessions.values().next().value;
+      this.statusBarItem.text = session.status
+        ? localize(
+            'profile.status.single',
+            '$(loading) Click to Stop Profiling ({0})',
+            session.status,
+          )
+        : localize('profile.status.default', '$(loading) Click to Stop Profiling');
+    } else {
+      this.statusBarItem.text = localize(
+        'profile.status.multiSession',
+        '$(loading) Click to Stop Profiling ({0} sessions)',
+        this.activeSessions.size,
+      );
+    }
+
+    this.statusBarItem.show();
+  }
+
+  /**
+   * Triggered when we try to profile a session we're already profiling. Asks
+   * if they want to stop and start profiling it again.
+   */
+  private async alreadyRunningSession(existing: UiProfileSession) {
+    const yes = localize('yes', 'Yes');
+    const no = localize('no', 'No');
+    const stopExisting = await vscode.window.showErrorMessage(
+      localize(
+        'profile.alreadyRunning',
+        'A profiling session is already running, would you like to stop it and start a new session?',
+      ),
+      yes,
+      no,
+    );
+
+    if (stopExisting !== yes) {
+      return false;
+    }
+
+    await this.stop(existing.session.id);
+    return true;
+  }
+
+  /**
+   * Quickpick to select any of the given candidate sessions.
+   */
+  private async pickSession(candidates: ReadonlyArray<vscode.DebugSession>) {
+    if (candidates.length === 0) {
+      return;
+    }
+
+    if (candidates.length === 1) {
+      return candidates[0];
+    }
+
+    const chosen = await vscode.window.showQuickPick(
+      candidates.map(c => ({ label: c.name, id: c.id })),
+    );
+    return chosen && candidates.find(c => c.id === chosen.id);
+  }
+
+  /**
+   * Picks the profiler type to run in the session.
+   */
+  private async pickType(session: vscode.DebugSession) {
+    const params = session.configuration as AnyLaunchConfiguration;
+    const chosen = await vscode.window.showQuickPick(
+      ProfilerFactory.ctors
+        .filter(ctor => ctor.canApplyTo(params))
+        .map(ctor => ({ type: ctor.type, label: ctor.label, description: ctor.description })),
+    );
+
+    return chosen && ProfilerFactory.ctors.find(c => c.type === chosen.type);
+  }
+}

--- a/src/ui/profiling/uiProfileSession.ts
+++ b/src/ui/profiling/uiProfileSession.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { EventEmitter } from '../../common/events';
+import * as vscode from 'vscode';
+import { DisposableList, IDisposable } from '../../common/disposable';
+import { IProfilerCtor } from '../../adapter/profiling';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+
+/**
+ * UI-side tracker for profiling sessions.
+ */
+export class UiProfileSession implements IDisposable {
+  private statusChangeEmitter = new EventEmitter<string>();
+  private stopEmitter = new EventEmitter<void>();
+  private _innerStatus?: string;
+  private disposables = new DisposableList();
+
+  /**
+   * Event that fires when the status changes.
+   */
+  public readonly onStatusChange = this.statusChangeEmitter.event;
+
+  /**
+   * Event that fires when the session stops for any reason.
+   */
+  public readonly onStop = this.stopEmitter.event;
+
+  /**
+   * Gets the current session status.
+   */
+  public get status() {
+    return this._innerStatus;
+  }
+
+  /**
+   * Starts the session and returns its ui-side tracker.
+   */
+  public static async start(session: vscode.DebugSession, impl: IProfilerCtor) {
+    const file = join(
+      tmpdir(),
+      `vscode-js-profile-${randomBytes(4).toString('hex')}${impl.extension}`,
+    );
+
+    try {
+      await session.customRequest('startProfile', { file, type: impl.type });
+    } catch (e) {
+      vscode.window.showErrorMessage(e.message);
+      return;
+    }
+
+    return new UiProfileSession(session, impl, file);
+  }
+
+  constructor(
+    public readonly session: vscode.DebugSession,
+    public readonly impl: IProfilerCtor,
+    private readonly file: string,
+  ) {
+    this.disposables.push(
+      vscode.debug.onDidReceiveDebugSessionCustomEvent(event => {
+        if (event.session === session && event.event === 'profilerStateUpdate') {
+          this.setStatus(event.body.label);
+        }
+      }),
+      vscode.debug.onDidTerminateDebugSession(s => {
+        if (s === session) {
+          this.stopEmitter.fire(undefined);
+        }
+      }),
+    );
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public dispose() {
+    this.disposables.dispose();
+  }
+
+  /**
+   * Stops the profile, and returns the file that profiling information was
+   * saved in.
+   */
+  public async stop() {
+    await this.session.customRequest('stopProfile', {});
+    this.stopEmitter.fire();
+    this.dispose();
+    return this.file;
+  }
+
+  private setStatus(status: string) {
+    this._innerStatus = status;
+    this.statusChangeEmitter.fire(status);
+  }
+}

--- a/src/ui/ui-ioc.ts
+++ b/src/ui/ui-ioc.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Container } from 'inversify';
+import {
+  ChromeDebugConfigurationProvider,
+  EdgeDebugConfigurationProvider,
+  ExtensionHostConfigurationProvider,
+  NodeConfigurationProvider,
+  TerminalDebugConfigurationProvider,
+  IDebugConfigurationProvider,
+} from './configuration';
+import { UiProfileManager } from './profiling/uiProfileManager';
+import { DebugSessionTracker } from './debugSessionTracker';
+import { trackDispose } from '../ioc-extras';
+
+export const registerUiComponents = (container: Container) => {
+  [
+    ChromeDebugConfigurationProvider,
+    EdgeDebugConfigurationProvider,
+    ExtensionHostConfigurationProvider,
+    NodeConfigurationProvider,
+    TerminalDebugConfigurationProvider,
+  ].forEach(cls => {
+    container
+      .bind(cls as { new (...args: unknown[]): unknown })
+      .toSelf()
+      .inSingletonScope();
+    container.bind(IDebugConfigurationProvider).to(cls);
+  });
+
+  container
+    .bind(DebugSessionTracker)
+    .toSelf()
+    .inSingletonScope()
+    .onActivation(trackDispose);
+  container
+    .bind(UiProfileManager)
+    .toSelf()
+    .inSingletonScope()
+    .onActivation(trackDispose);
+};


### PR DESCRIPTION
This PR implements basic .cpuprofile capturing for debug sessions.

- Users can start profiling through a context menu on the debug session,
or by running a command from the palette. If there's more than one
session, running a command will open a quickpick to choose the session
to profile.
- They will then be asked what kind of profile they want to record. For
Node.js this will be .cpuprofiles and .heapprofiles. For browsers, it
will allow the newer trace profiles.
- While profiling, the debugger is disabled, like the chrome devtools
does. This removes performance overhead and the ability to hit
breakpoints, which mess with the profile...
- Profiling state is shown in the status bar, and clicking on the entry
will stop profiling and ask the user where they want to save the profile
file. There's also a 'stop profiling' command.

This should give us a good foundation for further types and profiling
mechanics in the future.

I'm not totally happy with the entry and exitpoints as-is. You have to
know it's there to be able to start profiling, and then it's kind of
hard to figure out how to stop profiling. The chrome devtools shows an
overlay while profiling, which prevents the user try to e.g. set
breakpoints or use the REPL, implicitly communicating that debugging is
not possible in this state. I'm not sure what the best solution for us
is.

https://memes.peet.io/img/20-03-1ac56131-ddd4-47f7-9eb1-10644db126f4.webm

cc @roblourens @ididorn for thoughts. Will also bring this/whatever we
discuss up in next week's UX sync.