### PR TITLE
Add support for old CDP APIs for back compatibility with ios-webkit-debug-proxy

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -515,6 +515,10 @@ export class Thread implements IVariableStoreDelegate {
     this._cdp.Debugger.on('paused', async event => this._onPaused(event));
     this._cdp.Debugger.on('resumed', () => this.onResumed());
     this._cdp.Debugger.on('scriptParsed', event => this._onScriptParsed(event));
+    this._cdp.Console.enable({}).catch(() => {
+      /* Specifically ignore a fail here since it's only for backcompat */
+    });
+    this._cdp.Debugger.setBreakpointsActive({ active: true }); // This call is used for some non-standard runtimes like: https://github.com/google/ios-webkit-debug-proxy
     this._cdp.Runtime.enable({});
 
     if (!this.launchConfig.noDebug) {

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -516,10 +516,15 @@ export class Thread implements IVariableStoreDelegate {
     this._cdp.Debugger.on('paused', async event => this._onPaused(event));
     this._cdp.Debugger.on('resumed', () => this.onResumed());
     this._cdp.Debugger.on('scriptParsed', event => this._onScriptParsed(event));
+
+    // These calls are used for some non-standard runtimes like: https://github.com/google/ios-webkit-debug-proxy
     this._cdp.Console.enable({}).catch(() => {
       /* Specifically ignore a fail here since it's only for backcompat */
     });
-    this._cdp.Debugger.setBreakpointsActive({ active: true }); // This call is used for some non-standard runtimes like: https://github.com/google/ios-webkit-debug-proxy
+    this._cdp.Debugger.setBreakpointsActive({ active: true }).catch(() => {
+      /* Specifically ignore a fail here since it's only for backcompat */
+    });
+
     this._cdp.Runtime.enable({});
 
     if (!this.launchConfig.noDebug) {

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -636,7 +636,7 @@ export class Thread implements IVariableStoreDelegate {
         type: event.message.type,
         timestamp: event.message.timestamp,
         args: event.message.parameters || [{ type: 'string', value: event.message.text }],
-        stackTrace: event.message.stack,
+        stackTrace: { callFrames: event.message.stack || event.message.stackTrace },
         executionContextId: 1,
       };
       const slot = this._claimOutputSlot();


### PR DESCRIPTION
Fixes #647
Hi @connor4312 . Ported some handlers from [vscode-chrome-debug-core](https://github.com/microsoft/vscode-chrome-debug-core) for compatibility with updated Cordova Tools iOS debugger and React Native Tools iOS direct debugger with [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-proxy) usage.
Please let me know if any additional checks or tests for these scenarios are needed. 