### PR TITLE
Rewrite http redirects to be backward compatible with blazor redirects

### DIFF
--- a/src/cdp/webSocketTransport.ts
+++ b/src/cdp/webSocketTransport.ts
@@ -46,7 +46,10 @@ export class WebSocketTransport implements ITransport {
               // Check for invalid http redirects for compatibility with old cdp proxies
               const redirectedUrl = ws.url.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:');
 
-              if (redirectedUrl === url) reject(errorEvent); // Parameter is an ErrorEvent. See https://github.com/websockets/ws/blob/master/doc/ws.md#websocketonerror
+              if (redirectedUrl === url) {
+                reject(errorEvent); // Parameter is an ErrorEvent. See https://github.com/websockets/ws/blob/master/doc/ws.md#websocketonerror
+                return;
+              }
 
               // Try to reconnect with the redirected URL
               const redirectedSocket = new WebSocket(redirectedUrl, [], options);


### PR DESCRIPTION
when a redirect occurs the WebSocket updates the url property so we read that in the error handler and replace http(s): with ws(s): and try one more time to connect

fixes [https://github.com/microsoft/vscode-js-debug/issues/1190](https://github.com/microsoft/vscode-js-debug/issues/1190) here to support previous releases of the Blazor debugger