### PR TITLE
CDP Proxy: Allows Other Extensions to Reuse CDP Connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13553,6 +13553,11 @@
         "execa": "^4.0.0"
       }
     },
+    "vscode-js-debug-cdp-proxy-api": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-js-debug-cdp-proxy-api/-/vscode-js-debug-cdp-proxy-api-0.0.3.tgz",
+      "integrity": "sha512-Ns6bNXBRfItOSyUnt+y9eZSl3C0TN9YNBV8np1k0p+PQ15H4DtGSq9yT3Wr+NR3S4RdFL16GjKdy/uqw12FQCQ=="
+    },
     "vscode-nls": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "source-map-support": "^0.5.19",
     "split2": "^3.1.1",
     "vscode-js-debug-browsers": "^1.0.4",
+    "vscode-js-debug-cdp-proxy-api": "0.0.3",
     "vscode-nls": "^4.1.2",
     "ws": "^7.2.3"
   },

--- a/src/adapter/cdpProxy.ts
+++ b/src/adapter/cdpProxy.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Disposable } from 'vscode';
+import WebSocket from 'ws';
+import { Cdp } from '../cdp/api';
+
+export class CDPProxy implements Disposable {
+  private webSocket: WebSocket.Server | undefined;
+
+  async proxy(_cdp: Cdp.Api): Promise<void> {
+    if (!this.webSocket) {
+      this.webSocket = new WebSocket.Server({ port: 0 });
+    }
+  }
+
+  address(): { address: string; port: number; family: string } | undefined {
+    const address = this.webSocket?.address();
+    if (address && typeof address !== 'string') {
+      return address;
+    }
+    return undefined;
+  }
+
+  dispose(): void {
+    if (this.webSocket) {
+      this.webSocket.close();
+    }
+  }
+}

--- a/src/adapter/cdpProxy.ts
+++ b/src/adapter/cdpProxy.ts
@@ -2,30 +2,188 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { Disposable } from 'vscode';
+import * as ProxyProtocol from 'vscode-js-debug-cdp-proxy-api';
 import WebSocket from 'ws';
 import { Cdp } from '../cdp/api';
+import { DisposableList, IDisposable } from '../common/disposable';
 
