### PR TITLE
Fix breakpoint statistics

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -883,6 +883,10 @@ export class Thread implements IVariableStoreDelegate {
           const isStopOnEntry =
             event.hitBreakpoints.length === 1 &&
             this._delegate.entryBreakpointId === event.hitBreakpoints[0];
+
+          if (!isStopOnEntry) {
+            this._breakpointManager.registerBreakpointsHit(event.hitBreakpoints);
+          }
           return {
             thread: this,
             stackTrace,

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -375,6 +375,7 @@ export class Binder implements IDisposable {
     } else {
       dap.on('attach', startThread);
       dap.on('disconnect', async () => {
+        container.get<ITelemetryReporter>(ITelemetryReporter).flush();
         this._rootServices.get<ITelemetryReporter>(ITelemetryReporter).flush();
         if (target.canStop()) target.stop();
         return {};

--- a/src/statistics/breakpointsStatistics.ts
+++ b/src/statistics/breakpointsStatistics.ts
@@ -20,6 +20,7 @@ export class BreakpointsStatisticsCalculator {
   public registerBreakpoints(manyBreakpoints: Dap.Breakpoint[]): void {
     manyBreakpoints.forEach(breakpoint => {
       breakpoint.id !== undefined &&
+        !this._statisticsById.has(breakpoint.id) &&
         this._statisticsById.set(
           breakpoint.id,
           new BreakpointStatistic(breakpoint.verified, false),


### PR DESCRIPTION
Fixed three bugs:
1. The statistics weren't sent, because the DA specific telemetry reporter wasn't flushed
2. The hits weren't computed because we weren't calling registerBreakpointsHit
3. The hits were removed after setting a breakpoint, because we re-setted breakpoints with the same ids
