### PR TITLE
await nyc.report() or no test coverage gets recorded

### DIFF
--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -115,7 +115,7 @@ export async function run(): Promise<void> {
   } finally {
     if (nyc) {
       nyc.writeCoverageFile();
-      nyc.report();
+      await nyc.report();
     }
   }
 }


### PR DESCRIPTION
`report` is an asynchronous function and should be awaited otherwise the test coverage might not get written to the disk