### PR TITLE
Fix forgotten push argument in fromRuntimeWithPredicate

### DIFF
--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -51,7 +51,7 @@ export class StackTrace {
       if (!stack.callFrames[frameNo].url.endsWith(SourceConstants.InternalExtension)) {
         const frame = StackFrame.fromRuntime(thread, stack.callFrames[frameNo], false);
         if (await predicate(frame)) {
-          result.frames.push();
+          result.frames.push(frame);
           frameLimit--;
         }
       }


### PR DESCRIPTION
Noticed this while working on the REPL eval issue; https://github.com/microsoft/vscode-js-debug/commit/879ccdcf478cf9800e690c0c879fa51dbfab0dac#diff-87879d4b5a52046a2d5b651bfc69640f5f05a1f680fa92ab75882be05216374eL31 modified this code, but seemed to drop the actual `push` argument.

This doesn't show up in any tests, as far as I can tell; the function is exported but unreferenced (maybe should be deleted? I don't know who can import this code.)