### PR TITLE
don't smart step entry breakpoint

### DIFF
--- a/src/adapter/smartStepping.ts
+++ b/src/adapter/smartStepping.ts
@@ -37,7 +37,7 @@ export class SmartStepper {
   constructor(
     private readonly launchConfig: AnyLaunchConfiguration,
     private readonly logger: ILogger,
-  ) { }
+  ) {}
 
   private resetSmartStepCount(): void {
     if (this._smartStepCount > 0) {

--- a/src/adapter/smartStepping.ts
+++ b/src/adapter/smartStepping.ts
@@ -25,7 +25,7 @@ export async function shouldSmartStepStackFrame(stackFrame: StackFrame): Promise
   return false;
 }
 
-const neverStepReasons: ReadonlySet<PausedReason> = new Set(['breakpoint', 'exception']);
+const neverStepReasons: ReadonlySet<PausedReason> = new Set(['breakpoint', 'exception', 'entry']);
 
 /**
  * The SmartStepper is a device that controls stepping through code that lacks
@@ -37,7 +37,7 @@ export class SmartStepper {
   constructor(
     private readonly launchConfig: AnyLaunchConfiguration,
     private readonly logger: ILogger,
-  ) {}
+  ) { }
 
   private resetSmartStepCount(): void {
     if (this._smartStepCount > 0) {


### PR DESCRIPTION
We run into the issue of the debugger pausing on the first line when we have smart stepping turned on for the entry breakpoint.