### PR TITLE
Added posibility to run with chosen package manager instead of `npm` only.

### DIFF
--- a/src/ui/debugNpmScript.ts
+++ b/src/ui/debugNpmScript.ts
@@ -38,13 +38,16 @@ export async function debugNpmScript(inFolder?: vscode.WorkspaceFolder) {
     label: multiDir ? `${path.basename(script.directory.name)}: ${script.name}` : script.name,
     description: script.command,
   }));
+  const packageManager = vscode.workspace
+    .getConfiguration('npm', inFolder?.uri)
+    .get<string>('packageManager', 'npm');
 
   quickPick.onDidAccept(() => {
     const { script } = quickPick.selectedItems[0];
     runCommand(
       vscode.commands,
       Commands.CreateDebuggerTerminal,
-      `npm run ${script.name}`,
+      `${packageManager} run ${script.name}`,
       script.directory,
     );
 


### PR DESCRIPTION
Was fully extracted from bundled `npm` extension.

Ideally it should consume function exposed by by `npm` extension bundled within VS Code, although function exposed from `tasks.ts` but not from whole extension and can't be consumed by `vscode.extensions.getExtension('vscode.npm')` notation.