### PR TITLE
fix: breakpoints not being set in files with unicode characters

### DIFF
--- a/src/common/stringUtils.ts
+++ b/src/common/stringUtils.ts
@@ -36,6 +36,9 @@ export function formatMillisForLog(millis: number): string {
 }
 
 const regexChars = '/\\.?*()^${}|[]+';
+
+export const isRegexSpecialChar = (chr: string) => regexChars.includes(chr);
+
 export function escapeRegexSpecialChars(str: string, except?: string): string {
   const useRegexChars = regexChars
     .split('')

--- a/src/test/common/urlUtils.test.ts
+++ b/src/test/common/urlUtils.test.ts
@@ -51,29 +51,38 @@ describe('urlUtils', () => {
     });
   });
 
+  const testUrlToRegex = (input: string, expectedRe: string) => {
+    const actualRe = urlToRegex(input);
+    expect(actualRe).to.equal(expectedRe);
+    expect(input).to.match(new RegExp(actualRe));
+  };
+
   describe('urlToRegex - case sensitive', () => {
     before(() => setCaseSensitivePaths(true));
     after(() => resetCaseSensitivePaths());
 
     it('works for a simple posix path', () => {
-      expect(urlToRegex('file:///a/b.js')).to.equal('file:\\/\\/\\/a\\/b\\.js|\\/a\\/b\\.js');
+      testUrlToRegex('file:///a/b.js', 'file:\\/\\/\\/a\\/b\\.js|\\/a\\/b\\.js');
     });
 
     it('works for a simple windows path', () => {
-      expect(urlToRegex('file:///c:/a/b.js')).to.equal(
-        'file:\\/\\/\\/[Cc]:\\/a\\/b\\.js|[Cc]:\\\\a\\\\b\\.js',
-      );
+      testUrlToRegex('file:///c:/a/b.js', 'file:\\/\\/\\/[Cc]:\\/a\\/b\\.js|[Cc]:\\\\a\\\\b\\.js');
     });
 
     it('works for a url', () => {
-      expect(urlToRegex('http://localhost:8080/a/b.js')).to.equal(
-        'http:\\/\\/localhost:8080\\/a\\/b\\.js',
-      );
+      testUrlToRegex('http://localhost:8080/a/b.js', 'http:\\/\\/localhost:8080\\/a\\/b\\.js');
     });
 
     it('space in path', () => {
-      expect(urlToRegex('file:///a/space%20path.js')).to.equal(
-        'file:\\/\\/\\/a\\/space( |%20)path\\.js|\\/a\\/space( |%20)path\\.js',
+      testUrlToRegex(
+        'file:///a/space%20path.js',
+        'file:\\/\\/\\/a\\/space(?: |%20)path\\.js|\\/a\\/space(?: |%20)path\\.js',
+      );
+    });
+    it('preserves high unicode (#496)', () => {
+      testUrlToRegex(
+        'file:///c:/foo/%E2%91%A0%E2%85%AB%E3%84%A8%E3%84%A9%20%E5%95%8A%E9%98%BF%E9%BC%BE%E9%BD%84%E4%B8%82%E4%B8%84%E7%8B%9A%E7%8B%9B%E7%8B%9C%E7%8B%9D%EF%A8%A8%EF%A8%A9%CB%8A%CB%8B%CB%99%E2%80%93%E2%BF%BB%E3%80%87%E3%90%80%E3%90%81%E4%B6%B4%E4%B6%B5U1[%EE%80%A5%EE%80%A6%EE%80%A7%EE%80%B8%EE%80%B9]U2[%EE%89%9A%EE%89%9B%EE%89%AC%EE%89%AD]U3[%EE%93%BE%EE%93%BF%EE%94%80%EE%94%8B%EE%94%8C].js',
+        'file:\\/\\/\\/[Cc]:\\/foo\\/(?:①|%E2%91%A0)(?:Ⅻ|%E2%85%AB)(?:ㄨ|%E3%84%A8)(?:ㄩ|%E3%84%A9)(?: |%20)(?:啊|%E5%95%8A)(?:阿|%E9%98%BF)(?:鼾|%E9%BC%BE)(?:齄|%E9%BD%84)(?:丂|%E4%B8%82)(?:丄|%E4%B8%84)(?:狚|%E7%8B%9A)(?:狛|%E7%8B%9B)(?:狜|%E7%8B%9C)(?:狝|%E7%8B%9D)(?:﨨|%EF%A8%A8)(?:﨩|%EF%A8%A9)(?:ˊ|%CB%8A)(?:ˋ|%CB%8B)(?:˙|%CB%99)(?:–|%E2%80%93)(?:⿻|%E2%BF%BB)(?:〇|%E3%80%87)(?:㐀|%E3%90%80)(?:㐁|%E3%90%81)(?:䶴|%E4%B6%B4)(?:䶵|%E4%B6%B5)U1(?:\\[|%5B)(?:|%EE%80%A5)(?:|%EE%80%A6)(?:|%EE%80%A7)(?:|%EE%80%B8)(?:|%EE%80%B9)(?:\\]|%5D)U2(?:\\[|%5B)(?:|%EE%89%9A)(?:|%EE%89%9B)(?:|%EE%89%AC)(?:|%EE%89%AD)(?:\\]|%5D)U3(?:\\[|%5B)(?:|%EE%93%BE)(?:|%EE%93%BF)(?:|%EE%94%80)(?:|%EE%94%8B)(?:|%EE%94%8C)(?:\\]|%5D)\\.js|[Cc]:\\\\foo\\\\(?:①|%E2%91%A0)(?:Ⅻ|%E2%85%AB)(?:ㄨ|%E3%84%A8)(?:ㄩ|%E3%84%A9)(?: |%20)(?:啊|%E5%95%8A)(?:阿|%E9%98%BF)(?:鼾|%E9%BC%BE)(?:齄|%E9%BD%84)(?:丂|%E4%B8%82)(?:丄|%E4%B8%84)(?:狚|%E7%8B%9A)(?:狛|%E7%8B%9B)(?:狜|%E7%8B%9C)(?:狝|%E7%8B%9D)(?:﨨|%EF%A8%A8)(?:﨩|%EF%A8%A9)(?:ˊ|%CB%8A)(?:ˋ|%CB%8B)(?:˙|%CB%99)(?:–|%E2%80%93)(?:⿻|%E2%BF%BB)(?:〇|%E3%80%87)(?:㐀|%E3%90%80)(?:㐁|%E3%90%81)(?:䶴|%E4%B6%B4)(?:䶵|%E4%B6%B5)U1(?:\\[|%5B)(?:|%EE%80%A5)(?:|%EE%80%A6)(?:|%EE%80%A7)(?:|%EE%80%B8)(?:|%EE%80%B9)(?:\\]|%5D)U2(?:\\[|%5B)(?:|%EE%89%9A)(?:|%EE%89%9B)(?:|%EE%89%AC)(?:|%EE%89%AD)(?:\\]|%5D)U3(?:\\[|%5B)(?:|%EE%93%BE)(?:|%EE%93%BF)(?:|%EE%94%80)(?:|%EE%94%8B)(?:|%EE%94%8C)(?:\\]|%5D)\\.js',
       );
     });
   });
@@ -83,26 +92,37 @@ describe('urlUtils', () => {
     after(() => resetCaseSensitivePaths());
 
     it('works for a simple posix path', () => {
-      expect(urlToRegex('file:///a/b.js')).to.equal(
+      testUrlToRegex(
+        'file:///a/b.js',
         '[fF][iI][lL][eE]:\\/\\/\\/[aA]\\/[bB]\\.[jJ][sS]|\\/[aA]\\/[bB]\\.[jJ][sS]',
       );
     });
 
     it('works for a simple windows path', () => {
-      expect(urlToRegex('file:///c:/a/b.js')).to.equal(
+      testUrlToRegex(
+        'file:///c:/a/b.js',
         '[fF][iI][lL][eE]:\\/\\/\\/[cC]:\\/[aA]\\/[bB]\\.[jJ][sS]|[cC]:\\\\[aA]\\\\[bB]\\.[jJ][sS]',
       );
     });
 
     it('works for a url', () => {
-      expect(urlToRegex('http://localhost:8080/a/b.js')).to.equal(
+      testUrlToRegex(
+        'http://localhost:8080/a/b.js',
         '[hH][tT][tT][pP]:\\/\\/[lL][oO][cC][aA][lL][hH][oO][sS][tT]:8080\\/[aA]\\/[bB]\\.[jJ][sS]',
       );
     });
 
     it('space in path', () => {
-      expect(urlToRegex('file:///a/space%20path.js')).to.equal(
-        '[fF][iI][lL][eE]:\\/\\/\\/[aA]\\/[sS][pP][aA][cC][eE]( |%20)[pP][aA][tT][hH]\\.[jJ][sS]|\\/[aA]\\/[sS][pP][aA][cC][eE]( |%20)[pP][aA][tT][hH]\\.[jJ][sS]',
+      testUrlToRegex(
+        'file:///a/space%20path.js',
+        '[fF][iI][lL][eE]:\\/\\/\\/[aA]\\/[sS][pP][aA][cC][eE](?: |%20)[pP][aA][tT][hH]\\.[jJ][sS]|\\/[aA]\\/[sS][pP][aA][cC][eE](?: |%20)[pP][aA][tT][hH]\\.[jJ][sS]',
+      );
+    });
+
+    it('preserves high unicode (#496)', () => {
+      testUrlToRegex(
+        'file:///c:/foo/%E2%91%A0%E2%85%AB%E3%84%A8%E3%84%A9%20%E5%95%8A%E9%98%BF%E9%BC%BE%E9%BD%84%E4%B8%82%E4%B8%84%E7%8B%9A%E7%8B%9B%E7%8B%9C%E7%8B%9D%EF%A8%A8%EF%A8%A9%CB%8A%CB%8B%CB%99%E2%80%93%E2%BF%BB%E3%80%87%E3%90%80%E3%90%81%E4%B6%B4%E4%B6%B5U1[%EE%80%A5%EE%80%A6%EE%80%A7%EE%80%B8%EE%80%B9]U2[%EE%89%9A%EE%89%9B%EE%89%AC%EE%89%AD]U3[%EE%93%BE%EE%93%BF%EE%94%80%EE%94%8B%EE%94%8C].js',
+        '[fF][iI][lL][eE]:\\/\\/\\/[cC]:\\/[fF][oO][oO]\\/(?:①|%E2%91%A0)(?:ⅻ|%E2%85%BB|Ⅻ|%E2%85%AB)(?:ㄨ|%E3%84%A8)(?:ㄩ|%E3%84%A9)(?: |%20)(?:啊|%E5%95%8A)(?:阿|%E9%98%BF)(?:鼾|%E9%BC%BE)(?:齄|%E9%BD%84)(?:丂|%E4%B8%82)(?:丄|%E4%B8%84)(?:狚|%E7%8B%9A)(?:狛|%E7%8B%9B)(?:狜|%E7%8B%9C)(?:狝|%E7%8B%9D)(?:﨨|%EF%A8%A8)(?:﨩|%EF%A8%A9)(?:ˊ|%CB%8A)(?:ˋ|%CB%8B)(?:˙|%CB%99)(?:–|%E2%80%93)(?:⿻|%E2%BF%BB)(?:〇|%E3%80%87)(?:㐀|%E3%90%80)(?:㐁|%E3%90%81)(?:䶴|%E4%B6%B4)(?:䶵|%E4%B6%B5)[uU]1(?:\\[|%5B)(?:|%EE%80%A5)(?:|%EE%80%A6)(?:|%EE%80%A7)(?:|%EE%80%B8)(?:|%EE%80%B9)(?:\\]|%5D)[uU]2(?:\\[|%5B)(?:|%EE%89%9A)(?:|%EE%89%9B)(?:|%EE%89%AC)(?:|%EE%89%AD)(?:\\]|%5D)[uU]3(?:\\[|%5B)(?:|%EE%93%BE)(?:|%EE%93%BF)(?:|%EE%94%80)(?:|%EE%94%8B)(?:|%EE%94%8C)(?:\\]|%5D)\\.[jJ][sS]|[cC]:\\\\[fF][oO][oO]\\\\(?:①|%E2%91%A0)(?:ⅻ|%E2%85%BB|Ⅻ|%E2%85%AB)(?:ㄨ|%E3%84%A8)(?:ㄩ|%E3%84%A9)(?: |%20)(?:啊|%E5%95%8A)(?:阿|%E9%98%BF)(?:鼾|%E9%BC%BE)(?:齄|%E9%BD%84)(?:丂|%E4%B8%82)(?:丄|%E4%B8%84)(?:狚|%E7%8B%9A)(?:狛|%E7%8B%9B)(?:狜|%E7%8B%9C)(?:狝|%E7%8B%9D)(?:﨨|%EF%A8%A8)(?:﨩|%EF%A8%A9)(?:ˊ|%CB%8A)(?:ˋ|%CB%8B)(?:˙|%CB%99)(?:–|%E2%80%93)(?:⿻|%E2%BF%BB)(?:〇|%E3%80%87)(?:㐀|%E3%90%80)(?:㐁|%E3%90%81)(?:䶴|%E4%B6%B4)(?:䶵|%E4%B6%B5)[uU]1(?:\\[|%5B)(?:|%EE%80%A5)(?:|%EE%80%A6)(?:|%EE%80%A7)(?:|%EE%80%B8)(?:|%EE%80%B9)(?:\\]|%5D)[uU]2(?:\\[|%5B)(?:|%EE%89%9A)(?:|%EE%89%9B)(?:|%EE%89%AC)(?:|%EE%89%AD)(?:\\]|%5D)[uU]3(?:\\[|%5B)(?:|%EE%93%BE)(?:|%EE%93%BF)(?:|%EE%94%80)(?:|%EE%94%8B)(?:|%EE%94%8C)(?:\\]|%5D)\\.[jJ][sS]',
       );
     });
   });


### PR DESCRIPTION
We weren't handling URI encoding of file paths. Also, updated urlToRegex
(which I had copied from the previous debugger) to handle these with
case sensitivity in mind. For the path given in the issue, this produces
a regex like:

```
[fF][iI][lL][eE]:\/\/\/[cC]:\/[fF][oO][oO]\/(?:①|%E2%91%A0)(?:ⅻ|%E2%85%BB|Ⅻ|%E2%85%AB)(?:ㄨ|%E3%84%A8)(?:ㄩ|%E3%84%A9)(?: |%20)(?:啊|%E5%95%8A)(?:阿|%E9%98%BF)(?:鼾|%E9%BC%BE)(?:齄|%E9%BD%84)(?:丂|%E4%B8%82)(?:丄|%E4%B8%84)(?:狚|%E7%8B%9A)(?:狛|%E7%8B%9B)(?:狜|%E7%8B%9C)(?:狝|%E7%8B%9D)(?:﨨|%EF%A8%A8)(?:﨩|%EF%A8%A9)(?:ˊ|%CB%8A)(?:ˋ|%CB%8B)(?:˙|%CB%99)(?:–|%E2%80%93)(?:⿻|%E2%BF%BB)(?:〇|%E3%80%87)(?:㐀|%E3%90%80)(?:㐁|%E3%90%81)(?:䶴|%E4%B6%B4)(?:䶵|%E4%B6%B5)[uU]1(?:\[|%5B)(?:|%EE%80%A5)(?:|%EE%80%A6)(?:|%EE%80%A7)(?:|%EE%80%B8)(?:|%EE%80%B9)(?:\]|%5D)[uU]2(?:\[|%5B)(?:|%EE%89%9A)(?:|%EE%89%9B)(?:|%EE%89%AC)(?:|%EE%89%AD)(?:\]|%5D)[uU]3(?:\[|%5B)(?:|%EE%93%BE)(?:|%EE%93%BF)(?:|%EE%94%80)(?:|%EE%94%8B)(?:|%EE%94%8C)(?:\]|%5D)\.[jJ][sS]
|[cC]:\\[fF][oO][oO]\\(?:①|%E2%91%A0)(?:ⅻ|%E2%85%BB|Ⅻ|%E2%85%AB)(?:ㄨ|%E3%84%A8)(?:ㄩ|%E3%84%A9)(?: |%20)(?:啊|%E5%95%8A)(?:阿|%E9%98%BF)(?:鼾|%E9%BC%BE)(?:齄|%E9%BD%84)(?:丂|%E4%B8%82)(?:丄|%E4%B8%84)(?:狚|%E7%8B%9A)(?:狛|%E7%8B%9B)(?:狜|%E7%8B%9C)(?:狝|%E7%8B%9D)(?:﨨|%EF%A8%A8)(?:﨩|%EF%A8%A9)(?:ˊ|%CB%8A)(?:ˋ|%CB%8B)(?:˙|%CB%99)(?:–|%E2%80%93)(?:⿻|%E2%BF%BB)(?:〇|%E3%80%87)(?:㐀|%E3%90%80)(?:㐁|%E3%90%81)(?:䶴|%E4%B6%B4)(?:䶵|%E4%B6%B5)[uU]1(?:\[|%5B)(?:|%EE%80%A5)(?:|%EE%80%A6)(?:|%EE%80%A7)(?:|%EE%80%B8)(?:|%EE%80%B9)(?:\]|%5D)[uU]2(?:\[|%5B)(?:|%EE%89%9A)(?:|%EE%89%9B)(?:|%EE%89%AC)(?:|%EE%89%AD)(?:\]|%5D)[uU]3(?:\[|%5B)(?:|%EE%93%BE)(?:|%EE%93%BF)(?:|%EE%94%80)(?:|%EE%94%8B)(?:|%EE%94%8C)(?:\]|%5D)\.[jJ][sS]
```

It's long (so is the original file path) but seems to be
correctly-sensitive and work well in practice.

Fixes #496