### PR TITLE
fix: Error when trying to set a breakpoint in index.html

### DIFF
--- a/src/common/urlUtils.test.ts
+++ b/src/common/urlUtils.test.ts
@@ -85,6 +85,21 @@ describe('urlUtils', () => {
         'file:\\/\\/\\/[Cc]:\\/foo\\/(?:①|%E2%91%A0)(?:Ⅻ|%E2%85%AB)(?:ㄨ|%E3%84%A8)(?:ㄩ|%E3%84%A9)(?: |%20)(?:啊|%E5%95%8A)(?:阿|%E9%98%BF)(?:鼾|%E9%BC%BE)(?:齄|%E9%BD%84)(?:丂|%E4%B8%82)(?:丄|%E4%B8%84)(?:狚|%E7%8B%9A)(?:狛|%E7%8B%9B)(?:狜|%E7%8B%9C)(?:狝|%E7%8B%9D)(?:﨨|%EF%A8%A8)(?:﨩|%EF%A8%A9)(?:ˊ|%CB%8A)(?:ˋ|%CB%8B)(?:˙|%CB%99)(?:–|%E2%80%93)(?:⿻|%E2%BF%BB)(?:〇|%E3%80%87)(?:㐀|%E3%90%80)(?:㐁|%E3%90%81)(?:䶴|%E4%B6%B4)(?:䶵|%E4%B6%B5)U1(?:\\[|%5B)(?:|%EE%80%A5)(?:|%EE%80%A6)(?:|%EE%80%A7)(?:|%EE%80%B8)(?:|%EE%80%B9)(?:\\]|%5D)U2(?:\\[|%5B)(?:|%EE%89%9A)(?:|%EE%89%9B)(?:|%EE%89%AC)(?:|%EE%89%AD)(?:\\]|%5D)U3(?:\\[|%5B)(?:|%EE%93%BE)(?:|%EE%93%BF)(?:|%EE%94%80)(?:|%EE%94%8B)(?:|%EE%94%8C)(?:\\]|%5D)\\.js|[Cc]:\\\\foo\\\\(?:①|%E2%91%A0)(?:Ⅻ|%E2%85%AB)(?:ㄨ|%E3%84%A8)(?:ㄩ|%E3%84%A9)(?: |%20)(?:啊|%E5%95%8A)(?:阿|%E9%98%BF)(?:鼾|%E9%BC%BE)(?:齄|%E9%BD%84)(?:丂|%E4%B8%82)(?:丄|%E4%B8%84)(?:狚|%E7%8B%9A)(?:狛|%E7%8B%9B)(?:狜|%E7%8B%9C)(?:狝|%E7%8B%9D)(?:﨨|%EF%A8%A8)(?:﨩|%EF%A8%A9)(?:ˊ|%CB%8A)(?:ˋ|%CB%8B)(?:˙|%CB%99)(?:–|%E2%80%93)(?:⿻|%E2%BF%BB)(?:〇|%E3%80%87)(?:㐀|%E3%90%80)(?:㐁|%E3%90%81)(?:䶴|%E4%B6%B4)(?:䶵|%E4%B6%B5)U1(?:\\[|%5B)(?:|%EE%80%A5)(?:|%EE%80%A6)(?:|%EE%80%A7)(?:|%EE%80%B8)(?:|%EE%80%B9)(?:\\]|%5D)U2(?:\\[|%5B)(?:|%EE%89%9A)(?:|%EE%89%9B)(?:|%EE%89%AC)(?:|%EE%89%AD)(?:\\]|%5D)U3(?:\\[|%5B)(?:|%EE%93%BE)(?:|%EE%93%BF)(?:|%EE%94%80)(?:|%EE%94%8B)(?:|%EE%94%8C)(?:\\]|%5D)\\.js',
       );
     });
