### PR TITLE
Kill only the tab by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The following options can be configured:
 
 <details><h4>browserLaunchLocation</h4><p>Forces the browser to be launched in one location. In a remote workspace (through ssh or WSL, for example) this can be used to open the browser on the remote machine rather than locally.</p>
 <h5>Default value:</h4><pre><code>"workspace"</pre></code><h4>cleanUp</h4><p>What clean-up to do after the debugging session finishes. Close only the tab being debug, vs. close the whole browser.</p>
-<h5>Default value:</h4><pre><code>null</pre></code><h4>cwd</h4><p>Optional working directory for the runtime executable.</p>
+<h5>Default value:</h4><pre><code>"onlyTab"</pre></code><h4>cwd</h4><p>Optional working directory for the runtime executable.</p>
 <h5>Default value:</h4><pre><code>null</pre></code><h4>disableNetworkCache</h4><p>Controls whether to skip the network cache for each request</p>
 <h5>Default value:</h4><pre><code>true</pre></code><h4>env</h4><p>Optional dictionary of environment key/value pairs for the browser.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>file</h4><p>A local html file to open in the browser</p>
@@ -359,7 +359,7 @@ The following options can be configured:
 <details><h4>address</h4><p>When debugging webviews, the IP address or hostname the webview is listening on. Will be automatically discovered if not set.</p>
 <h5>Default value:</h4><pre><code>"localhost"</pre></code><h4>browserLaunchLocation</h4><p>Forces the browser to be launched in one location. In a remote workspace (through ssh or WSL, for example) this can be used to open the browser on the remote machine rather than locally.</p>
 <h5>Default value:</h4><pre><code>"workspace"</pre></code><h4>cleanUp</h4><p>What clean-up to do after the debugging session finishes. Close only the tab being debug, vs. close the whole browser.</p>
-<h5>Default value:</h4><pre><code>null</pre></code><h4>cwd</h4><p>Optional working directory for the runtime executable.</p>
+<h5>Default value:</h4><pre><code>"onlyTab"</pre></code><h4>cwd</h4><p>Optional working directory for the runtime executable.</p>
 <h5>Default value:</h4><pre><code>null</pre></code><h4>disableNetworkCache</h4><p>Controls whether to skip the network cache for each request</p>
 <h5>Default value:</h4><pre><code>true</pre></code><h4>env</h4><p>Optional dictionary of environment key/value pairs for the browser.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>file</h4><p>A local html file to open in the browser</p>

--- a/README.md
+++ b/README.md
@@ -286,7 +286,8 @@ The following options can be configured:
 ### pwa-chrome: launch
 
 <details><h4>browserLaunchLocation</h4><p>Forces the browser to be launched in one location. In a remote workspace (through ssh or WSL, for example) this can be used to open the browser on the remote machine rather than locally.</p>
-<h5>Default value:</h4><pre><code>"workspace"</pre></code><h4>cwd</h4><p>Optional working directory for the runtime executable.</p>
+<h5>Default value:</h4><pre><code>"workspace"</pre></code><h4>cleanUp</h4><p>What clean-up to do after the debugging session finishes. Close only the tab being debug, vs. close the whole browser.</p>
+<h5>Default value:</h4><pre><code>null</pre></code><h4>cwd</h4><p>Optional working directory for the runtime executable.</p>
 <h5>Default value:</h4><pre><code>null</pre></code><h4>disableNetworkCache</h4><p>Controls whether to skip the network cache for each request</p>
 <h5>Default value:</h4><pre><code>true</pre></code><h4>env</h4><p>Optional dictionary of environment key/value pairs for the browser.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>file</h4><p>A local html file to open in the browser</p>
@@ -357,7 +358,8 @@ The following options can be configured:
 
 <details><h4>address</h4><p>When debugging webviews, the IP address or hostname the webview is listening on. Will be automatically discovered if not set.</p>
 <h5>Default value:</h4><pre><code>"localhost"</pre></code><h4>browserLaunchLocation</h4><p>Forces the browser to be launched in one location. In a remote workspace (through ssh or WSL, for example) this can be used to open the browser on the remote machine rather than locally.</p>
