### PR TITLE
Update ws errors to be actual errors when possible

### DIFF
--- a/src/cdp/webSocketTransport.ts
+++ b/src/cdp/webSocketTransport.ts
@@ -38,7 +38,7 @@ export class WebSocketTransport implements ITransport {
     return timeoutPromise(
       new Promise<WebSocketTransport>((resolve, reject) => {
         ws.addEventListener('open', () => resolve(new WebSocketTransport(ws)));
-        ws.addEventListener('error', reject);
+        ws.addEventListener('error', errorEvent => reject(errorEvent.error)); // Parameter is an ErrorEvent. See https://github.com/websockets/ws/blob/master/doc/ws.md#websocketonerror
       }),
       cancellationToken,
       `Could not open ${url}`,


### PR DESCRIPTION
From the telemetry it seems that we are getting errors on ws.addEventListener('error', reject) that are not of the class error.
Documentation says we get an ErrorEvent which is not an error, see https://github.com/websockets/ws/blob/2e5c01f5b550ae4171d127b0b707ebcec5925cc3/lib/event-target.js#L87