### PR TITLE
Fix logging logic when we don't have sourcemapurl

### DIFF
--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -92,6 +92,8 @@ export default class Connection {
       objectToLog = { ...object, result: { ...object.result, scriptSource: '<script source>' } };
     } else if (
       object.method === 'Debugger.scriptParsed' &&
+      object.params &&
+      object.params.sourceMapURL &&
       object.params.sourceMapURL.startsWith('data:')
     ) {
       objectToLog = {


### PR DESCRIPTION
Handler was crashing when a sourceMapUrl wasn't specified