### PR TITLE
Fix undefined function description

### DIFF
--- a/src/adapter/objectPreview/index.ts
+++ b/src/adapter/objectPreview/index.ts
@@ -3,11 +3,14 @@
  *--------------------------------------------------------*/
 
 import Cdp from '../../cdp/api';
+import * as nls from 'vscode-nls';
 import * as stringUtils from '../../common/stringUtils';
 import { BudgetStringBuilder } from '../../common/budgetStringBuilder';
 import * as messageFormat from '../messageFormat';
 import { getContextForType, IPreviewContext } from './contexts';
 import * as ObjectPreview from './betterTypes';
+
+const localize = nls.loadMessageBundle();
 
 const maxArrowFunctionCharacterLength = 30;
 const maxPropertyPreviewLength = 100;
@@ -298,6 +301,9 @@ function renderValue(object: Cdp.Runtime.RemoteObject, budget: number, quote: bo
 }
 
 function formatFunctionDescription(description: string, characterBudget: number): string {
+  if (description === undefined)
+    return localize('objectPreview.functionWithoutDescription', '<function without description>');
+
   const builder = new BudgetStringBuilder(characterBudget);
   const text = description
     .replace(/^function [gs]et /, 'function ')


### PR DESCRIPTION
We got telemetry that description is sometimes undefined on formatFunctionDescription:
TypeError: Cannot read property 'replace' of undefined
    at formatFunctionDescription (index.js:251:10)
    at renderPreview (index.js:88:16)
    at renderObjectPreview (index.js:176:25)
    at renderPreview (index.js:91:16)
    at previewRemoteObjectInternal (index.js:61:11)
    at Object.previewRemoteObject (index.js:48:20)
    at _createObjectVariable (variables.js:417:31)
    at _createVariable (variables.js:388:25)
    at _createVariablesForProperty (variables.js:366:30)
    at _getObjectProperties (variables.js:276:37)"
