### PR TITLE
Pass path mapping config to Edge DevTools opener command

### DIFF
--- a/src/ui/edgeDevToolOpener.ts
+++ b/src/ui/edgeDevToolOpener.ts
@@ -24,6 +24,14 @@ const qualifies = (session: vscode.DebugSession) => {
 const toolExtensionId = 'ms-edgedevtools.vscode-edge-devtools';
 const commandId = 'vscode-edge-devtools.attachToCurrentDebugTarget';
 
+function findRootSession(session: vscode.DebugSession): vscode.DebugSession {
+  let root = session;
+  while (root.parentSession) {
+    root = root.parentSession;
+  }
+  return root;
+}
+
 @injectable()
 export class EdgeDevToolOpener implements IExtensionContribution {
   constructor(@inject(DebugSessionTracker) private readonly tracker: DebugSessionTracker) {}
@@ -47,8 +55,10 @@ export class EdgeDevToolOpener implements IExtensionContribution {
           return;
         }
 
+        const rootSession = findRootSession(session);
+
         try {
-          return await vscode.commands.executeCommand(commandId, session.id);
+          return await vscode.commands.executeCommand(commandId, session.id, rootSession.configuration);
         } catch (e) {
           if (e instanceof Error && /command .+ not found/.test(e.message)) {
             return vscode.commands.executeCommand(

--- a/src/ui/edgeDevToolOpener.ts
+++ b/src/ui/edgeDevToolOpener.ts
@@ -58,7 +58,11 @@ export class EdgeDevToolOpener implements IExtensionContribution {
         const rootSession = findRootSession(session);
 
         try {
-          return await vscode.commands.executeCommand(commandId, session.id, rootSession.configuration);
+          return await vscode.commands.executeCommand(
+            commandId,
+            session.id,
+            rootSession.configuration,
+          );
         } catch (e) {
           if (e instanceof Error && /command .+ not found/.test(e.message)) {
             return vscode.commands.executeCommand(


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-edge-devtools/issues/787

Microsoft Edge DevTools extension users expect the `webRoot` and `pathMapping` properties in `launch.json` to apply to file links opened through the Edge DevTools. Today, the Edge DevTools extension only considers the `webRoot` and `pathMapping` properties from its own extension settings. This change plumbs the relevant launc config properties through to the `EdgeDevToolOpener` command so that they are available to the DevTools.

Related: https://github.com/microsoft/vscode-edge-devtools/pull/885