### PR TITLE
Translate stack traces to typescript

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -185,6 +185,7 @@ async function runWebpack(packages) {
         filename: path.basename(entry),
         devtoolModuleFilenameTemplate: '../[resource-path]',
       },
+      devtool: 'nosources-source-map',
       resolve: {
         extensions: ['.js', '.json'],
       },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -166,7 +166,7 @@ gulp.task('compile:static', () =>
 
 gulp.task('compile', gulp.series('compile:ts', 'compile:static', 'compile:dynamic'));
 
-async function runWebpack(packages) {
+async function runWebpack(packages, devtool) {
   // add the entrypoints common to both vscode and vs here
   packages = [
     ...packages,
@@ -185,7 +185,7 @@ async function runWebpack(packages) {
         filename: path.basename(entry),
         devtoolModuleFilenameTemplate: '../[resource-path]',
       },
-      devtool: 'nosources-source-map',
+      devtool: devtool,
       resolve: {
         extensions: ['.js', '.json'],
       },
@@ -228,13 +228,13 @@ async function runWebpack(packages) {
 /** Run webpack to bundle the extension output files */
 gulp.task('package:webpack-bundle', async () => {
   const packages = [{ entry: `${buildSrcDir}/extension.js`, library: true }];
-  return runWebpack(packages);
+  return runWebpack(packages, undefined /* No sourcemaps */);
 });
 
 /** Run webpack to bundle into the flat session launcher (for VS or standalone debug server)  */
 gulp.task('flatSessionBundle:webpack-bundle', async () => {
   const packages = [{ entry: `${buildSrcDir}/flatSessionLauncher.js`, library: true }];
-  return runWebpack(packages);
+  return runWebpack(packages, /* Sourcemaps to convert stack traces to TS */ 'nosources-source-map');
 });
 
 /** Copy the extension static files */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1930,8 +1930,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -4435,8 +4434,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4457,14 +4455,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4479,20 +4475,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4609,8 +4602,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4622,7 +4614,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4637,7 +4628,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4645,14 +4635,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4671,7 +4659,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4752,8 +4739,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4765,7 +4751,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4851,8 +4836,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4888,7 +4872,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4908,7 +4891,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4952,14 +4934,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10244,10 +10224,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
-      "dev": true,
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -10256,8 +10235,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "micromatch": "^4.0.2",
     "reflect-metadata": "^0.1.13",
     "source-map": "^0.7.3",
+    "source-map-support": "^0.5.19",
     "split2": "^3.1.1",
     "typescript": "^3.8.3",
     "vscode-js-debug-browsers": "^1.0.0",

--- a/src/flatSessionLauncher.ts
+++ b/src/flatSessionLauncher.ts
@@ -2,6 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+require('source-map-support').install(); // Enable TypeScript stack traces translation
 import 'reflect-metadata';
 
 /**


### PR DESCRIPTION
So it's easier to understand them on telemetry:
![image](https://user-images.githubusercontent.com/14098140/80248657-418ea200-8625-11ea-9c52-d18be5dce3eb.png)

nosources-source-map - A SourceMap is created without the sourcesContent in it. It can be used to map stack traces on the client without exposing all of the source code. You can deploy the Source Map file to the webserver.

from: https://webpack.js.org/configuration/devtool/