### PR TITLE
Do not print sources in logs

### DIFF
--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -84,9 +84,16 @@ export default class Connection {
 
   async _onMessage(message: string, receivedTime: HrTime) {
     const object = JSON.parse(message);
+    let objectToLog = object;
+
+    // Don't print source code of getScriptSource responses
+    if (object.result && object.result.scriptSource) {
+      objectToLog = { ...object, result: { ...object.result, scriptSource: '<script source>' } };
+    }
+
     this.logger.verbose(LogTag.CdpReceive, undefined, {
       connectionId: this._connectionId,
-      message: object,
+      message: objectToLog,
     });
 
     const session = this._sessions.get(object.sessionId || '');

--- a/src/dap/transport.ts
+++ b/src/dap/transport.ts
@@ -80,9 +80,16 @@ export class StreamDapTransport implements IDapTransport {
   send(message: Message, shouldLog = true): void {
     const json = JSON.stringify(message);
     if (shouldLog) {
+      let objectToLog = message;
+
+      // Don't log the content for source responses
+      if (message.type === 'response' && message.command === 'source') {
+        objectToLog = { ...message, body: { ...message.body, content: '<script source>' } };
+      }
+
       this.logger?.verbose(LogTag.DapSend, undefined, {
         connectionId: this._connectionId,
-        message,
+        objectToLog,
       });
     }
     const data = `Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`;


### PR DESCRIPTION
Now we log this instead:
```
{"tag":"cdp.receive","timestamp":1591302982704,"metadata":{"connectionId":0,"message":{"id":28,"result":{"scriptSource":"<script source>"},"sessionId":"349604CB8C037F470A4BCAFCD223B94C"}},"level":0}
{"tag":"dap.send","timestamp":1591302982706,"metadata":{"connectionId":0,"objectToLog":{"seq":191,"type":"response","request_seq":5,"command":"source","success":true,"body":{"content":"<script source>","mimeType":"text/javascript"},"sessionId":"C9995BF646D2938A47CC5EE7A5673E48"}},"level":0}

```