-export class CDPProxy implements Disposable {
-  private webSocket: WebSocket.Server | undefined;
+export class CDPProxyServer implements IDisposable {
+  private server?: WebSocket.Server;
+  private readonly disposables = new DisposableList();
 
-  async proxy(_cdp: Cdp.Api): Promise<void> {
-    if (!this.webSocket) {
-      this.webSocket = new WebSocket.Server({ port: 0 });
-    }
-  }
+  constructor(private readonly cdp: Cdp.Api) {}
 
-  address(): { address: string; port: number; family: string } | undefined {
-    const address = this.webSocket?.address();
+  address(): { host: string; port: number } | undefined {
+    const address = this.server?.address();
     if (address && typeof address !== 'string') {
-      return address;
+      return {
+        host: address.address,
+        port: address.port,
+      };
     }
-    return undefined;
+    return;
   }
 
-  dispose(): void {
-    if (this.webSocket) {
-      this.webSocket.close();
+  async proxy(): Promise<void> {
+    if (!this.server) {
+      const server = new WebSocket.Server({ port: 0 });
+
+      server.on('connection', client => {
+        const clientHandle = new ClientHandle(client);
+
+        client.on('close', () => {
+          this.disposables.disposeObject(clientHandle);
+        });
+
+        client.on('message', async d => {
+          const request = parseRequest(d.toString());
+
+          if (request) {
+            try {
+              switch (request.operation) {
+                case ProxyProtocol.Operation.Subscribe:
+                  const subscribeResult = await this.subscribeToCDP(request, clientHandle);
+                  this.sendResultResponse(clientHandle, request, subscribeResult);
+                  break;
+                case ProxyProtocol.Operation.Send:
+                  const sendResult = await this.sendToCDP(request);
+                  this.sendResultResponse(clientHandle, request, sendResult);
+                  break;
+              }
+            } catch (e) {
+              this.sendErrorResponse(clientHandle, request, e.toString());
+            }
+          }
+        });
+      });
+
+      this.server = server;
     }
+  }
+
+  dispose() {
+    this.disposables.dispose();
+    this.server?.close();
+  }
+
+  private async sendToCDP({
+    domain,
+    method,
+    params,
+  }: ProxyProtocol.SendRequest): Promise<Record<string, unknown>> {
+    const agent = this.cdp[domain as keyof Cdp.Api];
+
+    if (agent) {
+      const fn = (agent as any)[method]; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      if (typeof fn === 'function') {
+        return await fn(params);
+      } else {
+        throw new Error(`Unknown method for domain "${method}"`);
+      }
+    } else {
+      throw new Error(`Unknown domain "${domain}"`);
+    }
+  }
+
+  private sendResultResponse<O extends ProxyProtocol.Operation>(
+    { webSocket }: ClientHandle,
+    request: ProxyProtocol.RequestMessage<O>,
+    result: ProxyProtocol.IResponsePayload[O],
+  ): void {
+    const response: ProxyProtocol.ResponseMessage<O> = {
+      requestId: request.requestId,
+      result,
+    };
+    webSocket.send(JSON.stringify(response));
+  }
+
+  private sendErrorResponse<O extends ProxyProtocol.Operation>(
+    { webSocket }: ClientHandle,
+    request: ProxyProtocol.Request,
+    error: string,
+  ): void {
+    const response: ProxyProtocol.ResponseMessage<O> = {
+      requestId: request.requestId,
+      error,
+    };
+    webSocket.send(JSON.stringify(response));
+  }
+
+  private subscribeToCDP(
+    { domain, event }: ProxyProtocol.SubscribeRequest,
+    clientHandle: ClientHandle,
+  ) {
+    if (!event) {
+      throw new Error('Subscription of complete domain not implemented!');
+    }
+
+    const agent = this.cdp[domain as keyof Cdp.Api];
+    if (agent) {
+      const on = (agent as any).on; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      if (typeof on === 'function') {
+        clientHandle.pushDisposable(
+          on(event, (data: Record<string, unknown>) =>
+            this.sendEvent(clientHandle.webSocket, domain, event, data),
+          ),
+        );
+      } else {
+        throw new Error(`Domain "${domain}" does not provide event subscriptions.`);
+      }
+    } else {
+      throw new Error(`Unknown domain "${domain}"`);
+    }
+  }
+
+  private sendEvent(
+    socket: WebSocket,
+    domain: string,
+    event: string,
+    data: Record<string, unknown>,
+  ) {
+    const message: ProxyProtocol.IEvent = {
+      domain,
+      event,
+      data,
+    };
+    socket.send(JSON.stringify(message));
+  }
+}
+
+function parseRequest(raw: string): ProxyProtocol.Request | undefined {
+  try {
+    const json = JSON.parse(raw);
+    const { operation } = json;
+
+    if (typeof operation !== 'string') {
+      return;
+    }
+
+    // TODO do proper parsing of the incoming requests JSON?
+    switch (operation) {
+      case ProxyProtocol.Operation.Subscribe:
+        return json as ProxyProtocol.RequestMessage<ProxyProtocol.Operation.Subscribe>;
+      case ProxyProtocol.Operation.Send:
+        return json as ProxyProtocol.RequestMessage<ProxyProtocol.Operation.Send>;
+    }
+  } catch (e) {
+    // Ignore requests which cannot be parsed
+  }
+  return;
+}
+
+class ClientHandle implements IDisposable {
+  private readonly disposables: DisposableList = new DisposableList();
+
+  constructor(readonly webSocket: WebSocket) {}
+
+  pushDisposable(d: IDisposable): void {
+    this.disposables.push(d);
+  }
+
+  dispose() {
+    this.disposables.dispose();
+    this.webSocket.close();
   }
 }

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -17,7 +17,7 @@ import { disposeContainer } from '../ioc-extras';
 import { ITelemetryReporter } from '../telemetry/telemetryReporter';
 import { IAsyncStackPolicy } from './asyncStackPolicy';
 import { BreakpointManager } from './breakpoints';
-import { CDPProxy } from './cdpProxy';
+import { CDPProxyServer } from './cdpProxy';
 import { ICompletions } from './completions';
 import { IConsole } from './console';
 import { Diagnostics } from './diagnosics';
@@ -46,7 +46,7 @@ export class DebugAdapter implements IDisposable {
   private _thread: Thread | undefined;
   private _configurationDoneDeferred: IDeferred<void>;
   private lastBreakpointId = 0;
-  private cdpProxy: CDPProxy | undefined;
+  private _cdpProxyServer: CDPProxyServer | undefined;
 
   constructor(
     dap: Dap.Api,
@@ -422,19 +422,19 @@ export class DebugAdapter implements IDisposable {
   }
 
   async _requestCDPProxy() {
-    if (!this.cdpProxy) {
+    if (!this._cdpProxyServer) {
       const cdp = this._thread?.cdp();
 
       if (cdp) {
-        const cdpProxy = new CDPProxy();
-        cdpProxy.proxy(cdp);
+        const cdpProxy = new CDPProxyServer(cdp);
+        cdpProxy.proxy();
 
         this._disposables.push(cdpProxy);
-        this.cdpProxy = cdpProxy;
+        this._cdpProxyServer = cdpProxy;
       }
     }
 
-    return this.cdpProxy?.address() || {};
+    return this._cdpProxyServer?.address() || {};
   }
 
   dispose() {

--- a/src/build/dapCustom.ts
+++ b/src/build/dapCustom.ts
@@ -473,11 +473,29 @@ const dapCustom: JSONSchema4 = {
         required: ['file'],
       },
     ),
-
     ...makeEvent(
       'suggestDiagnosticTool',
       "Shows a prompt to the user suggesting they use the diagnostic tool if breakpoints don't bind.",
       {},
+    ),
+    ...makeRequest(
+      'requestCDPProxy',
+      'Request WebSocket connection information on a proxy for this debug sessions CDP connection.',
+      undefined,
+      {
+        properties: {
+          host: {
+            type: 'string',
+            description:
+              'Name of the host, on which the CDP proxy is available through a WebSocket.',
+          },
+          port: {
+            type: 'number',
+            description:
+              'Port on the host, under which the CDP proxy is available through a WebSocket.',
+          },
+        },
+      },
     ),
   },
 };

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -1240,6 +1240,11 @@ const commands: ReadonlyArray<{
     title: refString('startWithStopOnEntry.label'),
     category: 'Debug',
   },
+  {
+    command: Commands.RequestCDPProxy,
+    title: refString('requestCDPProxy.label'),
+    category: 'Debug',
+  },
 ];
 
 const menus: Menus = {
@@ -1279,6 +1284,11 @@ const menus: Menus = {
       command: Commands.RevealPage,
       group: 'navigation',
       when: forBrowserDebugType('debugType', `callStackItemType == 'session'`),
+    },
+    {
+      command: Commands.RequestCDPProxy,
+      group: 'navigation',
+      when: forAnyDebugType('debugType', `callStackItemType == 'session'`),
     },
     {
       command: Commands.ToggleSkipping,

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -308,6 +308,7 @@ A common case to disable certificate verification can be done by passing \`{ "ht
   'debugLink.label': 'Open Link',
   'createDiagnostics.label': 'Diagnose Breakpoint Problems',
   'startWithStopOnEntry.label': 'Start Debugging and Stop on Entry',
+  'requestCDPProxy.label': 'Request CDP Proxy for Debug Session',
 };
 
 export default strings;

--- a/src/common/contributionUtils.ts
+++ b/src/common/contributionUtils.ts
@@ -33,6 +33,7 @@ export const enum Commands {
   RemoveAllCustomBreakpoints = 'extension.js-debug.removeAllCustomBreakpoints',
   RemoveCustomBreakpoint = 'extension.js-debug.removeCustomBreakpoint',
   RevealPage = 'extension.js-debug.revealPage',
+  RequestCDPProxy = 'extension.js-debug.requestCDPProxy',
   /** Use node-debug's command so existing keybindings work */
   StartWithStopOnEntry = 'extension.node-debug.startWithStopOnEntry',
   StartProfile = 'extension.js-debug.startProfile',
@@ -77,6 +78,7 @@ const commandsObj: { [K in Commands]: null } = {
   [Commands.StopProfile]: null,
   [Commands.ToggleSkipping]: null,
   [Commands.StartWithStopOnEntry]: null,
+  [Commands.RequestCDPProxy]: null,
 };
 
 /**
@@ -163,6 +165,9 @@ export interface ICommandTypes {
   [Commands.RevealPage](sessionId: string): void;
   [Commands.DebugLink](link?: string): void;
   [Commands.StartWithStopOnEntry](): void;
+  [Commands.RequestCDPProxy](
+    sessionId: string,
+  ): { address: string; port: number; family: string } | null;
 }
 
 /**

--- a/src/dap/api.d.ts
+++ b/src/dap/api.d.ts
@@ -1024,9 +1024,16 @@ export namespace Dap {
     createDiagnosticsRequest(params: CreateDiagnosticsParams): Promise<CreateDiagnosticsResult>;
 
     /**
-     * Shows a prompt to the user suggesting they use the diagnostic tool if breakpoints don't bind.
+     * Request WebSocket connection information on a proxy for this debug sessions CDP connection.
      */
-    suggestDiagnosticTool(params: SuggestDiagnosticToolEventParams): void;
+    on(
+      request: 'requestCDPProxy',
+      handler: (params: RequestCDPProxyParams) => Promise<RequestCDPProxyResult | Error>,
+    ): () => void;
+    /**
+     * Request WebSocket connection information on a proxy for this debug sessions CDP connection.
+     */
+    requestCDPProxyRequest(params: RequestCDPProxyParams): Promise<RequestCDPProxyResult>;
   }
 
   export interface TestApi {
@@ -1699,20 +1706,9 @@ export namespace Dap {
     createDiagnostics(params: CreateDiagnosticsParams): Promise<CreateDiagnosticsResult>;
 
     /**
-     * Shows a prompt to the user suggesting they use the diagnostic tool if breakpoints don't bind.
+     * Request WebSocket connection information on a proxy for this debug sessions CDP connection.
      */
-    on(
-      request: 'suggestDiagnosticTool',
-      handler: (params: SuggestDiagnosticToolEventParams) => void,
-    ): void;
-    off(
-      request: 'suggestDiagnosticTool',
-      handler: (params: SuggestDiagnosticToolEventParams) => void,
-    ): void;
-    once(
-      request: 'suggestDiagnosticTool',
-      filter?: (event: SuggestDiagnosticToolEventParams) => boolean,
-    ): Promise<SuggestDiagnosticToolEventParams>;
+    requestCDPProxy(params: RequestCDPProxyParams): Promise<RequestCDPProxyResult>;
   }
 
   export interface AttachParams {
@@ -2799,6 +2795,20 @@ export namespace Dap {
     doesExists: boolean;
   }
 
+  export interface RequestCDPProxyParams {}
+
+  export interface RequestCDPProxyResult {
+    /**
+     * Name of the host, on which the CDP proxy is available through a WebSocket.
+     */
+    host?: string;
+
+    /**
+     * Port on the host, under which the CDP proxy is available through a WebSocket.
+     */
+    port?: number;
+  }
+
   export interface RestartFrameParams {
     /**
      * Restart this stackframe.
@@ -3310,8 +3320,6 @@ export namespace Dap {
      */
     hitBreakpointIds?: integer[];
   }
-
-  export interface SuggestDiagnosticToolEventParams {}
 
   export interface SuggestDisableSourcemapEventParams {
     /**

--- a/src/dap/telemetryClassification.d.ts
+++ b/src/dap/telemetryClassification.d.ts
@@ -122,4 +122,6 @@ interface IDAPOperationClassification {
   '!disablesourcemap.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
   creatediagnostics: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
   '!creatediagnostics.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
+  requestcdpproxy: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
+  '!requestcdpproxy.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { toggleOnExperiment } from './ui/experimentEnlist';
 import { PrettyPrintTrackerFactory } from './ui/prettyPrint';
 import { attachProcess, pickProcess } from './ui/processPicker';
 import { registerProfilingCommand } from './ui/profiling';
+import { registerRequestCDPProxy } from './ui/requestCDPProxy';
 import { registerRevealPage } from './ui/revealPage';
 import { TerminalLinkHandler } from './ui/terminalLinkHandler';
 import { toggleSkippingFile } from './ui/toggleSkippingFile';
@@ -43,7 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
     registerCommand(vscode.commands, Commands.PickProcess, pickProcess),
     registerCommand(vscode.commands, Commands.AttachProcess, attachProcess),
     registerCommand(vscode.commands, Commands.ToggleSkipping, toggleSkippingFile),
-    registerCommand(vscode.commands, Commands.EnlistExperiment, toggleOnExperiment),
+    registerCommand(vscode.commands, Commands.EnlistExperiment, toggleOnExperiment)
   );
 
   context.subscriptions.push(
@@ -95,6 +96,7 @@ export function activate(context: vscode.ExtensionContext) {
   registerProfilingCommand(context, services);
   registerAutoAttach(context, services.get(DelegateLauncherFactory), services);
   registerRevealPage(context, debugSessionTracker);
+  registerRequestCDPProxy(context, debugSessionTracker);
   services.getAll<IExtensionContribution>(IExtensionContribution).forEach(c => c.register(context));
 }
 

--- a/src/ui/requestCDPProxy.ts
+++ b/src/ui/requestCDPProxy.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Commands, registerCommand } from '../common/contributionUtils';
+import { DebugSessionTracker } from './debugSessionTracker';
+
+export const registerRequestCDPProxy = (
+  context: vscode.ExtensionContext,
+  tracker: DebugSessionTracker,
+) => {
+  context.subscriptions.push(
+    registerCommand(vscode.commands, Commands.RequestCDPProxy, async sessionId => {
+      const session = tracker.getById(sessionId);
+      return await session?.customRequest('requestCDPProxy');
+    }),
+  );
+};


### PR DESCRIPTION
Extends `js-debug` to expose its internal CDP connection to other extensions.

This pull request resolves #893.

## Overview

- A new command `requestCDPProxy` returns websocket connection details to connect to the CDP proxy.
  - If `requestCDPProxy` is called the first time, the proxy is created
  - Otherwise connection details for the previously created proxy are returned
- The debug adapter holds an instance of the CDP proxy and ensures forwarding of any communication between proxy clients and the CDP connection.
- The proxy and its clients use a basic JSON communication protocol described here: https://github.com/swissmanu/vscode-js-debug-cdp-proxy-api