### PR TITLE
Node 16.x breakpoint warning resolved in 16.4

### DIFF
--- a/src/targets/node/nodeBinaryProvider.ts
+++ b/src/targets/node/nodeBinaryProvider.ts
@@ -75,7 +75,7 @@ const warningMessages: ReadonlyArray<IWarningMessage> = [
     inclusiveMax: new Semver(16, 3, 99),
     message: localize(
       'warning.16bpIssue',
-      'Some breakpoints might not work in your version of Node.js. We suggest temporarily downgrading to Node 14. Details: https://aka.ms/AAcsvqm',
+      'Some breakpoints might not work in your version of Node.js. We recommend upgrading for the latest bug, performance, and security fixes. Details: https://aka.ms/AAcsvqm',
     ),
   },
   {


### PR DESCRIPTION
Since the said issue is resolved and shipped in 16.4, Suggesting users to downgrade is a bad idea, instead they should be recommended to upgrade to the latest release to resolve this issue.

Reference: https://github.com/nodejs/node/pull/38273