### PR TITLE
fix: broken VS error telemetry

### DIFF
--- a/src/binder.ts
+++ b/src/binder.ts
@@ -27,7 +27,7 @@ import Dap from './dap/api';
 import DapConnection from './dap/connection';
 import { ProtocolError } from './dap/protocolError';
 import { createTargetContainer, provideLaunchParams } from './ioc';
-import { disposeContainer, ExtensionLocation, IInitializeParams } from './ioc-extras';
+import { disposeContainer, ExtensionLocation, IInitializeParams, IsVSCode } from './ioc-extras';
 import { ITargetOrigin } from './targets/targetOrigin';
 import { ILauncher, ILaunchResult, ITarget } from './targets/targets';
 import { ITelemetryReporter } from './telemetry/telemetryReporter';
@@ -75,6 +75,7 @@ export class Binder implements IDisposable {
       installUnhandledErrorReporter(
         _rootServices.get(ILogger),
         _rootServices.get(ITelemetryReporter),
+        _rootServices.get(IsVSCode),
       ),
     ];
 

--- a/src/telemetry/classification.ts
+++ b/src/telemetry/classification.ts
@@ -88,11 +88,13 @@ export interface IRPCOperation {
 interface IErrorClassification {
   exceptionType: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
   '!error': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
+  error: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' } | undefined;
 }
 
 export interface IErrorMetrics {
   exceptionType: 'uncaughtException' | 'unhandledRejection';
   '!error': unknown;
+  error: unknown | undefined;
 }
 
 interface IBreakpointClassification {

--- a/src/telemetry/unhandledErrorReporter.ts
+++ b/src/telemetry/unhandledErrorReporter.ts
@@ -15,9 +15,20 @@ export const enum ErrorType {
 export function installUnhandledErrorReporter(
   logger: ILogger,
   telemetryReporter: ITelemetryReporter,
+  isVsCode?: boolean,
 ): IDisposable {
-  const exceptionListener = onUncaughtError(logger, telemetryReporter, ErrorType.Exception);
-  const rejectionListener = onUncaughtError(logger, telemetryReporter, ErrorType.Rejection);
+  const exceptionListener = onUncaughtError(
+    logger,
+    telemetryReporter,
+    ErrorType.Exception,
+    isVsCode,
+  );
+  const rejectionListener = onUncaughtError(
+    logger,
+    telemetryReporter,
+    ErrorType.Rejection,
+    isVsCode,
+  );
 
   process.addListener('uncaughtException', exceptionListener);
   process.addListener('unhandledRejection', rejectionListener);
@@ -34,6 +45,7 @@ export const onUncaughtError = (
   logger: ILogger,
   telemetryReporter: ITelemetryReporter,
   src: ErrorType,
+  isVsCode?: boolean,
 ) => (error: unknown) => {
   if (!shouldReportThisError(error)) {
     return;
@@ -41,6 +53,7 @@ export const onUncaughtError = (
 
   telemetryReporter.report('error', {
     '!error': error,
+    error: isVsCode ? undefined : error,
     exceptionType: src,
   });
   logger.error(LogTag.RuntimeException, 'Unhandled error in debug adapter', error);

--- a/src/telemetry/unhandledErrorReporter.ts
+++ b/src/telemetry/unhandledErrorReporter.ts
@@ -45,7 +45,7 @@ export const onUncaughtError = (
   logger: ILogger,
   telemetryReporter: ITelemetryReporter,
   src: ErrorType,
-  isVsCode?: boolean,
+  isVsCode = true,
 ) => (error: unknown) => {
   if (!shouldReportThisError(error)) {
     return;


### PR DESCRIPTION
Visual Studio's telemetry APIs reject properties with exclamation points. Adding back the regular error property name for VS only.