### PR TITLE
feat: disable pause if all breakpoints have been disabled

### DIFF
--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -494,7 +494,7 @@ export class BreakpointManager {
     params: Dap.SetBreakpointsParams,
     ids: number[],
   ): Promise<Dap.SetBreakpointsResult> {
-    if (!this._sourceMapHandlerWasUpdated && this._thread) {
+    if (!this._sourceMapHandlerWasUpdated && this._thread && params.breakpoints) {
       await this._updateSourceMapHandler(this._thread);
     }
 
@@ -584,6 +584,11 @@ export class BreakpointManager {
     await Promise.all(result.unbound.map(b => b.disable()));
 
     this._totalBreakpointsCount += result.new.length;
+
+    if (this._thread && this._totalBreakpointsCount === 0 && this._sourceMapHandlerWasUpdated) {
+      this._thread.setScriptSourceMapHandler(false);
+      this._sourceMapHandlerWasUpdated = false;
+    }
 
     const thread = this._thread;
     if (thread && result.new.length) {

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -499,7 +499,7 @@ export class BreakpointManager {
     params: Dap.SetBreakpointsParams,
     ids: number[],
   ): Promise<Dap.SetBreakpointsResult> {
-    if (!this._sourceMapHandlerInstalled && this._thread && params.breakpoints) {
+    if (!this._sourceMapHandlerInstalled && this._thread && params.breakpoints?.length) {
       await this._installSourceMapHandler(this._thread);
     }
 


### PR DESCRIPTION
The current behavior is that the debugger is configured to pause while loading source maps if at least one breakpoint has been set during a debugging session. This has the side effect of switching to the sources tab on page reload even if all breakpoints have since been disabled. This commit removes the automatic pausing of the debugger while loading source maps if there are no longer any active breakpoints. Pausing while source maps are loading should resume if any breakpoints are reenabled or new breakpoints are added. This allows developers keep the benefit of more reliable breakpoints early in program without the drawback of extra pauses when they are not needed.
