### PR TITLE
fix: prefer to parse source map directly before failling back to path mapping

### DIFF
--- a/src/common/sourceMaps/sourceMapFactory.ts
+++ b/src/common/sourceMaps/sourceMapFactory.ts
@@ -57,9 +57,15 @@ export class SourceMapFactory implements ISourceMapFactory {
    * @inheritdoc
    */
   public async load(metadata: ISourceMapMetadata): Promise<SourceMap> {
-    const basic =
-      (await this.parsePathMappedSourceMap(metadata.sourceMapUrl)) ||
-      (await this.parseSourceMap(metadata.sourceMapUrl));
+    let basic: RawSourceMap | undefined;
+    try {
+      basic = await this.parseSourceMap(metadata.sourceMapUrl);
+    } catch (e) {
+      basic = await this.parsePathMappedSourceMap(metadata.sourceMapUrl);
+      if (!basic) {
+        throw e;
+      }
+    }
 
     // The source-map library is destructive with its sources parsing. If the
     // source root is '/', it'll "helpfully" resolve a source like `../foo.ts`


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/148864. See my comment on the bottom of an explaination of what changed.