### PR TITLE
feat: implement webview debugging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,26 +1,17 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-	"javascript.validate.enable": false,
-	"typescript.tsdk": "node_modules/typescript/lib",
-	"files.trimTrailingWhitespace": true,
-	"editor.insertSpaces": true,
+  "javascript.validate.enable": false,
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "files.trimTrailingWhitespace": true,
+  "editor.insertSpaces": true,
   "editor.tabSize": 2,
   "editor.detectIndentation": false,
-  "typescript.preferences.quoteStyle": "single",
-  "workbench.colorCustomizations": {
-    "[Default Dark+]": {
-      "activityBar.background": "#105200"
-    },
-  },
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript"],
   "search.exclude": {
-    "**/testdata": true,
+    "**/testdata": true
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-},
+  },
+  "editor.formatOnSave": true
 }

--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ The following options can be configured:
   "--extensionDevelopmentPath=${workspaceFolder}"
 ]</pre></code><h4>autoAttachChildProcesses</h4><p>Attach debugger to new child processes automatically.</p>
 <h5>Default value:</h4><pre><code>false</pre></code><h4>cwd</h4><p>Absolute path to the working directory of the program being debugged.</p>
-<h5>Default value:</h4><pre><code>"${workspaceFolder}"</pre></code><h4>env</h4><p>Environment variables passed to the program. The value <code>null</code> removes the variable from the environment.</p>
+<h5>Default value:</h4><pre><code>"${workspaceFolder}"</pre></code><h4>debugWebviews</h4><p>Configures whether we should try to attach to webviews in the launched VS Code instance. <strong>Note:</strong> at the moment this requires the setting <code>&quot;webview.experimental.useExternalEndpoint&quot;: true</code> to work properly, and will only work in desktop VS Code.</p>
+<h5>Default value:</h4><pre><code>false</pre></code><h4>env</h4><p>Environment variables passed to the program. The value <code>null</code> removes the variable from the environment.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>envFile</h4><p>Absolute path to a file containing environment variable definitions.</p>
 <h5>Default value:</h4><pre><code>null</pre></code><h4>localRoot</h4><p>Path to the local directory containing the program.</p>
 <h5>Default value:</h4><pre><code>null</pre></code><h4>outFiles</h4><p>If source maps are enabled, these glob patterns specify the generated JavaScript files. If a pattern starts with <code>!</code> the files are excluded. If not specified, the generated code is expected in the same directory as its source.</p>

--- a/src/adapter/objectPreview/contexts.ts
+++ b/src/adapter/objectPreview/contexts.ts
@@ -30,7 +30,7 @@ export const enum PreviewContextType {
   Clipboard = 'clipboard',
 }
 
-const repl: IPreviewContext = { budget: 1000, quoted: true };
+const repl: IPreviewContext = { budget: 100_000, quoted: true };
 const hover: IPreviewContext = {
   budget: 1000,
   quoted: true,

--- a/src/build/dapCustom.ts
+++ b/src/build/dapCustom.ts
@@ -577,6 +577,9 @@ const dapCustom: JSONSchema4 = {
         env: {
           type: 'object',
         },
+        debugRenderer: {
+          type: 'boolean',
+        },
       },
     },
     LaunchVSCodeArgument: {
@@ -598,6 +601,17 @@ const dapCustom: JSONSchema4 = {
         {
           type: 'object',
           description: "Response to 'LaunchVSCode' request.",
+          required: ['body'],
+          properties: {
+            body: {
+              type: 'object',
+              properties: {
+                rendererDebugPort: {
+                  type: 'number',
+                },
+              },
+            },
+          },
         },
       ],
     },

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -670,45 +670,6 @@ const chromiumAttachConfigurationAttributes: ConfigurationAttributes<IChromeAtta
   },
 };
 
