### PR TITLE
fix: DebugSessionTunnels. Misplaced remote/local port usage

### DIFF
--- a/src/ui/companionBrowserLaunch.ts
+++ b/src/ui/companionBrowserLaunch.ts
@@ -68,14 +68,14 @@ const launchCompanionBrowser = async (
       tunnelRemoteServerIfNecessary(args),
       sessionTunnels
         .request(session.id, {
-          localPort: args.serverPort,
+          remotePort: args.serverPort,
           label: 'Browser Debug Tunnel',
         })
         .catch(() => undefined),
     ]);
 
     await vscode.commands.executeCommand('js-debug-companion.launchAndAttach', {
-      proxyUri: tunnel ? `127.0.0.1:${tunnel.remoteAddress.port}` : `127.0.0.1:${args.serverPort}`,
+      proxyUri: tunnel ? `127.0.0.1:${tunnel.localAddress.port}` : `127.0.0.1:${args.serverPort}`,
       ...args,
     });
   } catch (e) {

--- a/src/ui/debugSessionTunnels.ts
+++ b/src/ui/debugSessionTunnels.ts
@@ -45,15 +45,15 @@ export class DebugSessionTunnels implements IDisposable {
     sessionId: string,
     opts: {
       label: string;
-      localPort: number;
-      remotePort?: number;
+      localPort?: number;
+      remotePort: number;
     },
   ) {
     let tunnel = this.tunnels.get(sessionId);
     if (!tunnel) {
       tunnel = await vscode.workspace.openTunnel({
-        remoteAddress: { port: opts.remotePort ?? opts.localPort, host: 'localhost' },
-        localAddressPort: opts.localPort,
+        remoteAddress: { port: opts.remotePort, host: 'localhost' },
+        localAddressPort: opts.localPort ?? opts.remotePort,
         label: opts.label,
       });
     }

--- a/src/ui/requestCDPProxy.ts
+++ b/src/ui/requestCDPProxy.ts
@@ -30,12 +30,12 @@ export const registerRequestCDPProxy = (
       try {
         const tunneled = await tunnels.request(sessionId, {
           label: 'Edge Devtools Tunnel',
-          localPort: proxied.port,
+          remotePort: proxied.port,
         });
 
         return {
-          host: tunneled.remoteAddress.host,
-          port: tunneled.remoteAddress.port,
+          host: tunneled.localAddress.host,
+          port: tunneled.localAddress.port,
           path: proxied.path,
         };
       } catch {


### PR DESCRIPTION
- fix #1162 
- changed remote/local address usages in `DebugSessionTunnels` class to conform to vscode api standard as used in `vscode.workspace.openTunnel` api method