### PR TITLE
Fixed auto attach smart pattern with one workspace.

### DIFF
--- a/src/targets/node/autoAttachLauncher.ts
+++ b/src/targets/node/autoAttachLauncher.ts
@@ -152,7 +152,10 @@ export class AutoAttachLauncher
 
   private readSmartPatterns() {
     const configured = readConfig(vscode.workspace, Configuration.AutoAttachSmartPatterns);
-    const allFolders = `{${vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath).join(',')}}`;
+    const allFolders =
+      vscode.workspace.workspaceFolders?.length === 1
+        ? vscode.workspace.workspaceFolders[0].uri.fsPath
+        : `{${vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath).join(',')}}`;
     return configured
       ?.map(c => c.replace('${workspaceFolder}', allFolders))
       .map(forceForwardSlashes);


### PR DESCRIPTION
This fixes the "${workspaceFolder}/**" smart pattern being generated being invalid when there is only one workspace folder.

The bootloader code uses micromatch to compare smart patterns to the script path. One of the default patterns is "${workspaceFolder}/**" and that gets converted into something like "{workspace1,workspace2}/**".

When you only have one workspace it looks like this "{workspace1}/**" and while the micromatch documentation is unclear on that point, in my testing this is not expanded and the braces remain making the match impossible. In practice this makes smart attach not work at all in my case.

This PR simply doesn't include the braces in the generated smart pattern when there is only one workspace folder.

As a workaround you can add a wider pattern. In my case "**/dist/**" works and "**" would probably be fine as well.

https://github.com/micromatch/braces#lists