### PR TITLE
Wait for configuration before resuming pages

### DIFF
--- a/src/targets/browser/frames.ts
+++ b/src/targets/browser/frames.ts
@@ -24,6 +24,7 @@ export class FrameModel {
     cdp.Page.getResourceTree({}).then(result => {
       this._processCachedResources(cdp, result ? result.frameTree : undefined, targetId);
     });
+    cdp.Page.waitForDebugger({});
   }
 
   mainFrame(): Frame | undefined {


### PR DESCRIPTION
We now block pages from executing until we can set all the configuration (breakpoints, exceptions, etc...).

This will make it that we'll hit more breakpoints reliable