### PR TITLE
Refactoring to create absolutePathToUrlRegexp

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -92,6 +92,7 @@ export class ExecutionContext {
 
 export type Script = {
   url: string;
+  urlRegexp?: string;
   scriptId: string;
   hash: string;
   source: Promise<Source>;

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -92,7 +92,6 @@ export class ExecutionContext {
 
 export type Script = {
   url: string;
-  urlRegexp?: string;
   scriptId: string;
   hash: string;
   source: Promise<Source>;

--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -2,14 +2,14 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
 import * as path from 'path';
-import { IDisposable } from '../disposable';
 import { ILoggingConfiguration } from '../../configuration';
 import Dap from '../../dap/api';
+import { IDisposable } from '../disposable';
 import { ConsoleLogSink } from './consoleLogSink';
-import { tmpdir } from 'os';
 import { FileLogSink } from './fileLogSink';
-import { existsSync } from 'fs';
 
 export const enum LogLevel {
   Verbose = 0,
@@ -29,6 +29,7 @@ export const enum LogTag {
   RuntimeWelcome = 'runtime.welcome',
   RuntimeException = 'runtime.exception',
   RuntimeSourceMap = 'runtime.sourcemap',
+  RuntimeBreakpoints = 'runtime.breakpoints',
   SourceMapParsing = 'sourcemap.parsing',
   PerfFunction = 'perf.function',
   CdpSend = 'cdp.send',
@@ -47,6 +48,7 @@ const logTabObj: { [K in LogTag]: null } = {
   [LogTag.RuntimeWelcome]: null,
   [LogTag.RuntimeException]: null,
   [LogTag.RuntimeSourceMap]: null,
+  [LogTag.RuntimeBreakpoints]: null,
   [LogTag.SourceMapParsing]: null,
   [LogTag.PerfFunction]: null,
   [LogTag.CdpSend]: null,

--- a/src/common/sourcePathResolver.ts
+++ b/src/common/sourcePathResolver.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { SourceMap, ISourceMapMetadata } from './sourceMaps/sourceMap';
+import { ISourceMapMetadata, SourceMap } from './sourceMaps/sourceMap';
 
 /**
  * Request to resolve a URL to an absolute path.
@@ -50,7 +50,7 @@ export interface ISourcePathResolver {
   /**
    * Attempts to convert an absolute path on disk to a URL for CDP.
    */
-  absolutePathToUrl(absolutePath: string): string | undefined;
+  absolutePathToUrlRegexp(absolutePath: string): string | undefined;
 }
 
 // Script tags in html have line/column numbers offset relative to the actual script start.

--- a/src/targets/browser/blazorSourcePathResolver.ts
+++ b/src/targets/browser/blazorSourcePathResolver.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import path from 'path';
+import { IVueFileMapper } from '../../adapter/vueFileMapper';
+import { IFsUtils } from '../../common/fsUtils';
+import { ILogger, LogTag } from '../../common/logging';
+import * as utils from '../../common/urlUtils';
+import { BrowserSourcePathResolver, IOptions } from './browserPathResolver';
+
+export class BlazorSourcePathResolver extends BrowserSourcePathResolver {
+  private readonly blazorInCodespacesRegexp: RegExp;
+  private readonly blazorInCodespacesRegexpSubstitution = '$1:\\$2';
+
+  constructor(vueMapper: IVueFileMapper, fsUtils: IFsUtils, options: IOptions, logger: ILogger) {
+    super(vueMapper, fsUtils, options, logger);
+    if (this.options.remoteFilePrefix) {
+      const sep = `\\${path.sep}`;
+      const escapedPrefix = this.options.remoteFilePrefix.replace(new RegExp(sep, 'g'), sep);
+      this.blazorInCodespacesRegexp = new RegExp(
+        `^${escapedPrefix}${sep}([A-z])\\$${sep}(.*)$`,
+        // Sample value: /^C:\\Users\\digeff\\AppData\\Local\\Temp\\4169355D62D44D791D2A7534DE8994AB4B9E\\9\\~~\\([A-z])\$\\(.*)$/
+      );
+    } else {
+      this.blazorInCodespacesRegexp = new RegExp('');
+    }
+  }
+
+  public absolutePathToUrlRegexp(absolutePath: string): string | undefined {
+    if (this.options.remoteFilePrefix) {
+      // Sample values:
+      // absolutePath = C:\\Users\\digeff\\AppData\\Local\\Temp\\97D4F6178D8AD3159C555FA5FACA1ABA807E\\7\\~~\\C$\\workspace\\BlazorApp\\Pages\\Counter.razor
+      const filePath = absolutePath.replace(
+        this.blazorInCodespacesRegexp,
+        this.blazorInCodespacesRegexpSubstitution,
+      );
+      // filePath = C:\\workspace\\BlazorApp\\Pages\\Counter.razor
+      const fileUrlPath = utils.platformPathToUrlPath(filePath);
+      // fileUrlPath = C:/workspace/BlazorApp/Pages/Counter.razor
+      const noColonFileUrlPath = fileUrlPath.replace(/^(\w):(.*)$/, '$1$2');
+      // noColonFileUrlPath = C/workspace/BlazorApp/Pages/Counter.razor
+      const fileRegexp = utils.urlToRegex(noColonFileUrlPath);
+      // fileRegexp = [cC]\\/[wW][oO][rR][kK][sS][pP][aA][cC][eE]\\/[bB][lL][aA][zZ][oO][rR][wW][aA][sS][mM]\\/[pP][aA][gG][eE][sS]\\/[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]
+      if (fileRegexp) {
+        const dotnetUrlRegexp = `dotnet://.*\\.dll/${fileRegexp}`;
+        // dotnetUrlRegexp = dotnet://.*\\.dll/[cC]\\/[wW][oO][rR][kK][sS][pP][aA][cC][eE]\\/[bB][lL][aA][zZ][oO][rR][wW][aA][sS][mM]\\/[pP][aA][gG][eE][sS]\\/[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]
+        this.logger.verbose(LogTag.RuntimeBreakpoints, 'absolutePathToUrlRegexp.blazor.remoteFs', {
+          absolutePath,
+          dotnetUrlRegexp,
+        });
+        return dotnetUrlRegexp;
+      }
+    } else {
+      // Blazor files have a file:/// url. Override the default absolutePathToUrlRegexp which returns an http based regexp
+      const fileUrl = utils.absolutePathToFileUrl(absolutePath);
+      const fileRegexp = utils.urlToRegex(fileUrl);
+      return fileRegexp;
+    }
+
+    return super.absolutePathToUrlRegexp(absolutePath);
+  }
+}

--- a/src/targets/browser/browserPathResolver.ts
+++ b/src/targets/browser/browserPathResolver.ts
@@ -2,37 +2,42 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import * as utils from '../../common/urlUtils';
-import { ISourcePathResolverOptions, SourcePathResolverBase } from '../sourcePathResolver';
-import { IUrlResolution } from '../../common/sourcePathResolver';
-import {
-  properResolve,
-  fixDriveLetterAndSlashes,
-  properRelative,
-  isSubdirectoryOf,
-} from '../../common/pathUtils';
-import { PathMapping } from '../../configuration';
 import { URL } from 'url';
+import { IVueFileMapper, VueHandling } from '../../adapter/vueFileMapper';
+import { IFsUtils } from '../../common/fsUtils';
+import { ILogger, LogTag } from '../../common/logging';
+import {
+  fixDriveLetterAndSlashes,
+  isSubdirectoryOf,
+  properRelative,
+  properResolve,
+} from '../../common/pathUtils';
 import { SourceMap } from '../../common/sourceMaps/sourceMap';
 import {
-  getFullSourceEntry,
   defaultPathMappingResolver,
   getComputedSourceRoot,
+  getFullSourceEntry,
 } from '../../common/sourceMaps/sourceMapResolutionUtils';
-import { injectable, inject } from 'inversify';
-import { IVueFileMapper, VueHandling } from '../../adapter/vueFileMapper';
-import { ILogger } from '../../common/logging';
-import { IFsUtils } from '../../common/fsUtils';
+import { IUrlResolution } from '../../common/sourcePathResolver';
+import * as utils from '../../common/urlUtils';
+import { PathMapping } from '../../configuration';
+import { ISourcePathResolverOptions, SourcePathResolverBase } from '../sourcePathResolver';
 
 interface IOptions extends ISourcePathResolverOptions {
   baseUrl?: string;
   pathMapping: PathMapping;
   clientID: string | undefined;
+  isBlazor: boolean;
+  remoteFilePrefix: string | undefined;
 }
 
 @injectable()
 export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> {
+  private readonly blazorInCodespacesRegexp: RegExp;
+  private readonly blazorInCodespacesRegexpSubstitution = '$1:\\$2';
+
   constructor(
     @inject(IVueFileMapper) private readonly vueMapper: IVueFileMapper,
     @inject(IFsUtils) private readonly fsUtils: IFsUtils,
@@ -40,6 +45,56 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
     logger: ILogger,
   ) {
     super(options, logger);
+    if (this.options.isBlazor && this.options.remoteFilePrefix) {
+      const sep = `\\${path.sep}`;
+      const escapedPrefix = this.options.remoteFilePrefix.replace(new RegExp(sep, 'g'), sep);
+      this.blazorInCodespacesRegexp = new RegExp(
+        `^${escapedPrefix}${sep}([A-z])\\$${sep}(.*)$`,
+        // Sample value: /^C:\\Users\\digeff\\AppData\\Local\\Temp\\4169355D62D44D791D2A7534DE8994AB4B9E\\9\\~~\\([A-z])\$\\(.*)$/
+      );
+    } else {
+      this.blazorInCodespacesRegexp = new RegExp('');
+    }
+  }
+
+  public absolutePathToUrlRegexp(absolutePath: string): string | undefined {
+    if (this.options.isBlazor) {
+      if (this.options.remoteFilePrefix) {
+        // Sample values:
+        // absolutePath = C:\\Users\\digeff\\AppData\\Local\\Temp\\97D4F6178D8AD3159C555FA5FACA1ABA807E\\7\\~~\\C$\\workspace\\BlazorApp\\Pages\\Counter.razor
+        const filePath = absolutePath.replace(
+          this.blazorInCodespacesRegexp,
+          this.blazorInCodespacesRegexpSubstitution,
+        );
+        // filePath = C:\\workspace\\BlazorApp\\Pages\\Counter.razor
+        const fileUrlPath = utils.platformPathToUrlPath(filePath);
+        // fileUrlPath = C:/workspace/BlazorApp/Pages/Counter.razor
+        const noColonFileUrlPath = fileUrlPath.replace(/^(\w):(.*)$/, '$1$2');
+        // noColonFileUrlPath = C/workspace/BlazorApp/Pages/Counter.razor
+        const fileRegexp = utils.urlToRegex(noColonFileUrlPath);
+        // fileRegexp = [cC]\\/[wW][oO][rR][kK][sS][pP][aA][cC][eE]\\/[bB][lL][aA][zZ][oO][rR][wW][aA][sS][mM]\\/[pP][aA][gG][eE][sS]\\/[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]
+        if (fileRegexp) {
+          const dotnetUrlRegexp = `dotnet://.*\\.dll/${fileRegexp}`;
+          // dotnetUrlRegexp = dotnet://.*\\.dll/[cC]\\/[wW][oO][rR][kK][sS][pP][aA][cC][eE]\\/[bB][lL][aA][zZ][oO][rR][wW][aA][sS][mM]\\/[pP][aA][gG][eE][sS]\\/[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]
+          this.logger.verbose(
+            LogTag.RuntimeBreakpoints,
+            'absolutePathToUrlRegexp.blazor.remoteFs',
+            {
+              absolutePath,
+              dotnetUrlRegexp,
+            },
+          );
+          return dotnetUrlRegexp;
+        }
+      } else {
+        // Blazor files have a file:/// url. Override the default absolutePathToUrlRegexp which returns an http based regexp
+        const fileUrl = utils.absolutePathToFileUrl(absolutePath);
+        const fileRegexp = utils.urlToRegex(fileUrl);
+        return fileRegexp;
+      }
+    }
+
+    return super.absolutePathToUrlRegexp(absolutePath);
   }
 
   absolutePathToUrl(absolutePath: string): string | undefined {

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -21,6 +21,7 @@ import {
   isAbsolute,
   isDataUri,
   isFileUrl,
+  urlToRegex,
 } from '../common/urlUtils';
 import { SourceMapOverrides } from './sourceMapOverrides';
 
@@ -58,7 +59,12 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
 
   public abstract urlToAbsolutePath(request: IUrlResolution): Promise<string | undefined>;
 
-  public abstract absolutePathToUrl(absolutePath: string): string | undefined;
+  public absolutePathToUrlRegexp(absolutePath: string): string | undefined {
+    const url = this.absolutePathToUrl(absolutePath);
+    return url ? urlToRegex(url) : undefined;
+  }
+
+  protected abstract absolutePathToUrl(absolutePath: string): string | undefined;
 
   /**
    * Returns whether the source map should be used to resolve a local path,

--- a/src/targets/sourcePathResolverFactory.ts
+++ b/src/targets/sourcePathResolverFactory.ts
@@ -5,14 +5,14 @@
 import { inject, injectable } from 'inversify';
 import { IVueFileMapper } from '../adapter/vueFileMapper';
 import { DebugType } from '../common/contributionUtils';
+import { IFsUtils, LocalFsUtils } from '../common/fsUtils';
 import { ILogger } from '../common/logging';
 import { AnyLaunchConfiguration } from '../configuration';
 import Dap from '../dap/api';
+import { IInitializeParams } from '../ioc-extras';
 import { baseURL } from './browser/browserLaunchParams';
 import { BrowserSourcePathResolver } from './browser/browserPathResolver';
-import { IInitializeParams } from '../ioc-extras';
 import { NodeSourcePathResolver } from './node/nodeSourcePathResolver';
-import { IFsUtils, LocalFsUtils } from '../common/fsUtils';
 
 @injectable()
 export class SourcePathResolverFactory {
@@ -52,6 +52,8 @@ export class SourcePathResolverFactory {
           pathMapping: { '/': c.webRoot, ...c.pathMapping },
           sourceMapOverrides: c.sourceMapPathOverrides,
           clientID: this.initializeParams.clientID,
+          isBlazor: !!c.inspectUri,
+          remoteFilePrefix: c.__remoteFilePrefix,
         },
         this.logger,
       );

--- a/src/targets/sourcePathResolverFactory.ts
+++ b/src/targets/sourcePathResolverFactory.ts
@@ -10,6 +10,7 @@ import { ILogger } from '../common/logging';
 import { AnyLaunchConfiguration } from '../configuration';
 import Dap from '../dap/api';
 import { IInitializeParams } from '../ioc-extras';
+import { BlazorSourcePathResolver } from './browser/blazorSourcePathResolver';
 import { baseURL } from './browser/browserLaunchParams';
 import { BrowserSourcePathResolver } from './browser/browserPathResolver';
 import { NodeSourcePathResolver } from './node/nodeSourcePathResolver';
@@ -41,7 +42,8 @@ export class SourcePathResolverFactory {
         this.logger,
       );
     } else {
-      return new BrowserSourcePathResolver(
+      const isBlazor = !!c.inspectUri;
+      return new (isBlazor ? BlazorSourcePathResolver : BrowserSourcePathResolver)(
         this.vueMapper,
         this.fsUtils,
         {
@@ -52,7 +54,6 @@ export class SourcePathResolverFactory {
           pathMapping: { '/': c.webRoot, ...c.pathMapping },
           sourceMapOverrides: c.sourceMapPathOverrides,
           clientID: this.initializeParams.clientID,
-          isBlazor: !!c.inspectUri,
           remoteFilePrefix: c.__remoteFilePrefix,
         },
         this.logger,

--- a/src/test/browser/blazorSourcePathResolverTest.ts
+++ b/src/test/browser/blazorSourcePathResolverTest.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { expect } from 'chai';
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+import { LocalFsUtils } from '../../common/fsUtils';
+import { Logger } from '../../common/logging/logger';
+import { defaultSourceMapPathOverrides } from '../../configuration';
+import { BlazorSourcePathResolver } from '../../targets/browser/blazorSourcePathResolver';
+import { testFixturesDir } from '../test';
+import { testVueMapper } from './browserPathResolverTest';
+
+function createBlazorSourcePathResolver(
+  remoteFilePrefix: string | undefined,
+): BlazorSourcePathResolver {
+  return new BlazorSourcePathResolver(
+    testVueMapper,
+    new LocalFsUtils(fsPromises),
+    {
+      pathMapping: { '/': path.join(testFixturesDir, 'web') },
+      clientID: 'vscode',
+      baseUrl: 'http://localhost:1234/',
+      sourceMapOverrides: defaultSourceMapPathOverrides(path.join(testFixturesDir, 'web')),
+      localRoot: null,
+      remoteRoot: null,
+      resolveSourceMapLocations: null,
+      remoteFilePrefix,
+    },
+    Logger.null,
+  );
+}
+
+describe('BlazorSourcePathResolver.absolutePathToUrlRegexp', () => {
+  it('generates the correct regexp in local scenarios', () => {
+    const sourcePath =
+      'c:\\Users\\digeff\\source\\repos\\MyBlazorApp\\MyBlazorApp\\Pages\\Counter.razor';
+    const regexp = createBlazorSourcePathResolver(undefined).absolutePathToUrlRegexp(sourcePath);
+
+    // This regexp was generated from running the real scenario, verifying that the breakpoint with this regexp works, and then copying it here
+    expect(regexp).to.equal(
+      '[fF][iI][lL][eE]:\\/\\/\\/[cC]:\\/[uU][sS][eE][rR][sS]\\/[dD][iI][gG][eE][fF][fF]\\/[sS][oO][uU][rR][cC][eE]\\/' +
+        '[rR][eE][pP][oO][sS]\\/[mM][yY][bB][lL][aA][zZ][oO][rR][aA][pP][pP]\\/[mM][yY][bB][lL][aA][zZ][oO][rR][aA][pP][pP]\\/' +
+        '[pP][aA][gG][eE][sS]\\/[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]|[cC]:\\\\[uU][sS][eE][rR][sS]\\\\[dD][iI][gG][eE][fF][fF]\\\\' +
+        '[sS][oO][uU][rR][cC][eE]\\\\[rR][eE][pP][oO][sS]\\\\[mM][yY][bB][lL][aA][zZ][oO][rR][aA][pP][pP]\\\\[mM][yY][bB][lL][aA][zZ][oO][rR][aA][pP][pP]\\\\' +
+        '[pP][aA][gG][eE][sS]\\\\[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]',
+    );
+  });
+
+  it('generates the correct regexp in codespace scenarios', () => {
+    const remoteFilePrefix =
+      'c:\\Users\\digeff\\AppData\\Local\\Temp\\2689D069D40B1EFF4B570B2DB12506073980\\5~~';
+    const sourcePath = `${remoteFilePrefix}\\C$\\workspace\\NewBlazorWASM\\NewBlazorWASM\\Pages\\Counter.razor`;
+    const regexp = createBlazorSourcePathResolver(remoteFilePrefix).absolutePathToUrlRegexp(
+      sourcePath,
+    );
+
+    // This regexp was generated from running the real scenario, verifying that the breakpoint with this regexp works, and then copying it here
+    expect(regexp).to.equal(
+      'dotnet://.*\\.dll/[cC]\\/[wW][oO][rR][kK][sS][pP][aA][cC][eE]\\/[nN][eE][wW][bB][lL][aA][zZ][oO][rR][wW][aA][sS][mM]\\/' +
+        '[nN][eE][wW][bB][lL][aA][zZ][oO][rR][wW][aA][sS][mM]\\/[pP][aA][gG][eE][sS]\\/[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]',
+    );
+  });
+});

--- a/src/test/browser/browserPathResolverTest.ts
+++ b/src/test/browser/browserPathResolverTest.ts
@@ -52,6 +52,8 @@ describe('browserPathResolver.urlToAbsolutePath', () => {
         localRoot: null,
         remoteRoot: null,
         resolveSourceMapLocations: null,
+        remoteFilePrefix: undefined,
+        isBlazor: false,
       },
       Logger.null,
     );
@@ -156,6 +158,8 @@ describe('browserPathResolver.urlToAbsolutePath', () => {
         localRoot: null,
         remoteRoot: null,
         resolveSourceMapLocations: null,
+        isBlazor: false,
+        remoteFilePrefix: undefined,
       },
       Logger.null,
     );
@@ -194,6 +198,8 @@ describe('browserPathResolver.urlToAbsolutePath', () => {
           localRoot: null,
           remoteRoot: null,
           resolveSourceMapLocations: null,
+          isBlazor: false,
+          remoteFilePrefix: undefined,
         },
         await Logger.test(),
       );

--- a/src/test/browser/browserPathResolverTest.ts
+++ b/src/test/browser/browserPathResolverTest.ts
@@ -53,7 +53,6 @@ describe('browserPathResolver.urlToAbsolutePath', () => {
         remoteRoot: null,
         resolveSourceMapLocations: null,
         remoteFilePrefix: undefined,
-        isBlazor: false,
       },
       Logger.null,
     );
@@ -158,7 +157,6 @@ describe('browserPathResolver.urlToAbsolutePath', () => {
         localRoot: null,
         remoteRoot: null,
         resolveSourceMapLocations: null,
-        isBlazor: false,
         remoteFilePrefix: undefined,
       },
       Logger.null,
@@ -198,7 +196,6 @@ describe('browserPathResolver.urlToAbsolutePath', () => {
           localRoot: null,
           remoteRoot: null,
           resolveSourceMapLocations: null,
-          isBlazor: false,
           remoteFilePrefix: undefined,
         },
         await Logger.test(),

--- a/src/test/browser/browserPathResolverTest.ts
+++ b/src/test/browser/browserPathResolverTest.ts
@@ -15,17 +15,18 @@ import { defaultSourceMapPathOverrides } from '../../configuration';
 import { BrowserSourcePathResolver } from '../../targets/browser/browserPathResolver';
 import { testFixturesDir } from '../test';
 
+export const testVueMapper: IVueFileMapper = {
+  lookup: async url => path.join(testFixturesDir, 'web', 'looked up', url),
+  getVueHandling: url =>
+    url.includes('lookup.vue')
+      ? VueHandling.Lookup
+      : url.includes('omit.vue')
+      ? VueHandling.Omit
+      : VueHandling.Unhandled,
+};
+
 describe('browserPathResolver.urlToAbsolutePath', () => {
   let fsExistStub: SinonStub<[PathLike, (cb: boolean) => void], void>;
-  const testVueMapper: IVueFileMapper = {
-    lookup: async url => path.join(testFixturesDir, 'web', 'looked up', url),
-    getVueHandling: url =>
-      url.includes('lookup.vue')
-        ? VueHandling.Lookup
-        : url.includes('omit.vue')
-        ? VueHandling.Omit
-        : VueHandling.Unhandled,
-  };
 
   before(() => {
     fsExistStub = stub(fsModule, 'exists').callsFake((path, cb) => {

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -84,6 +84,7 @@ export async function run(): Promise<void> {
     runner.addFile(join(__dirname, 'breakpoints/breakpointsTest'));
     runner.addFile(join(__dirname, 'browser/framesTest'));
     runner.addFile(join(__dirname, 'browser/browserPathResolverTest'));
+    runner.addFile(join(__dirname, 'browser/blazorSourcePathResolverTest'));
     runner.addFile(join(__dirname, 'evaluate/evaluate'));
     runner.addFile(join(__dirname, 'sources/sourcesTest'));
     runner.addFile(join(__dirname, 'stacks/stacksTest'));


### PR DESCRIPTION
Start using absolutePathToUrlRegexp instead of absolutePathToUrl so we can customize the Regexp we use for Blazor scenarios  


@connor4312 If you like this approach, I'll add some unit tests for BrowserSourcePathResolver.absolutePathToUrlRegexp