### PR TITLE
Adding support for indexed source maps.

### DIFF
--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -1067,7 +1067,7 @@ export class SourceContainer {
       const fileUrl = absolutePath && utils.absolutePathToFileUrl(absolutePath);
       const content = this.sourceMapFactory.guardSourceMapFn(
         map,
-        () => map.sourceContentFor(url),
+        () => map.sourceContentFor(url, true),
         () => null,
       );
 

--- a/src/common/sourceMaps/sourceMap.test.ts
+++ b/src/common/sourceMaps/sourceMap.test.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+import { expect } from 'chai';
+import {
+  RawIndexMap, RawSourceMap, SourceMapConsumer
+} from 'source-map';
+import { SourceMap } from './sourceMap';
+
+const sampleSource = 'console.log(123)';
+const basicSourceMap: RawSourceMap = {
+  version: 3,
+  sources: ['one.js'],
+  sourcesContent: [sampleSource],
+  names: [],
+  file: '',
+  mappings: '',
+};
+const indexedSourceMap: RawIndexMap = {
+  version: 3,
+  sections: [{
+    offset: { line: 0, column: 100},
+    map: basicSourceMap,
+  }],
+};
+
+describe('SourceMap', () => {
+  it('loads basic source-maps', async () => {
+    const map = new SourceMap(await new SourceMapConsumer(basicSourceMap), {
+      sourceMapUrl: JSON.stringify(basicSourceMap),
+      compiledPath: 'one.js',
+    }, '', ['one.js'], false);
+
+    expect(map.sourceContentFor('one.js')).to.eq(sampleSource);
+  });
+
+  it('loads indexed source-maps', async () => {
+    const map = new SourceMap(await new SourceMapConsumer(indexedSourceMap), {
+      sourceMapUrl: JSON.stringify(indexedSourceMap),
+      compiledPath: 'one.js',
+    }, '', ['one.js'], false);
+
+    expect(map.sourceContentFor('one.js')).to.eq(sampleSource);
+  });
+});

--- a/src/common/sourceMaps/sourceMap.test.ts
+++ b/src/common/sourceMaps/sourceMap.test.ts
@@ -2,9 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 import { expect } from 'chai';
-import {
-  RawIndexMap, RawSourceMap, SourceMapConsumer
-} from 'source-map';
+import { RawIndexMap, RawSourceMap, SourceMapConsumer } from 'source-map';
 import { SourceMap } from './sourceMap';
 
 const sampleSource = 'console.log(123)';
@@ -18,27 +16,41 @@ const basicSourceMap: RawSourceMap = {
 };
 const indexedSourceMap: RawIndexMap = {
   version: 3,
-  sections: [{
-    offset: { line: 0, column: 100},
-    map: basicSourceMap,
-  }],
+  sections: [
+    {
+      offset: { line: 0, column: 100 },
+      map: basicSourceMap,
+    },
+  ],
 };
 
 describe('SourceMap', () => {
   it('loads basic source-maps', async () => {
-    const map = new SourceMap(await new SourceMapConsumer(basicSourceMap), {
-      sourceMapUrl: JSON.stringify(basicSourceMap),
-      compiledPath: 'one.js',
-    }, '', ['one.js'], false);
+    const map = new SourceMap(
+      await new SourceMapConsumer(basicSourceMap),
+      {
+        sourceMapUrl: JSON.stringify(basicSourceMap),
+        compiledPath: 'one.js',
+      },
+      '',
+      ['one.js'],
+      false,
+    );
 
     expect(map.sourceContentFor('one.js')).to.eq(sampleSource);
   });
 
   it('loads indexed source-maps', async () => {
-    const map = new SourceMap(await new SourceMapConsumer(indexedSourceMap), {
-      sourceMapUrl: JSON.stringify(indexedSourceMap),
-      compiledPath: 'one.js',
-    }, '', ['one.js'], false);
+    const map = new SourceMap(
+      await new SourceMapConsumer(indexedSourceMap),
+      {
+        sourceMapUrl: JSON.stringify(indexedSourceMap),
+        compiledPath: 'one.js',
+      },
+      '',
+      ['one.js'],
+      false,
+    );
 
     expect(map.sourceContentFor('one.js')).to.eq(sampleSource);
   });

--- a/src/common/sourceMaps/sourceMap.ts
+++ b/src/common/sourceMaps/sourceMap.ts
@@ -4,11 +4,13 @@
 
 import {
   BasicSourceMapConsumer,
+  IndexedSourceMapConsumer,
   MappedPosition,
   MappingItem,
   NullableMappedPosition,
   NullablePosition,
   Position,
+  SourceMapConsumer,
 } from 'source-map';
 import { fixDriveLetterAndSlashes } from '../pathUtils';
 import { completeUrlEscapingRoot } from '../urlUtils';
@@ -22,7 +24,7 @@ export interface ISourceMapMetadata {
 /**
  * Wrapper for a parsed sourcemap.
  */
-export class SourceMap implements BasicSourceMapConsumer {
+export class SourceMap implements SourceMapConsumer {
   private static idCounter = 0;
 
   /**
@@ -37,7 +39,7 @@ export class SourceMap implements BasicSourceMapConsumer {
   public readonly id = SourceMap.idCounter++;
 
   constructor(
-    private readonly original: BasicSourceMapConsumer,
+    private readonly original: BasicSourceMapConsumer | IndexedSourceMapConsumer,
     public readonly metadata: Readonly<ISourceMapMetadata>,
     private readonly actualRoot: string,
     public readonly actualSources: ReadonlyArray<string>,
@@ -65,25 +67,11 @@ export class SourceMap implements BasicSourceMapConsumer {
   }
 
   /**
-   * Gets the optional name of the generated code that this source map is associated with
-   */
-  public get file() {
-    return this.metadata.compiledPath ?? this.original.file;
-  }
-
-  /**
    * Gets the source root of the sourcemap.
    */
   public get sourceRoot() {
     // see SourceMapFactory.loadSourceMap for what's happening here
     return this.actualRoot;
-  }
-
-  /**
-   * Gets the sources content.
-   */
-  public get sourcesContent() {
-    return this.original.sourcesContent;
   }
 
   /**

--- a/src/common/sourceMaps/sourceMapFactory.test.ts
+++ b/src/common/sourceMaps/sourceMapFactory.test.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { expect } from 'chai';
+import dataUriToBuffer from 'data-uri-to-buffer';
+import { RawIndexMap, RawSourceMap } from 'source-map';
+import Dap from '../../dap/api';
+import { stubbedDapApi, StubDapApi } from '../../dap/stubbedApi';
+import { Logger } from '../logging/logger';
+import { SourceMapFactory } from './sourceMapFactory';
+
+const sampleSource = 'console.log(123)';
+const basicSourceMap: RawSourceMap = {
+  version: 3,
+  sources: ['one.js'],
+  sourcesContent: [sampleSource],
+  names: [],
+  file: '',
+  mappings: '',
+};
+const indexedSourceMap: RawIndexMap = {
+  version: 3,
+  sections: [{
+    offset: { line: 0, column: 100},
+    map: basicSourceMap,
+  }],
+};
+
+describe('SourceMapFactory', () => {
+  let stubDap: StubDapApi;
+
+  beforeEach(() => {
+    stubDap = stubbedDapApi();
+  })
+
+  it('loads source-maps', async () => {
+    const factory = new SourceMapFactory({
+      rebaseRemoteToLocal() { return '/tmp/local'; },
+      rebaseLocalToRemote() { return '/tmp/remote'; },
+      shouldResolveSourceMap() { return true; },
+      urlToAbsolutePath() { return Promise.resolve('/tmp/abs');},
+      absolutePathToUrlRegexp() { return undefined; },
+    }, {
+      fetch(url) { return Promise.resolve({ ok: true, body: dataUriToBuffer(url).toString('utf8'), url: url, statusCode: 500 }); },
+      fetchJson<T>() { return Promise.resolve({ ok: true, body: {} as T, url: '', statusCode: 200 }); },
+    }, stubDap as unknown as Dap.Api, Logger.null);
+
+    const map = await factory.load({
+      sourceMapUrl: 'data:application/json;base64,' + Buffer.from(JSON.stringify(indexedSourceMap)).toString('base64'),
+      compiledPath: '/tmp/local/one.js',
+    });
+
+    expect(map.sources).to.eql(['one.js']);
+  });
+});

--- a/src/common/sourceMaps/sourceMapFactory.test.ts
+++ b/src/common/sourceMaps/sourceMapFactory.test.ts
@@ -21,10 +21,12 @@ const basicSourceMap: RawSourceMap = {
 };
 const indexedSourceMap: RawIndexMap = {
   version: 3,
-  sections: [{
-    offset: { line: 0, column: 100},
-    map: basicSourceMap,
-  }],
+  sections: [
+    {
+      offset: { line: 0, column: 100 },
+      map: basicSourceMap,
+    },
+  ],
 };
 
 describe('SourceMapFactory', () => {
@@ -32,22 +34,48 @@ describe('SourceMapFactory', () => {
 
   beforeEach(() => {
     stubDap = stubbedDapApi();
-  })
+  });
 
   it('loads source-maps', async () => {
-    const factory = new SourceMapFactory({
-      rebaseRemoteToLocal() { return '/tmp/local'; },
-      rebaseLocalToRemote() { return '/tmp/remote'; },
-      shouldResolveSourceMap() { return true; },
-      urlToAbsolutePath() { return Promise.resolve('/tmp/abs');},
-      absolutePathToUrlRegexp() { return undefined; },
-    }, {
-      fetch(url) { return Promise.resolve({ ok: true, body: dataUriToBuffer(url).toString('utf8'), url: url, statusCode: 500 }); },
-      fetchJson<T>() { return Promise.resolve({ ok: true, body: {} as T, url: '', statusCode: 200 }); },
-    }, stubDap as unknown as Dap.Api, Logger.null);
+    const factory = new SourceMapFactory(
+      {
+        rebaseRemoteToLocal() {
+          return '/tmp/local';
+        },
+        rebaseLocalToRemote() {
+          return '/tmp/remote';
+        },
+        shouldResolveSourceMap() {
+          return true;
+        },
+        urlToAbsolutePath() {
+          return Promise.resolve('/tmp/abs');
+        },
+        absolutePathToUrlRegexp() {
+          return undefined;
+        },
+      },
+      {
+        fetch(url) {
+          return Promise.resolve({
+            ok: true,
+            body: dataUriToBuffer(url).toString('utf8'),
+            url: url,
+            statusCode: 500,
+          });
+        },
+        fetchJson<T>() {
+          return Promise.resolve({ ok: true, body: {} as T, url: '', statusCode: 200 });
+        },
+      },
+      stubDap as unknown as Dap.Api,
+      Logger.null,
+    );
 
     const map = await factory.load({
-      sourceMapUrl: 'data:application/json;base64,' + Buffer.from(JSON.stringify(indexedSourceMap)).toString('base64'),
+      sourceMapUrl:
+        'data:application/json;base64,' +
+        Buffer.from(JSON.stringify(indexedSourceMap)).toString('base64'),
       compiledPath: '/tmp/local/one.js',
     });
 


### PR DESCRIPTION
Indexed source maps, described in https://sourcemaps.info/spec.html#h.535es3xeprgt this should allow users to debug bundled output, like that produced by the closure-compiler when producing bundled output.

Fixes #1260 