### PR TITLE
Fix reduce failing when array is empty

### DIFF
--- a/src/adapter/objectPreview/index.ts
+++ b/src/adapter/objectPreview/index.ts
@@ -436,7 +436,7 @@ export function formatAsTable(param: Cdp.Runtime.ObjectPreview): string {
   }
 
   // Shrink columns if necessary.
-  const columnsWidth = Array.from(colLengths.values()).reduce((a, c) => a + c);
+  const columnsWidth = Array.from(colLengths.values()).reduce((a, c) => a + c, 0);
   const maxColumnsWidth = maxTableWidth - 4 - (colNames.size - 1) * 3;
   if (columnsWidth > maxColumnsWidth) {
     const ratio = maxColumnsWidth / columnsWidth;


### PR DESCRIPTION
We got this unhandled rejection from telemetry:

TypeError: Reduce of empty array with no initial value
    at Array.reduce (<anonymous>)
    at Object.formatAsTable (index.js:381:58)
    at k.slot [as _onConsoleMessage] (threads.js:791:41)
    at threads.js:341:17

Using 0 as an initial seed won't change the value when the array has contents, and will avoid the crash when it's empty.

I'm assuming that columnsWidth = 0 makes sense if we don't have any columns.