### PR TITLE
Ensure source.rootPaths being defined when Node is a child session of Chrome

### DIFF
--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -490,7 +490,8 @@ export class SourceContainer {
   ) {
     this._dap = dap;
 
-    const mainRootPath = 'webRoot' in launchConfig ? launchConfig.webRoot : launchConfig.rootPath;
+    const mainRootPath =
+      'webRoot' in launchConfig ? launchConfig.webRoot : launchConfig.rootPath || launchConfig.cwd;
     if (mainRootPath) {
       // Prefixing ../ClientApp is a workaround for a bug in ASP.NET debugging in VisualStudio because the wwwroot is not properly configured
       this.rootPaths = [mainRootPath, properResolve(mainRootPath, '..', 'ClientApp')];

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -642,6 +642,8 @@ export interface IPseudoAttachConfiguration extends IMandatedConfiguration {
   postDebugTask?: string;
   preRestartTask?: string;
   postRestartTask?: string;
+  rootPath?: string;
+  cwd?: string;
 }
 
 /**

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -222,6 +222,10 @@ export class SessionManager<TSessionImpl extends IDebugSessionLike>
         // fix for https://github.com/microsoft/vscode/issues/102296
         preRestartTask: parentConfig.preRestartTask ?? parentConfig.postDebugTask,
         postRestartTask: parentConfig.postRestartTask ?? parentConfig.preLaunchTask,
+
+        // TODO: Do we need to copy any more parameters?
+        rootPath: target.launchConfig.rootPath,
+        cwd: ((target.launchConfig as unknown) as { cwd?: string }).cwd,
       };
 
       this.sessionLauncher.launch(parentSession, target, config);


### PR DESCRIPTION
We were having some issues on Node sessions that were a child of a Chrome session because they were started without the rootSession or cwd configured, and so we couldn't configure the source.rootPath so we ended up showing absolute paths for the loaded script files. With this fix, we show relative file paths instead