### PR TITLE
fix: use edge if it's the default on macOS

### DIFF
--- a/src/common/defaultBrowserProvider.ts
+++ b/src/common/defaultBrowserProvider.ts
@@ -23,6 +23,7 @@ const substrings = new Map([
   ['safari', DefaultBrowser.Safari],
   ['firefox', DefaultBrowser.Firefox],
   ['msedge', DefaultBrowser.Edge],
+  ['microsoft edge', DefaultBrowser.Edge],
   ['appxq0fevzme2pys62n3e0fbqa7peapykr8v', DefaultBrowser.OldEdge],
   ['ie.http', DefaultBrowser.IE],
 ]);


### PR DESCRIPTION
I use edge for my default browser on Mac. When I run `Debug: Open Link` for browser debugging, it always launches a chrome instance. So I debug this extension.
The  `name` is `"Microsoft Edge"` when the default browser is edge on Mac, so `getMatchingBrowserInString(name)` does not return  `DefaultBrowser.Edge`
![Xnip2021-10-13_16-45-49](https://user-images.githubusercontent.com/34713301/137099413-bc329cf2-3127-4946-af12-73d6a30d652a.jpg)
.
