### PR TITLE
Only fail a resume request if we were paused

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -191,8 +191,12 @@ export class Thread implements IVariableStoreDelegate {
 
   async resume(): Promise<Dap.ContinueResult | Dap.Error> {
     this._sourceContainer.clearDisabledSourceMaps();
-    if (!(await this._cdp.Debugger.resume({})))
-      return errors.createSilentError(localize('error.resumeDidFail', 'Unable to resume'));
+    if (!(await this._cdp.Debugger.resume({}))) {
+      // We don't report the failure if the target wasn't paused. VS relies on this behavior.
+      if (this._pausedDetails !== undefined) {
+        return errors.createSilentError(localize('error.resumeDidFail', 'Unable to resume'));
+      }
+    }
     return { allThreadsContinued: false };
   }
 


### PR DESCRIPTION
In VS when we stop on a breakpoint, and reload the page, we end up with the JavaScript debugging session in a "running state", and the "root js-debug session" that we use on VS on a paused state, so VS tries to show the call stack of the "root js-debug session" (which doesn't make sense).
The core diagnostic teams suggested us to fix this by making a resume request never fail if we weren't paused when it failed.