### PR TITLE
fix: Align hoverEvaluation config suggestion with actual default

### DIFF
--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -234,7 +234,7 @@ const baseConfigurationAttributes: ConfigurationAttributes<IBaseConfiguration> =
       hoverEvaluation: {
         type: 'number',
         description: refString('timeouts.hoverEvaluation.description'),
-        default: 10000,
+        default: 500,
       },
     },
     additionalProperties: false,


### PR DESCRIPTION
In 877e0ae1957172d905b892d898e52b5322853899 the hoverEvaluation timeout default was changed back to 500ms for undocumented reasons. However, the suggested default when adding the timeout to a `launch.json` wasn't changed back.