### PR TITLE
Update bootloader so that `$jsDebugIsRegistered` not enumerable on global

### DIFF
--- a/src/targets/node/bootloader.ts
+++ b/src/targets/node/bootloader.ts
@@ -42,7 +42,12 @@ const jsDebugRegisteredToken = '$jsDebugIsRegistered';
       args: process.argv,
     });
 
-    Object.assign(global, { [jsDebugRegisteredToken]: true });
+    // not enumerable to not get picked up by node's testing globals leakage checks
+    Object.defineProperty(global, jsDebugRegisteredToken, {
+      value: true,
+      enumerable: false,
+    });
+
     if (!checkAll(inspectorOptions)) {
       env.unsetForTree(); // save work for any children
       return;


### PR DESCRIPTION
While working on a `node` PR, I encountered the following error when running tests:

![image](https://user-images.githubusercontent.com/13711224/150654028-407af318-466d-49ae-868a-c53470db3042.png)

This is thrown by a cleanup phase in some of `node`'s testing setup:

```ts
function leakedGlobals() {
  const leaked = [];

  for (const val in global) {
    if (!knownGlobals.includes(global[val])) {
      leaked.push(val);
    }
  }

  return leaked;
}
```

I can, technically, adjust `node`'s checks to be able to add `"$jsDebugIsRegistered"` to the allowlist, but I think it's better to change it here because:
1. It helps keep editor-specific changes out of `node`.
2. If the token string were to change in this library, `node` would have to be changed again.

Overall, the purpose of this PR is to make it a tiny bit easier to work on `node` using `vscode`.