### PR TITLE
feat: Create the VS Debug Server mode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -273,6 +273,12 @@ gulp.task('flatSessionBundle:webpack-bundle', async () => {
   return runWebpack({ packages, devtool: 'nosources-source-map' });
 });
 
+/** Run webpack to bundle into the VS debug server */
+gulp.task('flatSessionBundle:webpack-bundle', async () => {
+  const packages = [{ entry: `${buildSrcDir}/vsDebugServer.js`, library: true }];
+  return runWebpack({ packages, devtool: 'nosources-source-map' });
+});
+
 /** Copy the extension static files */
 gulp.task('package:copy-extension-files', () =>
   merge(
@@ -375,6 +381,17 @@ gulp.task(
 
 gulp.task(
   'flatSessionBundle',
+  gulp.series(
+    'clean',
+    'compile',
+    'flatSessionBundle:webpack-bundle',
+    'package:copy-extension-files',
+    gulp.parallel('nls:bundle-download', 'nls:bundle-create'),
+  ),
+);
+
+gulp.task(
+  'vsDebugServerBundle',
   gulp.series(
     'clean',
     'compile',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -274,7 +274,7 @@ gulp.task('flatSessionBundle:webpack-bundle', async () => {
 });
 
 /** Run webpack to bundle into the VS debug server */
-gulp.task('flatSessionBundle:webpack-bundle', async () => {
+gulp.task('vsDebugServerBundle:webpack-bundle', async () => {
   const packages = [{ entry: `${buildSrcDir}/vsDebugServer.js`, library: true }];
   return runWebpack({ packages, devtool: 'nosources-source-map' });
 });
@@ -390,11 +390,13 @@ gulp.task(
   ),
 );
 
+// for now, this task will build both flat session and debug server until we no longer need flat session
 gulp.task(
   'vsDebugServerBundle',
   gulp.series(
     'clean',
     'compile',
+    'vsDebugServerBundle:webpack-bundle',
     'flatSessionBundle:webpack-bundle',
     'package:copy-extension-files',
     gulp.parallel('nls:bundle-download', 'nls:bundle-create'),

--- a/src/flatSessionLauncher.ts
+++ b/src/flatSessionLauncher.ts
@@ -15,7 +15,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { createGlobalContainer } from './ioc';
-import { IDebugSessionLike, SessionManager, SessionLauncher } from './sessionManager';
+import { IDebugSessionLike, SessionManager, ISessionLauncher } from './sessionManager';
 import { getDeferred } from './common/promiseUtil';
 import DapConnection from './dap/connection';
 import { IDapTransport, StreamDapTransport, SessionIdDapTransport } from './dap/transport';
@@ -70,29 +70,31 @@ class VSSessionManager {
     });
   }
 
-  buildVSSessionLauncher(): SessionLauncher<VSDebugSession> {
-    return (parentSession, target, config) => {
-      const childAttachConfig = { ...config, sessionId: target.id() };
+  buildVSSessionLauncher(): ISessionLauncher<VSDebugSession> {
+    return {
+      launch: (parentSession, target, config) => {
+        const childAttachConfig = { ...config, sessionId: target.id() };
 
-      this.createSession(target.id(), target.name(), childAttachConfig);
+        this.createSession(target.id(), target.name(), childAttachConfig);
 
-      // Custom message currently not part of DAP
-      parentSession.connection._send({
-        seq: 0,
-        command: 'attachedChildSession',
-        type: 'request',
-        arguments: {
-          config: childAttachConfig,
-        },
-      });
+        // Custom message currently not part of DAP
+        parentSession.connection._send({
+          seq: 0,
+          command: 'attachedChildSession',
+          type: 'request',
+          arguments: {
+            config: childAttachConfig,
+          },
+        });
+      },
     };
   }
 
   createSession(sessionId: string | undefined, name: string, config: IPseudoAttachConfiguration) {
     const deferredConnection = getDeferred<DapConnection>();
-    const newSession = this.sessionManager.createNewSession(
+    const newSession = this.sessionManager.createNewChildSession(
       new VSDebugSession(sessionId || 'root', name, deferredConnection.promise, config),
-      config,
+      config.__pendingTargetId,
       new SessionIdDapTransport(sessionId, this.rootTransport),
     );
     deferredConnection.resolve(newSession.connection);

--- a/src/serverSessionManager.ts
+++ b/src/serverSessionManager.ts
@@ -100,6 +100,7 @@ export class ServerSessionManager<T extends IDebugSessionLike> {
       const session = sessionCreationFunc(transport);
       deferredConnection.resolve(session.connection);
     });
+    debugServer.on('error', deferredConnection.reject);
     debugServer.listen(debugServerPort || 0);
     this.servers.set(debugSession.id, debugServer);
 

--- a/src/serverSessionManager.ts
+++ b/src/serverSessionManager.ts
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { SessionManager, ISessionLauncher, IDebugSessionLike, Session } from './sessionManager';
+import { IDisposable } from './common/disposable';
+import * as net from 'net';
+import { Container } from 'inversify';
+import { StreamDapTransport, IDapTransport } from './dap/transport';
+import { IPseudoAttachConfiguration } from './configuration';
+import { getDeferred, IDeferred } from './common/promiseUtil';
+import DapConnection from './dap/connection';
+import { Readable, Writable } from 'stream';
+
+interface IDebugServerCreateResult {
+  server: net.Server;
+  connectionPromise: Promise<DapConnection>;
+}
+
+/**
+ * A class for handling specifically server-based sessions in js-debug
+ */
+export class ServerSessionManager<T extends IDebugSessionLike> {
+  private readonly sessionManager: SessionManager<T>;
+  private disposables: IDisposable[] = [];
+  private servers = new Map<string, net.Server>();
+
+  constructor(globalContainer: Container, sessionLauncher: ISessionLauncher<T>) {
+    this.sessionManager = new SessionManager(globalContainer, sessionLauncher);
+    this.disposables.push(this.sessionManager);
+  }
+
+  /**
+   * Create the appropriate debug server type from the configuration passed in the debug session
+   * @param debugSession The IDE-specific debug session
+   * @param debugServerPort Optional debug port to specify the listening port for the server
+   */
+  public createDebugServer(debugSession: T, debugServerPort?: number) {
+    if ((debugSession.configuration as IPseudoAttachConfiguration).__pendingTargetId) {
+      return this.createChildDebugServer(debugSession);
+    } else {
+      return this.createRootDebugServer(debugSession, debugServerPort);
+    }
+  }
+
+  /**
+   * Create a new debug server for a new root session
+   * @param debugSession The IDE-specific debug session
+   * @returns The newly created debug server and a promise which resolves to the DapConnection associated with the session
+   */
+  public createRootDebugServer(
+    debugSession: T,
+    debugServerPort?: number,
+  ): IDebugServerCreateResult {
+    return this.innerCreateServer(
+      debugSession,
+      transport => this.sessionManager.createNewRootSession(debugSession, transport),
+      debugServerPort,
+    );
+  }
+
+  /**
+   * Create a new root debug session using an existing set of streams
+   * @param debugSession The IDE-specific debug session
+   * @param inputStream The DAP input stream
+   * @param outputStream The DAP output stream
+   */
+  public createRootDebugSessionFromStreams(
+    debugSession: T,
+    inputStream: Readable,
+    outputStream: Writable,
+  ): Session<T> {
+    const transport = new StreamDapTransport(inputStream, outputStream);
+    return this.sessionManager.createNewRootSession(debugSession, transport);
+  }
+
+  /**
+   * Create a new debug server for a new child session
+   * @param debugSession The IDE-specific debug session
+   * @returns The newly created debug server and a promise which resolves to the DapConnection associated with the session
+   */
+  public createChildDebugServer(debugSession: T): IDebugServerCreateResult {
+    return this.innerCreateServer(debugSession, transport =>
+      this.sessionManager.createNewChildSession(
+        debugSession,
+        (debugSession.configuration as IPseudoAttachConfiguration).__pendingTargetId,
+        transport,
+      ),
+    );
+  }
+
+  private innerCreateServer(
+    debugSession: T,
+    sessionCreationFunc: (transport: IDapTransport) => Session<T>,
+    debugServerPort?: number,
+  ): IDebugServerCreateResult {
+    const deferredConnection: IDeferred<DapConnection> = getDeferred();
+    const debugServer = net.createServer(socket => {
+      const transport = new StreamDapTransport(socket, socket);
+      const session = sessionCreationFunc(transport);
+      deferredConnection.resolve(session.connection);
+    });
+    debugServer.listen(debugServerPort || 0);
+    this.servers.set(debugSession.id, debugServer);
+
+    return { server: debugServer, connectionPromise: deferredConnection.promise };
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public terminate(debugSession: T) {
+    this.sessionManager.terminate(debugSession);
+    this.servers.get(debugSession.id)?.close();
+    this.servers.delete(debugSession.id);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public dispose() {
+    this.disposables.forEach(d => d.dispose());
+  }
+}

--- a/src/serverSessionManager.ts
+++ b/src/serverSessionManager.ts
@@ -120,6 +120,6 @@ export class ServerSessionManager<T extends IDebugSessionLike> {
    * @inheritdoc
    */
   public dispose() {
-    this.disposables.forEach(d => d.dispose());
+    this.sessionManager.dispose();
   }
 }

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -28,13 +28,12 @@ export interface IDebugSessionLike {
 }
 
 /**
- * Function signature for defining how to launch a new debug session on the host
+ * Interface for defining how to launch a new debug session on the host IDE
  */
-export type SessionLauncher<T extends IDebugSessionLike> = (
-  parentSession: Session<T>,
-  target: ITarget,
-  config: IPseudoAttachConfiguration,
-) => void;
+
+export interface ISessionLauncher<T extends IDebugSessionLike> {
+  launch(parentSession: Session<T>, target: ITarget, config: IPseudoAttachConfiguration): void;
+}
 
 /**
  * Encapsulates a running debug session under DAP
@@ -125,7 +124,7 @@ export class SessionManager<TSessionImpl extends IDebugSessionLike>
 
   constructor(
     private readonly globalContainer: Container,
-    private readonly sessionLauncher: SessionLauncher<TSessionImpl>,
+    private readonly sessionLauncher: ISessionLauncher<TSessionImpl>,
   ) {}
 
   public terminate(debugSession: TSessionImpl) {
@@ -134,48 +133,45 @@ export class SessionManager<TSessionImpl extends IDebugSessionLike>
     if (session) session.dispose();
   }
 
+  public createNewRootSession(debugSession: TSessionImpl, transport: IDapTransport) {
+    const root = new RootSession(
+      debugSession,
+      transport,
+      createTopLevelSessionContainer(this.globalContainer),
+    );
+    root.createBinder(this);
+    this._sessions.set(debugSession.id, root);
+    return root;
+  }
+
   /**
    * @inheritdoc
    */
-  public createNewSession(
+  public createNewChildSession(
     debugSession: TSessionImpl,
-    config: IPseudoAttachConfiguration,
+    pendingTargetId: string,
     transport: IDapTransport,
   ): Session<TSessionImpl> {
-    let session: Session<TSessionImpl>;
-
-    const pendingTargetId = config.__pendingTargetId;
-    if (pendingTargetId) {
-      const pending = this._pendingTarget.get(pendingTargetId);
-      if (!pending) {
-        throw new Error(`Cannot find target ${pendingTargetId}`);
-      }
-
-      const { target, parent } = pending;
-      session = new Session<TSessionImpl>(
-        debugSession,
-        transport,
-        parent.logger,
-        parent.sessionStates,
-        parent,
-      );
-
-      this._pendingTarget.delete(pendingTargetId);
-      session.debugSession.name = target.name();
-      session.listenToTarget(target);
-      const callbacks = this._sessionForTargetCallbacks.get(target);
-      this._sessionForTargetCallbacks.delete(target);
-      callbacks?.fulfill?.(session);
-    } else {
-      const root = new RootSession(
-        debugSession,
-        transport,
-        createTopLevelSessionContainer(this.globalContainer),
-      );
-      root.createBinder(this);
-      session = root;
+    const pending = this._pendingTarget.get(pendingTargetId);
+    if (!pending) {
+      throw new Error(`Cannot find target ${pendingTargetId}`);
     }
 
+    const { target, parent } = pending;
+    const session = new Session<TSessionImpl>(
+      debugSession,
+      transport,
+      parent.logger,
+      parent.sessionStates,
+      parent,
+    );
+
+    this._pendingTarget.delete(pendingTargetId);
+    session.debugSession.name = target.name();
+    session.listenToTarget(target);
+    const callbacks = this._sessionForTargetCallbacks.get(target);
+    this._sessionForTargetCallbacks.delete(target);
+    callbacks?.fulfill?.(session);
     this._sessions.set(debugSession.id, session);
     return session;
   }
@@ -228,7 +224,7 @@ export class SessionManager<TSessionImpl extends IDebugSessionLike>
         postRestartTask: parentConfig.preLaunchTask,
       };
 
-      this.sessionLauncher(parentSession, target, config);
+      this.sessionLauncher.launch(parentSession, target, config);
     });
 
     this._sessionForTarget.set(target, newSession);

--- a/src/vsDebugServer.ts
+++ b/src/vsDebugServer.ts
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+require('source-map-support').install(); // Enable TypeScript stack traces translation
+import 'reflect-metadata';
+
+/**
+ * This script launches vscode-js-debug in server mode for Visual Studio
+ */
+import * as net from 'net';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createGlobalContainer } from './ioc';
+import { IDebugSessionLike, ISessionLauncher, Session } from './sessionManager';
+import { getDeferred, IDeferred } from './common/promiseUtil';
+import DapConnection from './dap/connection';
+import { IPseudoAttachConfiguration } from './configuration';
+import { DebugConfiguration } from 'vscode';
+import { ServerSessionManager } from './serverSessionManager';
+import { ITarget } from './targets/targets';
+import { Readable, Writable } from 'stream';
+
+const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-js-debug-'));
+
+class VSDebugSession implements IDebugSessionLike {
+  constructor(
+    public id: string,
+    name: string,
+    private readonly childConnection: Promise<DapConnection>,
+    public readonly configuration: DebugConfiguration,
+  ) {
+    this._name = name;
+  }
+
+  private _name: string;
+  set name(newName: string) {
+    this._name = newName;
+    this.childConnection
+      .then(conn => conn.initializedBlocker)
+      .then(conn => conn.dap())
+      .then(dap => {
+        dap.process({ name: newName });
+      });
+  }
+  get name() {
+    return this._name;
+  }
+}
+
+class VsDebugServer implements ISessionLauncher<VSDebugSession> {
+  private readonly sessionServer: ServerSessionManager<VSDebugSession>;
+
+  constructor(inputStream?: Readable, outputStream?: Writable) {
+    const services = createGlobalContainer({ storagePath, isVsCode: false });
+    this.sessionServer = new ServerSessionManager(services, this);
+
+    if (inputStream && outputStream) {
+      this.launchRootFromExisting(inputStream, outputStream);
+    } else {
+      this.launchRoot();
+    }
+  }
+
+  launchRootFromExisting(inputStream: Readable, outputStream: Writable) {
+    const deferredConnection: IDeferred<DapConnection> = getDeferred();
+    const session = new VSDebugSession(
+      'root',
+      'JavaScript debugger root session',
+      deferredConnection.promise,
+      { type: 'pwa-chrome', name: 'root', request: 'launch' },
+    );
+    const newSession = this.sessionServer.createRootDebugSessionFromStreams(
+      session,
+      inputStream,
+      outputStream,
+    );
+    deferredConnection.resolve(newSession.connection);
+  }
+
+  launchRoot() {
+    const deferredConnection: IDeferred<DapConnection> = getDeferred();
+    const session = new VSDebugSession(
+      'root',
+      'JavaScript debugger root session',
+      deferredConnection.promise,
+      { type: 'pwa-chrome', name: 'root', request: 'launch' },
+    );
+    const result = this.sessionServer.createRootDebugServer(session, debugServerPort);
+    result.connectionPromise.then(x => deferredConnection.resolve(x));
+    console.log((result.server.address() as net.AddressInfo).port.toString());
+  }
+
+  launch(
+    parentSession: Session<VSDebugSession>,
+    target: ITarget,
+    config: IPseudoAttachConfiguration,
+  ): void {
+    const childAttachConfig = { ...config, sessionId: target.id, __jsDebugChildServer: '' };
+    const deferredConnection: IDeferred<DapConnection> = getDeferred();
+    const session = new VSDebugSession(
+      target.id(),
+      target.name(),
+      deferredConnection.promise,
+      childAttachConfig,
+    );
+    const result = this.sessionServer.createChildDebugServer(session);
+    result.connectionPromise.then(x => deferredConnection.resolve(x));
+    childAttachConfig[
+      '__jsDebugChildServer'
+    ] = (result.server.address() as net.AddressInfo).port.toString();
+
+    // Custom message currently not part of DAP
+    parentSession.connection._send({
+      seq: 0,
+      command: 'attachedChildSession',
+      type: 'request',
+      arguments: {
+        config: childAttachConfig,
+      },
+    });
+  }
+}
+
+const debugServerPort = process.argv.length >= 3 ? +process.argv[2] : undefined;
+if (debugServerPort !== undefined) {
+  net
+    .createServer(socket => {
+      new VsDebugServer(socket, socket);
+    })
+    .listen(debugServerPort);
+
+  console.log(`Listening at ${debugServerPort}`);
+} else {
+  new VsDebugServer();
+}

--- a/src/vsDebugServer.ts
+++ b/src/vsDebugServer.ts
@@ -21,8 +21,11 @@ import { DebugConfiguration } from 'vscode';
 import { ServerSessionManager } from './serverSessionManager';
 import { ITarget } from './targets/targets';
 import { Readable, Writable } from 'stream';
+import * as nls from 'vscode-nls';
 
 const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-js-debug-'));
+
+const localize = nls.loadMessageBundle();
 
 class VSDebugSession implements IDebugSessionLike {
   constructor(
@@ -59,7 +62,7 @@ class VsDebugServer implements ISessionLauncher<VSDebugSession> {
     const deferredConnection: IDeferred<DapConnection> = getDeferred();
     const rootSession = new VSDebugSession(
       'root',
-      'JavaScript debugger root session',
+      localize('session.rootSessionName', 'JavaScript debug adapter'),
       deferredConnection.promise,
       { type: 'pwa-chrome', name: 'root', request: 'launch' },
     );
@@ -123,13 +126,13 @@ class VsDebugServer implements ISessionLauncher<VSDebugSession> {
 
 const debugServerPort = process.argv.length >= 3 ? +process.argv[2] : undefined;
 if (debugServerPort !== undefined) {
-  net
+  const server = net
     .createServer(socket => {
       new VsDebugServer(socket, socket);
     })
     .listen(debugServerPort);
 
-  console.log(`Listening at ${debugServerPort}`);
+  console.log(`Listening at ${(server.address() as net.AddressInfo).port}`);
 } else {
   new VsDebugServer();
 }


### PR DESCRIPTION
This change is part of an effort for the VS implementation to move away from flat-session mode, and to as closely as possible follow the VS Code implementation, while sharing as much code as possible to avoid breakages due to divergent implementations.

This change moves most of the debug server creation logic out of vsCodeSessionManager and in to its own class (serverSessionManager), and adds the vsDebugServer entry-point which hosts a debug server without any VS Code API dependencies.