### PR TITLE
Ensure that the debugAdapter's _onInitialize() is called

### DIFF
--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -303,7 +303,11 @@ export class DebugAdapter implements IDisposable {
     return errors.createSilentError(localize('error.threadNotFound', 'Thread not found'));
   }
 
-  createThread(cdp: Cdp.Api, delegate: IThreadDelegate): Thread {
+  createThread(
+    cdp: Cdp.Api,
+    delegate: IThreadDelegate,
+    initializeParams?: Dap.InitializeParams,
+  ): Thread {
     this._thread = new Thread(
       this.sourceContainer,
       cdp,
@@ -318,6 +322,13 @@ export class DebugAdapter implements IDisposable {
       this._services.get(IConsole),
       this._services.get(IExceptionPauseService),
     );
+    if (initializeParams) {
+      // We won't get notified of an initialize message:
+      // that was already caught by the caller.
+      setTimeout(() => {
+        this._onInitialize(initializeParams);
+      }, 0);
+    }
 
     const profile = this._services.get<IProfileController>(IProfileController);
     profile.connect(this.dap, this._thread);

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -57,6 +57,7 @@ export class Binder implements IDisposable {
   private _onTargetListChangedEmitter = new EventEmitter<void>();
   readonly onTargetListChanged = this._onTargetListChangedEmitter.event;
   private _dap: Promise<Dap.Api>;
+  private _dapInitializeParams?: Dap.InitializeParams;
   private _targetOrigin: ITargetOrigin;
   private _launchParams?: AnyLaunchConfiguration;
   private _asyncStackPolicy?: IAsyncStackPolicy;
@@ -93,6 +94,7 @@ export class Binder implements IDisposable {
         if (clientCapabilities.clientID === 'vscode') {
           filterErrorsReportedToTelemetry();
         }
+        this._dapInitializeParams = clientCapabilities;
 
         setTimeout(() => {
           dap.initialized({});
@@ -403,7 +405,7 @@ export class Binder implements IDisposable {
 
     // todo: move scriptskipper into services collection
     const debugAdapter = new DebugAdapter(dap, this._asyncStackPolicy, launchParams, container);
-    const thread = debugAdapter.createThread(cdp, target);
+    const thread = debugAdapter.createThread(cdp, target, this._dapInitializeParams);
 
     const startThread = async () => {
       await debugAdapter.launchBlocker();


### PR DESCRIPTION
When launching a `pwa-node` process, the debugAdapter's _onInitialize()
method is never called, since the dap registers a listener for the
`'initialize'` message _after_ it has arrived. This causes the Thread's
`dap` to never be resolved, so any thread events (e.g. `'paused'`) are
never sent to the client! This in turn causes VSCode to never realize
that the process is stopped, so the debuggee just waits there,
patiently, forever.

This change stores the `Dap.InitializeParams` on the Binder and then
when the Thread is created, the params are forwarded so that the
DebugAdapter can _onInitialize() correctly and the thread-related events
can flow.

Fixes: #1009