### PR TITLE
feat: Allow callers of debugServerMain.ts to specify the host

### DIFF
--- a/src/debugServer.ts
+++ b/src/debugServer.ts
@@ -83,7 +83,7 @@ class Configurator {
   }
 }
 
-export function startDebugServer(port: number): Promise<IDisposable> {
+export function startDebugServer(port: number, host?: string): Promise<IDisposable> {
   return new Promise((resolve, reject) => {
     const server = net
       .createServer(async socket => {
@@ -115,7 +115,7 @@ export function startDebugServer(port: number): Promise<IDisposable> {
         const configurator = new Configurator(connection.dap());
       })
       .on('error', reject)
-      .listen(port, () => {
+      .listen({ port, host }, () => {
         console.log(`Debug server listening at ${(server.address() as net.AddressInfo).port}`);
         resolve({
           dispose: () => {

--- a/src/debugServerMain.ts
+++ b/src/debugServerMain.ts
@@ -4,4 +4,17 @@
 
 import { startDebugServer } from './debugServer';
 
-startDebugServer(process.argv.length >= 3 ? +process.argv[2] : 0);
+let port = 0;
+let host: string | undefined;
+if (process.argv.length >= 3) {
+  // Interpret the argument as either a port number, or 'address:port'.
+  const address = process.argv[2];
+  const colonIndex = address.lastIndexOf(':');
+  if (colonIndex === -1) {
+    port = +address;
+  } else {
+    host = address.substring(0, colonIndex);
+    port = +address.substring(colonIndex + 1);
+  }
+}
+startDebugServer(port, host);


### PR DESCRIPTION
This change allows callers of debugServerMain.ts to be able to provide
what address the DAP listener will bind to. This prevents random
eavesdroppers from listening into the DAP.

Fixes: #1005