+    it('works with a pre-escaped suffix', () => {
+      const url = 'file:///foo';
+      const escapedRe = '\\/?($|index(\\.html)?)';
+      expect(urlToRegex(`${url}${escapedRe}`, [0, url.length])).to.equal(
+        'file:\\/\\/\\/foo\\/?($|index(\\.html)?)|\\/foo\\/?($|index(\\.html)?)',
+      );
+    });
+    it('works with a pre-escaped prefix', () => {
+      const path = 'foo';
+      const wildcardHostname = 'https?:\\/\\/[^\\/]+\\/';
+      const url = `${wildcardHostname}${path}`;
+      expect(urlToRegex(url, [wildcardHostname.length, url.length])).to.equal(
+        'https?:\\/\\/[^\\/]+\\/foo',
+      );
+    });
   });
 
   describe('urlToRegex - case insensitive', () => {

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -325,6 +325,9 @@ export function urlToRegex(
   [escapeReStart, escapeReEnd]: [number, number] = [0, aPath.length],
 ) {
   const patterns: string[] = [];
+  const rePrefix = aPath.slice(0, escapeReStart);
+  const reSuffix = aPath.slice(escapeReEnd);
+  const unescapedPath = aPath.slice(escapeReStart, escapeReEnd);
 
   // aPath will often (always?) be provided as a file URI, or URL. Decode it
   // --we'll reencode it as we go--and also create a match for its absolute
@@ -336,7 +339,7 @@ export function urlToRegex(
   //  - For case insensitive systems, we generate a regex like [fF][oO][oO]/(?:💩|%F0%9F%92%A9).[jJ][sS]
   //  - If we didn't de-encode it, the percent would be case-insensitized as
   //    well and we would not include the original character in the regex
-  for (const str of [decodeURI(aPath), fileUrlToAbsolutePath(aPath)]) {
+  for (const str of [decodeURI(unescapedPath), fileUrlToAbsolutePath(unescapedPath)]) {
     if (!str) {
       continue;
     }
@@ -347,7 +350,7 @@ export function urlToRegex(
     let re = '';
     for (let i = 0; i < str.length; i++) {
       const char = str[i];
-      const escapeRegex = i >= escapeReStart && i < escapeReEnd;
+      const escapeRegex = true;
 
       if (isCaseSensitive) {
         urlToRegexChar(char, chars, escapeRegex);
@@ -364,7 +367,7 @@ export function urlToRegex(
     // fancy regex above), replace `file:///c:/` or simple `c:/` patterns with
     // an insensitive drive letter.
     patterns.push(
-      re.replace(
+      `${rePrefix}${re}${reSuffix}`.replace(
         /^(file:\\\/\\\/\\\/)?([a-z]):/i,
         (_, file = '', letter) => `${file}[${letter.toUpperCase()}${letter.toLowerCase()}]:`,
       ),

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -325,6 +325,8 @@ export function urlToRegex(
   [escapeReStart, escapeReEnd]: [number, number] = [0, aPath.length],
 ) {
   const patterns: string[] = [];
+
+  // Split out the portion of the path that has already been converted to a regex pattern
   const rePrefix = aPath.slice(0, escapeReStart);
   const reSuffix = aPath.slice(escapeReEnd);
   const unescapedPath = aPath.slice(escapeReStart, escapeReEnd);
@@ -339,10 +341,14 @@ export function urlToRegex(
   //  - For case insensitive systems, we generate a regex like [fF][oO][oO]/(?:💩|%F0%9F%92%A9).[jJ][sS]
   //  - If we didn't de-encode it, the percent would be case-insensitized as
   //    well and we would not include the original character in the regex
-  for (const str of [decodeURI(unescapedPath), fileUrlToAbsolutePath(unescapedPath)]) {
+  for (let str of [decodeURI(unescapedPath), fileUrlToAbsolutePath(unescapedPath)]) {
     if (!str) {
       continue;
     }
+
+    // Recombine the decoded portion of the string with the regex suffix/prefix before
+    // potentially converting the whole thing to a case insensitive pattern
+    str = `${rePrefix}${str}${reSuffix}`;
 
     // Loop through each character of the string. Convert the char to a regex,
     // creating a group, and then append that to the match.
@@ -350,7 +356,7 @@ export function urlToRegex(
     let re = '';
     for (let i = 0; i < str.length; i++) {
       const char = str[i];
-      const escapeRegex = true;
+      const escapeRegex = i >= rePrefix.length && i < str.length - reSuffix.length;
 
       if (isCaseSensitive) {
         urlToRegexChar(char, chars, escapeRegex);
@@ -367,7 +373,7 @@ export function urlToRegex(
     // fancy regex above), replace `file:///c:/` or simple `c:/` patterns with
     // an insensitive drive letter.
     patterns.push(
-      `${rePrefix}${re}${reSuffix}`.replace(
+      `${re}`.replace(
         /^(file:\\\/\\\/\\\/)?([a-z]):/i,
         (_, file = '', letter) => `${file}[${letter.toUpperCase()}${letter.toLowerCase()}]:`,
       ),

--- a/src/targets/browser/browserPathResolver.test.ts
+++ b/src/targets/browser/browserPathResolver.test.ts
@@ -178,21 +178,21 @@ describe('BrowserPathResolver', () => {
       const e1 = 'http://localhost:1234/foo/bar(\\.html)?';
       expect(
         resolver().absolutePathToUrlRegexp(path.join(testFixturesDir, 'web', 'foo', 'bar.html')),
-      ).to.equal(urlToRegex(e1, [0, e1.length - 10]));
+      ).to.equal(urlToRegex(e1, [0, e1.length - 9]));
 
       const e2 = 'http://localhost:1234/sibling/foo/bar(\\.html)?';
       expect(
         resolver().absolutePathToUrlRegexp(
           path.join(testFixturesDir, 'sibling-dir', 'foo', 'bar.html'),
         ),
-      ).to.equal(urlToRegex(e2, [0, e2.length - 10]));
+      ).to.equal(urlToRegex(e2, [0, e2.length - 9]));
     });
 
     it('falls back if not in any webroot', () => {
       const e = 'http://localhost:1234/../foo/bar(\\.html)?';
       expect(
         resolver().absolutePathToUrlRegexp(path.join(testFixturesDir, 'foo', 'bar.html')),
-      ).to.equal(urlToRegex(e, [0, e.length - 10]));
+      ).to.equal(urlToRegex(e, [0, e.length - 9]));
     });
 
     it('matches any path if no baseUrl is present', () => {


### PR DESCRIPTION
This is a fix for the urlToRegex issue referenced in #1028 along with 2 new test cases.

I'm making the assumption that any part of `aPath` that has already been escaped should also not have the url decode/encode step done, which seems to match the previous intended behavior. I am also making the assumption that there is no expectation at that point that the portion of the path that needs to be escaped will be a valid file url, especially if escapeReStart is not zero. This seems like a safe assumption given that the escape param only seems to be used from one place that works under those assumptions, but the behavior isn't super intuitive. I didn't want to change too much though, especially since I'm new to this codebase and don't know the history of that method.
