### PR TITLE
Skip Bootloader to hide it from users

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -273,6 +273,11 @@ gulp.task('flatSessionBundle:webpack-bundle', async () => {
   return runWebpack({ packages, devtool: 'nosources-source-map' });
 });
 
+gulp.task('markBootloaderAsCDPFile', done => {
+  const bootloaderFilePath = path.resolve(distSrcDir, 'bootloader.bundle.js');
+  fs.appendFile(bootloaderFilePath, '\n//# sourceURL=bootloader.bundle.cdp', done);
+});
+
 /** Run webpack to bundle into the VS debug server */
 gulp.task('vsDebugServerBundle:webpack-bundle', async () => {
   const packages = [{ entry: `${buildSrcDir}/vsDebugServer.js`, library: true }];
@@ -373,6 +378,7 @@ gulp.task(
     'compile:static',
     'compile:dynamic',
     'package:webpack-bundle',
+    'markBootloaderAsCDPFile',
     'package:copy-extension-files',
     'nls:bundle-create',
     'package:createVSIX',
@@ -385,6 +391,7 @@ gulp.task(
     'clean',
     'compile',
     'flatSessionBundle:webpack-bundle',
+    'markBootloaderAsCDPFile',
     'package:copy-extension-files',
     gulp.parallel('nls:bundle-download', 'nls:bundle-create'),
   ),
@@ -398,6 +405,7 @@ gulp.task(
     'compile',
     'vsDebugServerBundle:webpack-bundle',
     'flatSessionBundle:webpack-bundle',
+    'markBootloaderAsCDPFile',
     'package:copy-extension-files',
     gulp.parallel('nls:bundle-download', 'nls:bundle-create'),
   ),

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -38,7 +38,9 @@ import {
   serializeForClipboardTmpl,
 } from './templates/serializeForClipboard';
 import { IVariableStoreDelegate, VariableStore } from './variables';
+import { bootloaderDefaultPath } from '../targets/node/watchdogSpawn';
 const localize = nls.loadMessageBundle();
+import * as utils from '../common/urlUtils';
 
 export type PausedReason =
   | 'step'
@@ -136,6 +138,8 @@ class DeferredContainer<T> {
     }
   }
 }
+
+const bootloaderDefaultFilePath = utils.absolutePathToFileUrl(bootloaderDefaultPath).toLowerCase();
 
 export class Thread implements IVariableStoreDelegate {
   private static _lastThreadId = 0;
@@ -1096,6 +1100,11 @@ export class Thread implements IVariableStoreDelegate {
   }
 
   private _onScriptParsed(event: Cdp.Debugger.ScriptParsedEvent) {
+    if (event.url.toLowerCase() === bootloaderDefaultFilePath) {
+      // The customer doesn't care about the bootloader, so skip this event
+      return;
+    }
+
     if (this._sourceContainer.scriptsById.has(event.scriptId)) {
       return;
     }


### PR DESCRIPTION
This fixes all the bootloader sources appearing on the "Loaded scripts" list (which the user doesn't care about)