-const extensionHostConfig: IDebugger<IExtensionHostLaunchConfiguration> = {
-  type: DebugType.ExtensionHost,
-  request: 'launch',
-  label: refString('extensionHost.label'),
-  required: ['args'],
-  configurationSnippets: [
-    {
-      label: refString('extensionHost.snippet.launch.label'),
-      description: refString('extensionHost.snippet.launch.description'),
-      body: {
-        type: DebugType.ExtensionHost,
-        request: 'launch',
-        name: refString('extensionHost.launch.config.name'),
-        runtimeExecutable: '^"\\${execPath}"',
-        args: ['^"--extensionDevelopmentPath=\\${workspaceFolder}"'],
-        outFiles: ['^"\\${workspaceFolder}/out/**/*.js"'],
-        preLaunchTask: 'npm',
-      },
-    },
-  ],
-  configurationAttributes: {
-    ...nodeBaseConfigurationAttributes,
-    args: {
-      type: 'array',
-      description: refString('node.launch.args.description'),
-      items: {
-        type: 'string',
-      },
-      default: ['--extensionDevelopmentPath=${workspaceFolder}'],
-    },
-    runtimeExecutable: {
-      type: ['string', 'null'],
-      markdownDescription: refString('extensionHost.launch.runtimeExecutable.description'),
-      default: 'node',
-    },
-  },
-  defaults: extensionHostConfigDefaults,
-};
-
 const chromeLaunchConfig: IDebugger<IChromeLaunchConfiguration> = {
   type: DebugType.Chrome,
   request: 'launch',
@@ -818,6 +779,59 @@ const chromeAttachConfig: IDebugger<IChromeAttachConfiguration> = {
   ],
   configurationAttributes: chromiumAttachConfigurationAttributes,
   defaults: chromeAttachConfigDefaults,
+};
+
+const extensionHostConfig: IDebugger<IExtensionHostLaunchConfiguration> = {
+  type: DebugType.ExtensionHost,
+  request: 'launch',
+  label: refString('extensionHost.label'),
+  required: ['args'],
+  configurationSnippets: [
+    {
+      label: refString('extensionHost.snippet.launch.label'),
+      description: refString('extensionHost.snippet.launch.description'),
+      body: {
+        type: DebugType.ExtensionHost,
+        request: 'launch',
+        name: refString('extensionHost.launch.config.name'),
+        runtimeExecutable: '^"\\${execPath}"',
+        args: ['^"--extensionDevelopmentPath=\\${workspaceFolder}"'],
+        outFiles: ['^"\\${workspaceFolder}/out/**/*.js"'],
+        preLaunchTask: 'npm',
+      },
+    },
+  ],
+  configurationAttributes: {
+    ...nodeBaseConfigurationAttributes,
+    args: {
+      type: 'array',
+      description: refString('node.launch.args.description'),
+      items: {
+        type: 'string',
+      },
+      default: ['--extensionDevelopmentPath=${workspaceFolder}'],
+    },
+    runtimeExecutable: {
+      type: ['string', 'null'],
+      markdownDescription: refString('extensionHost.launch.runtimeExecutable.description'),
+      default: 'node',
+    },
+    debugWebviews: {
+      markdownDescription: refString('extensionHost.launch.debugWebviews'),
+      default: true,
+      oneOf: [
+        {
+          type: ['boolean'],
+          default: true,
+        },
+        {
+          type: 'object',
+          properties: chromiumAttachConfigurationAttributes as { [key: string]: JSONSchema6 },
+        },
+      ],
+    },
+  },
+  defaults: extensionHostConfigDefaults,
 };
 
 const edgeLaunchConfig: IDebugger<IEdgeLaunchConfiguration> = {

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -25,6 +25,8 @@ const strings = {
   'extensionHost.launch.config.name': 'Launch Extension',
   'extensionHost.launch.env.description': 'Environment variables passed to the extension host.',
   'extensionHost.launch.runtimeExecutable.description': 'Absolute path to VS Code.',
+  'extensionHost.launch.debugWebviews':
+    'Configures whether we should try to attach to webviews in the launched VS Code instance. **Note:** at the moment this requires the setting `"webview.experimental.useExternalEndpoint": true` to work properly, and will only work in desktop VS Code.',
   'extensionHost.launch.stopOnEntry.description':
     'Automatically stop the extension host after launch.',
   'extensionHost.snippet.launch.description': 'Launch a VS Code extension in debug mode',

--- a/src/cdp/api.d.ts
+++ b/src/cdp/api.d.ts
@@ -15626,6 +15626,11 @@ export namespace Cdp {
       showPositiveLineNumbers?: boolean;
 
       /**
+       * Show Negative line number labels (default: false).
+       */
+      showNegativeLineNumbers?: boolean;
+
+      /**
        * The grid container border highlight color (default: transparent).
        */
       gridBorderColor?: DOM.RGBA;

--- a/src/common/promiseUtil.ts
+++ b/src/common/promiseUtil.ts
@@ -2,7 +2,9 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 export const delay = (duration: number) =>
-  new Promise<void>(resolve => setTimeout(resolve, duration));
+  isFinite(duration)
+    ? new Promise<void>(resolve => setTimeout(resolve, duration))
+    : new Promise<void>(() => undefined);
 
 export interface IDeferred<T> {
   resolve: (result: T) => void;

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -11,7 +11,6 @@ import { promises as dns } from 'dns';
 import { memoize } from './objUtils';
 import { exists } from './fsUtils';
 import Cdp from '../cdp/api';
-import { BrowserTargetType } from '../targets/browser/browserTargets';
 
 let isCaseSensitive = process.platform !== 'win32';
 
@@ -400,14 +399,14 @@ export type TargetFilter = (info: Cdp.Target.TargetInfo) => boolean;
 export const createTargetFilterForConfig = (
   config: AnyChromiumConfiguration,
   additonalMatches: ReadonlyArray<string> = [],
-): ((t: { type: string; url: string }) => boolean) => {
+): ((t: { url: string }) => boolean) => {
   const filter = config.urlFilter || config.url || ('file' in config && config.file);
   if (!filter) {
-    return t => t.type === BrowserTargetType.Page;
+    return () => true;
   }
 
   const tester = createTargetFilter(filter, ...additonalMatches);
-  return t => t.type === BrowserTargetType.Page && tester(t.url);
+  return t => tester(t.url);
 };
 
 /**

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -11,6 +11,7 @@ import { promises as dns } from 'dns';
 import { memoize } from './objUtils';
 import { exists } from './fsUtils';
 import Cdp from '../cdp/api';
+import { BrowserTargetType } from '../targets/browser/browserTargets';
 
 let isCaseSensitive = process.platform !== 'win32';
 
@@ -399,14 +400,14 @@ export type TargetFilter = (info: Cdp.Target.TargetInfo) => boolean;
 export const createTargetFilterForConfig = (
   config: AnyChromiumConfiguration,
   additonalMatches: ReadonlyArray<string> = [],
-): ((t: { url: string }) => boolean) => {
+): ((t: { type: string; url: string }) => boolean) => {
   const filter = config.urlFilter || config.url || ('file' in config && config.file);
   if (!filter) {
-    return () => true;
+    return t => t.type === BrowserTargetType.Page;
   }
 
   const tester = createTargetFilter(filter, ...additonalMatches);
-  return t => tester(t.url);
+  return t => t.type === BrowserTargetType.Page && tester(t.url);
 };
 
 /**

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -192,6 +192,12 @@ export interface IExtensionHostLaunchConfiguration extends IExtensionHostBaseCon
   request: 'launch';
 
   /**
+   * Whether we should try to attach to webviews in the launched
+   * VS Code instance.
+   */
+  debugWebviews: boolean | Partial<IChromeAttachConfiguration>;
+
+  /**
    * Port the extension host is listening on.
    */
   port?: number;
@@ -205,10 +211,8 @@ export interface IExtensionHostLaunchConfiguration extends IExtensionHostBaseCon
 export interface IExtensionHostAttachConfiguration extends IExtensionHostBaseConfiguration {
   type: DebugType.ExtensionHost;
   request: 'attach';
-
-  /**
-   * Port the extension host is listening on.
-   */
+  debugWebviews: boolean | Partial<IChromeAttachConfiguration>;
+  __sessionId: string;
   port: number;
 }
 
@@ -732,6 +736,7 @@ export const extensionHostConfigDefaults: IExtensionHostLaunchConfiguration = {
   resolveSourceMapLocations: ['${workspaceFolder}/**', '!**/node_modules/**'],
   runtimeExecutable: '${execPath}',
   autoAttachChildProcesses: false,
+  debugWebviews: false,
   __sessionId: '',
 };
 

--- a/src/dap/api.d.ts
+++ b/src/dap/api.d.ts
@@ -2311,9 +2311,13 @@ export namespace Dap {
     args: LaunchVSCodeArgument[];
 
     env: object;
+
+    debugRenderer?: boolean;
   }
 
-  export interface LaunchVSCodeResult {}
+  export interface LaunchVSCodeResult {
+    rendererDebugPort?: number;
+  }
 
   export interface LoadedSourceEventParams {
     /**

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -82,6 +82,7 @@ import {
 import { LogPointCompiler } from './adapter/breakpoints/conditions/logPoint';
 import { OutFiles, VueComponentPaths } from './common/fileGlobList';
 import { IVueFileMapper, VueFileMapper } from './adapter/vueFileMapper';
+import { WebviewAttacher } from './targets/browser/webviewAttacher';
 
 /**
  * Contains IOC container factories for the extension. We use Inverisfy, which
@@ -110,6 +111,7 @@ export const createTargetContainer = (
 ) => {
   const container = new Container();
   container.parent = parent;
+  container.bind(AnyLaunchConfiguration).toConstantValue(target.launchConfig);
   container.bind(IContainer).toConstantValue(container);
   container.bind(IDapApi).toConstantValue(dap);
   container.bind(ICdpApi).toConstantValue(cdp);
@@ -188,6 +190,7 @@ export const createTopLevelSessionContainer = (parent: Container) => {
 
   // Launcher logic:
   container.bind(RestartPolicyFactory).toSelf();
+  container.bind(ILauncher).to(WebviewAttacher).onActivation(trackDispose);
   container.bind(ILauncher).to(ExtensionHostAttacher).onActivation(trackDispose);
   container.bind(ILauncher).to(ExtensionHostLauncher).onActivation(trackDispose);
   container.bind(ILauncher).to(NodeLauncher).onActivation(trackDispose);
@@ -279,6 +282,6 @@ export const provideLaunchParams = (container: Container, params: AnyLaunchConfi
 
   container
     .bind(ISourcePathResolver)
-    .toDynamicValue(ctx => ctx.container.get(SourcePathResolverFactory).create())
+    .toDynamicValue(ctx => ctx.container.get(SourcePathResolverFactory).create(params))
     .inSingletonScope();
 };

--- a/src/targets/browser/browserAttacher.ts
+++ b/src/targets/browser/browserAttacher.ts
@@ -7,7 +7,7 @@ import CdpConnection from '../../cdp/connection';
 import * as launcher from './launcher';
 import * as nls from 'vscode-nls';
 import type * as vscodeType from 'vscode';
-import { BrowserTargetManager } from './browserTargets';
+import { BrowserTargetManager, BrowserTargetType } from './browserTargets';
 import { ITarget, ILauncher, ILaunchResult, ILaunchContext, IStopMetadata } from '../targets';
 import { AnyLaunchConfiguration, AnyChromiumAttachConfiguration } from '../../configuration';
 import { DebugType } from '../../common/contributionUtils';
@@ -172,7 +172,8 @@ export class BrowserAttacher implements ILauncher {
     manager: BrowserTargetManager,
     params: AnyChromiumAttachConfiguration,
   ): Promise<TargetFilter> {
-    const baseFilter = createTargetFilterForConfig(params);
+    const rawFilter = createTargetFilterForConfig(params);
+    const baseFilter: TargetFilter = t => t.type === BrowserTargetType.Page && rawFilter(t);
     if (params.targetSelection !== 'pick') {
       return baseFilter;
     }

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -63,7 +63,7 @@ export type PauseOnExceptionsState = 'none' | 'uncaught' | 'all';
 
 export class BrowserTargetManager implements IDisposable {
   private _connection: CdpConnection;
-  private _targets: Map<Cdp.Target.TargetID, BrowserTarget> = new Map();
+  private _targets: Map<Cdp.Target.SessionID, BrowserTarget> = new Map();
   private _browser: Cdp.Api;
   readonly frameModel = new FrameModel();
   readonly serviceWorkerModel = new ServiceWorkerModel(this.frameModel);
@@ -153,8 +153,8 @@ export class BrowserTargetManager implements IDisposable {
         await this._browser.Browser.close({});
         this.process?.kill();
       } else {
-        for (const targetId of this._targets.keys()) {
-          await this._browser.Target.closeTarget({ targetId });
+        for (const target of this._targets.values()) {
+          await this._browser.Target.closeTarget({ targetId: target.targetId });
           this._connection.close();
         }
       }
@@ -175,12 +175,11 @@ export class BrowserTargetManager implements IDisposable {
     const detachedTargets = new Set<Cdp.Target.TargetID>();
     const promise = new Promise<BrowserTarget | undefined>(f => (callback = f));
     const attachInner = async ({ targetInfo }: { targetInfo: Cdp.Target.TargetInfo }) => {
-      if (this._targets.has(targetInfo.targetId) || detachedTargets.has(targetInfo.targetId)) {
+      if (
+        [...this._targets.values()].some(t => t.targetId === targetInfo.targetId) ||
+        detachedTargets.has(targetInfo.targetId)
+      ) {
         return; // targetInfoChanged on something we're already connected to
-      }
-
-      if (targetInfo.type !== 'page') {
-        return;
       }
 
       if (filter && !filter(targetInfo)) {
@@ -213,18 +212,20 @@ export class BrowserTargetManager implements IDisposable {
       callback(this._attachedToTarget(targetInfo, response.sessionId, true));
     };
 
-    const attemptAttach = (info: { targetInfo: Cdp.Target.TargetInfo }) => {
-      attachmentQueue = attachmentQueue.then(() => attachInner(info));
-    };
+    const enqueueCall = <T>(fn: (arg: T) => Promise<void>) => (arg: T) =>
+      (attachmentQueue = attachmentQueue.then(() => fn(arg)));
 
     this._browser.Target.setDiscoverTargets({ discover: true });
-    this._browser.Target.on('targetCreated', attemptAttach); // new page
-    this._browser.Target.on('targetInfoChanged', attemptAttach); // nav on existing page
-    this._browser.Target.on('detachedFromTarget', event => {
-      if (event.targetId) {
-        this._detachedFromTarget(event.targetId, false);
-      }
-    });
+    this._browser.Target.on('targetCreated', enqueueCall(attachInner)); // new page
+    this._browser.Target.on('targetInfoChanged', enqueueCall(attachInner)); // nav on existing page
+    this._browser.Target.on(
+      'detachedFromTarget',
+      enqueueCall(async event => {
+        if (event.targetId) {
+          await this._detachedFromTarget(event.sessionId, false);
+        }
+      }),
+    );
     this.onTargetRemoved(target => {
       detachedTargets.add(target.id());
     });
@@ -238,6 +239,11 @@ export class BrowserTargetManager implements IDisposable {
     waitingForDebugger: boolean,
     parentTarget?: BrowserTarget,
   ): BrowserTarget {
+    const existing = this._targets.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
     const cdp = this._connection.createSession(sessionId);
     const target = new BrowserTarget(
       this,
@@ -245,13 +251,15 @@ export class BrowserTargetManager implements IDisposable {
       cdp,
       parentTarget,
       waitingForDebugger,
+      this.launchParams,
+      sessionId,
       this.logger,
       () => {
         this._connection.disposeSession(sessionId);
-        this._detachedFromTarget(targetInfo.targetId);
+        this._detachedFromTarget(sessionId);
       },
     );
-    this._targets.set(targetInfo.targetId, target);
+    this._targets.set(sessionId, target);
     if (parentTarget) parentTarget._children.set(targetInfo.targetId, target);
 
     cdp.Target.on('attachedToTarget', async event => {
@@ -259,7 +267,7 @@ export class BrowserTargetManager implements IDisposable {
     });
     cdp.Target.on('detachedFromTarget', async event => {
       if (event.targetId) {
-        this._detachedFromTarget(event.targetId, false);
+        this._detachedFromTarget(event.sessionId, false);
       }
     });
     cdp.Target.setAutoAttach({ autoAttach: true, waitForDebuggerOnStart: true, flatten: true });
@@ -322,18 +330,14 @@ export class BrowserTargetManager implements IDisposable {
     }
   }
 
-  async _detachedFromTarget(targetId: string, isStillAttachedInternally = true) {
-    const target = this._targets.get(targetId);
+  async _detachedFromTarget(sessionId: string, isStillAttachedInternally = true) {
+    const target = this._targets.get(sessionId);
     if (!target) {
       return;
     }
 
-    this._targets.delete(targetId);
-    target.parentTarget?._children.delete(targetId);
-
-    await Promise.all(
-      [...target._children.keys()].map(k => this._detachedFromTarget(k, isStillAttachedInternally)),
-    );
+    this._targets.delete(sessionId);
+    target.parentTarget?._children.delete(sessionId);
 
     try {
       await target._detached();
@@ -343,7 +347,7 @@ export class BrowserTargetManager implements IDisposable {
 
     this._onTargetRemovedEmitter.fire(target);
     if (isStillAttachedInternally) {
-      await this._browser.Target.detachFromTarget({ targetId });
+      await this._browser.Target.detachFromTarget({ sessionId });
     }
 
     if (!this._targets.size && this.launchParams.request === 'launch') {
@@ -351,7 +355,7 @@ export class BrowserTargetManager implements IDisposable {
         if (this.launchParams.cleanUp === 'wholeBrowser') {
           await this._browser.Browser.close({});
         } else {
-          await this._browser.Target.closeTarget({ targetId });
+          await this._browser.Target.closeTarget({ targetId: target.id() });
           this._connection.close();
         }
       } catch {
@@ -361,18 +365,17 @@ export class BrowserTargetManager implements IDisposable {
   }
 
   private _targetInfoChanged(targetInfo: Cdp.Target.TargetInfo) {
-    const target = this._targets.get(targetInfo.targetId);
-    if (!target) {
-      return;
+    for (const target of this._targets.values()) {
+      if (target.targetId === targetInfo.targetId) {
+        target._updateFromInfo(targetInfo);
+      }
     }
-
-    target._updateFromInfo(targetInfo);
 
     // fire name changes for everyone since this might have caused a duplicate
     // title that we want to disambiguate.
-    for (const otherTarget of this._targets.values()) {
-      if (target !== otherTarget) {
-        otherTarget._onNameChangedEmitter.fire();
+    for (const target of this._targets.values()) {
+      if (target.targetId !== targetInfo.targetId) {
+        target._onNameChangedEmitter.fire();
       }
     }
   }
@@ -390,6 +393,10 @@ export class BrowserTarget implements ITarget, IThreadDelegate {
   readonly onNameChanged = this._onNameChangedEmitter.event;
   public readonly entryBreakpoint = undefined;
 
+  public get targetId() {
+    return this._targetInfo.targetId;
+  }
+
   _children: Map<Cdp.Target.TargetID, BrowserTarget> = new Map();
 
   constructor(
@@ -398,6 +405,8 @@ export class BrowserTarget implements ITarget, IThreadDelegate {
     cdp: Cdp.Api,
     parentTarget: BrowserTarget | undefined,
     waitingForDebugger: boolean,
+    public readonly launchConfig: AnyChromiumConfiguration,
+    public readonly sessionId: string,
     public readonly logger: ILogger,
     ondispose: (t: BrowserTarget) => void,
   ) {
@@ -417,7 +426,7 @@ export class BrowserTarget implements ITarget, IThreadDelegate {
   }
 
   id(): string {
-    return this._targetInfo.targetId;
+    return this.sessionId;
   }
 
   cdp(): Cdp.Api {
@@ -507,7 +516,7 @@ export class BrowserTarget implements ITarget, IThreadDelegate {
 
   async detach(): Promise<void> {
     this._attached = false;
-    this._manager._detachedFromTarget(this.id());
+    this._manager._detachedFromTarget(this.sessionId);
   }
 
   executionContextName(description: Cdp.Runtime.ExecutionContextDescription): string {

--- a/src/targets/browser/webviewAttacher.ts
+++ b/src/targets/browser/webviewAttacher.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { injectable, inject } from 'inversify';
+import { BrowserAttacher } from './browserAttacher';
+import {
+  applyDefaults,
+  IChromeAttachConfiguration,
+  AnyLaunchConfiguration,
+  AnyChromiumAttachConfiguration,
+} from '../../configuration';
+import { DebugType } from '../../common/contributionUtils';
+import type * as vscodeType from 'vscode';
+import { ILaunchContext } from '../targets';
+import { createConnection, Socket } from 'net';
+import { ITelemetryReporter } from '../../telemetry/telemetryReporter';
+import { RawPipeTransport } from '../../cdp/rawPipeTransport';
+import Connection from '../../cdp/connection';
+import { SourcePathResolverFactory } from '../sourcePathResolverFactory';
+import { ILogger } from '../../common/logging';
+import { ISourcePathResolver } from '../../common/sourcePathResolver';
+import { BrowserTargetManager, BrowserTargetType } from './browserTargets';
+import { DisposableList } from '../../common/disposable';
+import { TargetFilter } from '../../common/urlUtils';
+
+@injectable()
+export class WebviewAttacher extends BrowserAttacher {
+  /**
+   * Map of debug IDs to ports the renderer is listening on,
+   * set from the {@see ExtensionHostLauncher}.
+   */
+  public static readonly debugIdToRendererDebugPort = new Map<string, number>();
+
+  constructor(
+    @inject(ILogger) logger: ILogger,
+    @inject(ISourcePathResolver) pathResolver: ISourcePathResolver,
+    @inject(SourcePathResolverFactory)
+    private readonly pathResolverFactory: SourcePathResolverFactory,
+  ) {
+    super(logger, pathResolver);
+  }
+
+  /**
+   * @override
+   */
+  public async launch(params: AnyLaunchConfiguration, context: ILaunchContext) {
+    if (params.type !== DebugType.ExtensionHost || params.request !== 'attach') {
+      return { blockSessionTermination: false };
+    }
+
+    const rendererPort = WebviewAttacher.debugIdToRendererDebugPort.get(params.__sessionId);
+    if (!rendererPort) {
+      return { blockSessionTermination: false };
+    }
+
+    const configuration = applyDefaults({
+      name: 'Webview',
+      type: DebugType.Chrome,
+      request: 'attach',
+      port: rendererPort,
+      __workspaceFolder: params.__workspaceFolder,
+      urlFilter: '',
+      ...(typeof params.debugWebviews === 'object' ? params.debugWebviews : {}),
+    }) as IChromeAttachConfiguration;
+
+    return super.launch(configuration, context);
+  }
+
+  /**
+   * @override
+   */
+  protected async acquireConnectionInner(
+    telemetryReporter: ITelemetryReporter,
+    params: AnyChromiumAttachConfiguration,
+    cancellationToken: vscodeType.CancellationToken,
+  ) {
+    const disposable = new DisposableList();
+    const pipe = await new Promise<Socket>((resolve, reject) => {
+      const p: Socket = createConnection({ port: params.port }, () => resolve(p));
+      p.on('error', reject);
+
+      disposable.push(
+        cancellationToken.onCancellationRequested(() => {
+          p.destroy();
+          reject(new Error('connection timed out'));
+        }),
+      );
+    }).finally(() => disposable.dispose());
+
+    return new Connection(new RawPipeTransport(this.logger, pipe), this.logger, telemetryReporter);
+  }
+
+  protected async getTargetFilter(): Promise<TargetFilter> {
+    return target => target.type === BrowserTargetType.IFrame;
+  }
+
+  /**
+   * @override
+   */
+  protected async createTargetManager(
+    connection: Connection,
+    params: AnyChromiumAttachConfiguration,
+    context: ILaunchContext,
+  ) {
+    return new BrowserTargetManager(
+      connection,
+      undefined,
+      connection.rootSession(),
+      this.pathResolverFactory.create(params),
+      this.logger,
+      context.telemetryReporter,
+      params,
+      context.targetOrigin,
+    );
+  }
+}

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -382,6 +382,7 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
     }
 
     const target = new NodeTarget(
+      this.run.params,
       this.run.pathResolver,
       this.run.context.targetOrigin,
       connection,

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -12,6 +12,7 @@ import { absolutePathToFileUrl } from '../../common/urlUtils';
 import { ITargetOrigin } from '../targetOrigin';
 import { ITarget, IBreakpointPathAndId } from '../targets';
 import { ILogger, LogTag } from '../../common/logging';
+import { AnyNodeConfiguration } from '../../configuration';
 
 export interface INodeTargetLifecycleHooks {
   /**
@@ -44,6 +45,7 @@ export class NodeTarget implements ITarget, IThreadDelegate {
   public readonly onNameChanged = this._onNameChangedEmitter.event;
 
   constructor(
+    public readonly launchConfig: AnyNodeConfiguration,
     private readonly pathResolver: ISourcePathResolver,
     private readonly targetOriginValue: ITargetOrigin,
     public readonly connection: Connection,

--- a/src/targets/sourcePathResolverFactory.ts
+++ b/src/targets/sourcePathResolverFactory.ts
@@ -16,14 +16,12 @@ import { IVueFileMapper } from '../adapter/vueFileMapper';
 @injectable()
 export class SourcePathResolverFactory {
   constructor(
-    @inject(AnyLaunchConfiguration) private readonly config: AnyLaunchConfiguration,
     @inject(IInitializeParams) private readonly initializeParams: Dap.InitializeParams,
     @inject(ILogger) private readonly logger: ILogger,
     @inject(IVueFileMapper) private readonly vueMapper: IVueFileMapper,
   ) {}
 
-  public create() {
-    const c = this.config;
+  public create(c: AnyLaunchConfiguration) {
     if (
       c.type === DebugType.Node ||
       c.type === DebugType.Terminal ||

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -20,6 +20,13 @@ export const ITarget = Symbol('ITarget');
  * actually get a debug adapter API.
  */
 export interface ITarget {
+  /**
+   * Launch configuration for the target. This is used to inject into the IOC
+   * in cases where a target's configuration is different than its parent's
+   * (e.g. webview debugging in the extension host).
+   */
+  readonly launchConfig: AnyLaunchConfiguration;
+
   id(): string;
   name(): string;
   onNameChanged: IEvent<void>;

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -37,6 +37,7 @@ import { tmpdir, EOL } from 'os';
 import { forceForwardSlashes } from '../common/pathUtils';
 import playwright from 'playwright';
 import { DebugType } from '../common/contributionUtils';
+import { BrowserTarget } from '../targets/browser/browserTargets';
 
 export const kStabilizeNames = ['id', 'threadId', 'sourceReference', 'variablesReference'];
 
@@ -237,7 +238,7 @@ export class TestP implements ITestHandle {
     const result = await this._connection.rootSession().Target.attachToBrowserTarget({});
     const testSession = this._connection.createSession(result!.sessionId);
     const { sessionId } = (await testSession.Target.attachToTarget({
-      targetId: this._target.id(),
+      targetId: this._target instanceof BrowserTarget ? this._target.targetId : this._target.id(),
       flatten: true,
     }))!;
     this._cdp = this._connection.createSession(sessionId);


### PR DESCRIPTION
- soft dependency on microsoft/vscode#100242
- fixes microsoft/vscode#100242

With these changes, you can now add `debugWebviews: true` (or a Chrome
configuration object) to an extension host configuration to attach
and debug webviews. It works.

![](https://memes.peet.io/img/20-06-787960a9-f2de-4879-bee3-d7088738cea0.png)

Todo:

- As mentioned, this only works with iframe-based webviews. This is where
  VS Code is moving towards and Electron webviews are a different beast
	that I don't think it's worth dealing with.
- Currently, it attaches to all webviews in Code instances
- The name of the webview debug sessions is a long URL

This can be most easily fixed by exposing some data in the webview
title, cc @mjbvz. Alternatively, we could have some messaging in a
custom message that the main process can send over to js-debug to tell
it about webviews.