-<h5>Default value:</h4><pre><code>"workspace"</pre></code><h4>cwd</h4><p>Optional working directory for the runtime executable.</p>
+<h5>Default value:</h4><pre><code>"workspace"</pre></code><h4>cleanUp</h4><p>What clean-up to do after the debugging session finishes. Close only the tab being debug, vs. close the whole browser.</p>
+<h5>Default value:</h4><pre><code>null</pre></code><h4>cwd</h4><p>Optional working directory for the runtime executable.</p>
 <h5>Default value:</h4><pre><code>null</pre></code><h4>disableNetworkCache</h4><p>Controls whether to skip the network cache for each request</p>
 <h5>Default value:</h4><pre><code>true</pre></code><h4>env</h4><p>Optional dictionary of environment key/value pairs for the browser.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>file</h4><p>A local html file to open in the browser</p>

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -793,8 +793,9 @@ const chromeLaunchConfig: IDebugger<IChromeLaunchConfiguration> = {
     },
     cleanUp: {
       type: 'string',
+      enum: ['wholeBrowser', 'onlyTab'],
       description: refString('browser.cleanUp.description'),
-      default: null,
+      default: 'onlyTab',
     },
     browserLaunchLocation: {
       description: refString('browser.browserLaunchLocation.description'),

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -791,6 +791,11 @@ const chromeLaunchConfig: IDebugger<IChromeLaunchConfiguration> = {
       description: refString('browser.profileStartup.description'),
       default: true,
     },
+    cleanUp: {
+      type: 'string',
+      description: refString('browser.cleanUp.description'),
+      default: null,
+    },
     browserLaunchLocation: {
       description: refString('browser.browserLaunchLocation.description'),
       default: null,

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -51,6 +51,8 @@ const strings = {
   'browser.address.description': 'IP address or hostname the debugged browser is listening on.',
   'browser.launch.port.description':
     'Port for the browser to listen on. Defaults to "0", which will cause the browser to be debugged via pipes, which is generally more secure and should be chosen unless you need to attach to the browser from another tool.',
+  'browser.cleanUp.description':
+    'What clean-up to do after the debugging session finishes. Close only the tab being debug, vs. close the whole browser.',
   'browser.attach.port.description':
     'Port to use to remote debugging the browser, given as `--remote-debugging-port` when launching the browser.',
   'browser.baseUrl.description':

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -507,7 +507,7 @@ export interface IChromiumLaunchConfiguration extends IChromiumBaseConfiguration
   /**
    * Close whole browser or just the tab when cleaning up
    */
-  cleanUp: 'wholeBrowser' | 'onlyTab' | null;
+  cleanUp: 'wholeBrowser' | 'onlyTab';
 }
 
 /**
@@ -780,7 +780,7 @@ export const chromeLaunchConfigDefaults: IChromeLaunchConfiguration = {
   userDataDir: true,
   browserLaunchLocation: 'workspace',
   profileStartup: false,
-  cleanUp: null,
+  cleanUp: 'onlyTab',
 };
 
 export const edgeLaunchConfigDefaults: IEdgeLaunchConfiguration = {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -503,6 +503,11 @@ export interface IChromiumLaunchConfiguration extends IChromiumBaseConfiguration
    * If true, will start profiling soon as the page launches.
    */
   profileStartup: boolean;
+
+  /**
+   * Close whole browser or just the tab when cleaning up
+   */
+  cleanUp: 'wholeBrowser' | 'onlyTab' | null;
 }
 
 /**
@@ -775,6 +780,7 @@ export const chromeLaunchConfigDefaults: IChromeLaunchConfiguration = {
   userDataDir: true,
   browserLaunchLocation: 'workspace',
   profileStartup: false,
+  cleanUp: null,
 };
 
 export const edgeLaunchConfigDefaults: IEdgeLaunchConfiguration = {

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -155,6 +155,7 @@ export class BrowserTargetManager implements IDisposable {
       } else {
         for (const targetId of this._targets.keys()) {
           await this._browser.Target.closeTarget({ targetId });
+          this._connection.close();
         }
       }
 
@@ -351,6 +352,7 @@ export class BrowserTargetManager implements IDisposable {
           await this._browser.Browser.close({});
         } else {
           await this._browser.Target.closeTarget({ targetId });
+          this._connection.close();
         }
       } catch {
         // ignored -- any network error when we want to detach anyway is fine

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -149,8 +149,15 @@ export class BrowserTargetManager implements IDisposable {
 
   async closeBrowser(): Promise<void> {
     if (this.launchParams.request === 'launch') {
-      await this._browser.Browser.close({});
-      this.process?.kill();
+      if (this.launchParams.cleanUp === 'wholeBrowser') {
+        await this._browser.Browser.close({});
+        this.process?.kill();
+      } else {
+        for (const targetId of this._targets.keys()) {
+          await this._browser.Target.closeTarget({ targetId });
+        }
+      }
+
       this.process = undefined;
     }
   }
@@ -340,7 +347,11 @@ export class BrowserTargetManager implements IDisposable {
 
     if (!this._targets.size && this.launchParams.request === 'launch') {
       try {
-        await this._browser.Browser.close({});
+        if (this.launchParams.cleanUp === 'wholeBrowser') {
+          await this._browser.Browser.close({});
+        } else {
+          await this._browser.Target.closeTarget({ targetId });
+        }
       } catch {
         // ignored -- any network error when we want to detach anyway is fine
       }

--- a/src/targets/browser/launcher.ts
+++ b/src/targets/browser/launcher.ts
@@ -144,6 +144,8 @@ export async function launch(
       if (options.cleanUp === 'wholeBrowser') {
         await cdp.rootSession().Browser.close({});
         browserProcess.kill();
+      } else {
+        cdp.close();
       }
     };
     return { cdp: cdp, process: browserProcess };

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -440,6 +440,7 @@ export class TestRoot {
       runtimeExecutable: playwright.chromium.executablePath(),
       outFiles: [`${this._workspaceRoot}/**/*.js`, '!**/node_modules/**'],
       __workspaceFolder: this._workspaceRoot,
+      cleanUp: 'wholeBrowser', // We want the tests to clean up chrome afterwards
       ...options,
     } as AnyChromiumLaunchConfiguration);
 


### PR DESCRIPTION
Now we only kill the tab when the debugging sessions ends by default.
I added an option to keep the existing functionality too in case someone prefers that one.