### PR TITLE
Improve user experience when content validation fails

### DIFF
--- a/src/dap/errors.ts
+++ b/src/dap/errors.ts
@@ -205,6 +205,16 @@ export const sourceMapParseFailed = (compiledUrl: string, message: string) =>
     localize('sourcemapParseError', 'Could not read source map for {0}: {1}', compiledUrl, message),
   );
 
+export const contentHashValidationFailed = (sourcePath: string, message: string) =>
+  createUserError(
+    localize(
+      'contentHashValidationError',
+      'Could not validate source on storage matches the one seen by the JavaScript engine {0}: {1}\n',
+      sourcePath,
+      message,
+    ),
+  );
+
 export class ProtocolError extends Error {
   public readonly cause: Dap.Message;
 


### PR DESCRIPTION
Show an error message when content validation fails. Return undefined so other code that depends on this can work as expected.

This is in response of having several reports of this error from telemetry:
```
Error [ERR_IPC_CHANNEL_CLOSED]: Channel closed
    at ChildProcess.send (internal/child_process.js:678:16)
    at send (index.js:37:8)
    at Object.verifyFile (index.js:56:66)
    at Object.checkContentHash (sourceUtils.js:253:24)
    at new A (sources.js:92:50)
    at O.source [as addSource] (sources.js:511:24)
    at threads.js:912:19
```