### PR TITLE
Add new parameter for inspectUri needed to move BlazorProxy out of the project system

### DIFF
--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -110,6 +110,7 @@ const strings = {
     ' - `url.*` is the parsed address of the running application. For instance, `{url.port}`, `{url.hostname}`\n' +
     ' - `port` is the debug port that Chrome is listening on.\n' +
     ' - `browserInspectUri` is the inspector URI on the launched browser\n' +
+    ' - `browserInspectUriPath` is the path part of the inspector URI on the launched browser (e.g.: "/devtools/browser/e9ec0098-306e-472a-8133-5e42488929c2").\n' +
     ' - `wsProtocol` is the hinted websocket protocol. This is set to `wss` if the original URL is `https`, or `ws` otherwise.\n',
   'browser.restart': 'Whether to reconnect if the browser connection is closed',
   'browser.profileStartup.description':

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -464,6 +464,7 @@ export interface IChromiumBaseConfiguration extends IBaseConfiguration {
    *    `{url.port}`, `{url.hostname}`
    *  - `port` is the debug port that Chrome is listening on.
    *  - `browserInspectUri` is the inspector URI on the launched browser
+    ' - `browserInspectUriPath` is the path part of the inspector URI on the launched browser (e.g.: "/devtools/browser/e9ec0098-306e-472a-8133-5e42488929c2").\n' +
    *  - `wsProtocol` is the hinted websocket protocol. This is set to `wss` if
    *    the original URL is `https`, or `ws` otherwise.
    */

--- a/src/targets/browser/constructInspectorWSUri.ts
+++ b/src/targets/browser/constructInspectorWSUri.ts
@@ -32,6 +32,7 @@ export function constructInspectorWSUri(
     'url.hostname': () => getUrl(urlText).hostname,
     'url.port': () => getUrl(urlText).port,
     browserInspectUri: () => encodeURIComponent(browserInspectUri),
+    browserInspectUriPath: () => new URL(browserInspectUri).pathname,
     wsProtocol: () => (getUrl(urlText).protocol === 'https:' ? 'wss' : 'ws'), // the protocol includes the : at the end
   };
 


### PR DESCRIPTION
We need to add a new parameter for the inspectUri to move the BlazorProxy launch out of the project system