### PR TITLE
Remote 'New' from terminal label

### DIFF
--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -126,7 +126,7 @@ const strings = {
   'debug.npm.noScripts': 'No npm scripts found in your package.json',
   'debug.npm.parseError': 'Could not read {0}: {1}',
   'debug.npm.edit': 'Edit package.json',
-  'debug.terminal.label': 'New JavaScript Debug Terminal',
+  'debug.terminal.label': 'JavaScript Debug Terminal',
   'debug.terminal.program.description':
     'Command to run in the launched terminal. If not provided, the terminal will open without launching a program.',
   'debug.terminal.snippet.label': 'Run "npm start" in a debug terminal',

--- a/src/ui/configuration/nodeDebugConfigurationProvider.ts
+++ b/src/ui/configuration/nodeDebugConfigurationProvider.ts
@@ -14,7 +14,7 @@ import {
   AnyTerminalConfiguration,
   breakpointLanguages,
   ResolvingNodeConfiguration,
-  ResolvingTerminalConfiguration
+  ResolvingTerminalConfiguration,
 } from '../../configuration';
 import { findScripts } from '../debugNpmScript';
 import { getPackageManager } from '../getRunScriptCommand';

--- a/src/ui/configuration/nodeDebugConfigurationProvider.ts
+++ b/src/ui/configuration/nodeDebugConfigurationProvider.ts
@@ -14,7 +14,7 @@ import {
   AnyTerminalConfiguration,
   breakpointLanguages,
   ResolvingNodeConfiguration,
-  ResolvingTerminalConfiguration,
+  ResolvingTerminalConfiguration
 } from '../../configuration';
 import { findScripts } from '../debugNpmScript';
 import { getPackageManager } from '../getRunScriptCommand';
@@ -83,7 +83,7 @@ export class NodeDynamicDebugConfigurationProvider extends BaseConfigurationProv
   protected async getFromNpmScripts(folder?: vscode.WorkspaceFolder): Promise<DynamicConfig[]> {
     const openTerminal: AnyResolvingConfiguration = {
       type: DebugType.Terminal,
-      name: localize('debug.terminal.label', 'New JavaScript Debug Terminal'),
+      name: localize('debug.terminal.label', 'JavaScript Debug Terminal'),
       request: 'launch',
       cwd: folder?.uri.fsPath,
     };


### PR DESCRIPTION
We want to avoid using "New"/"Create" so we control how they're displayed. When tabs come in we'll be dropping the prefix all together.