### PR TITLE
Update userDataDir option documentation

### DIFF
--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -106,7 +106,7 @@ const strings = {
   'browser.perScriptSourcemaps.description':
     'Whether scripts are loaded individually with unique sourcemaps containing the basename of the source file. This can be set to optimize sourcemap handling when dealing with lots of small scripts. If set to "auto", we\'ll detect known cases where this is appropriate.',
   'browser.userDataDir.description':
-    'By default, the browser is launched with a separate user profile in a temp folder. Use this option to override it. Set to false to launch with your default user profile. If `userDataDir` is specified, VS Code can not launch a new browser instance in the default profile if one is already running.',
+    'By default, the browser is launched with a separate user profile in a temp folder. Use this option to override it. Set to false to launch with your default user profile. A new browser can\'t be launched if an instance is already running from `userDataDir`.',
   'browser.inspectUri.description':
     "Format to use to rewrite the inspectUri: It's a template string that interpolates keys in `{curlyBraces}`. Available keys are:\n" +
     ' - `url.*` is the parsed address of the running application. For instance, `{url.port}`, `{url.hostname}`\n' +

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -106,7 +106,7 @@ const strings = {
   'browser.perScriptSourcemaps.description':
     'Whether scripts are loaded individually with unique sourcemaps containing the basename of the source file. This can be set to optimize sourcemap handling when dealing with lots of small scripts. If set to "auto", we\'ll detect known cases where this is appropriate.',
   'browser.userDataDir.description':
-    'By default, the browser is launched with a separate user profile in a temp folder. Use this option to override it. Set to false to launch with your default user profile.',
+    'By default, the browser is launched with a separate user profile in a temp folder. Use this option to override it. Set to false to launch with your default user profile. If `userDataDir` is specified, VS Code can not launch a new browser instance in the default profile if one is already running.',
   'browser.inspectUri.description':
     "Format to use to rewrite the inspectUri: It's a template string that interpolates keys in `{curlyBraces}`. Available keys are:\n" +
     ' - `url.*` is the parsed address of the running application. For instance, `{url.port}`, `{url.hostname}`\n' +


### PR DESCRIPTION
Adding clarification to the `userDataDir` section to explain that another browser instance cannot be launched if this option has been specified, as is explained [here](https://github.com/microsoft/vscode/issues/120872#issuecomment-816215877).

Closes #1072. 