### PR TITLE
fix: bigint previews not working in certain cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ### Nightly (only)
 
 - chore: support new sha script hashes from chrome ([#1244](https://github.com/microsoft/vscode-js-debug/issues/1244))
+- fix: bigint value previews not working in some cases ([#1277](https://github.com/microsoft/vscode-js-debug/issues/1277))
 - fix: snap versions in alternate install locations resulting in warning ([#1239](https://github.com/microsoft/vscode-js-debug/issues/1239))
 - fix: align hoverEvaluation config suggestion with actual default
 - fix: remove query strings from sourcemapped URLs ([#1225](https://github.com/microsoft/vscode-js-debug/issues/1225))

--- a/src/adapter/objectPreview/betterTypes.ts
+++ b/src/adapter/objectPreview/betterTypes.ts
@@ -99,7 +99,7 @@ export type SpecialNumberPreview = TSpecialNumber;
 export type TBigint = {
   type: 'bigint';
   subtype: undefined;
-  unserializableValue: string;
+  unserializableValue?: string;
   description: string;
 };
 export type BigintPreview = TBigint;

--- a/src/adapter/objectPreview/index.ts
+++ b/src/adapter/objectPreview/index.ts
@@ -465,7 +465,7 @@ function formatAsNumber(
 
   if (param.type === 'bigint') {
     // parse unserializableValue is "1234n", slice the "n" off to parse and then base16 the number
-    const v = param.unserializableValue;
+    const v = param.unserializableValue || param.description;
     return format?.hex ? BigInt(v.slice(0, -1)).toString(16) : v;
   }
 

--- a/src/test/evaluate/evaluate-supports-bigint-map-keys-1277.txt
+++ b/src/test/evaluate/evaluate-supports-bigint-map-keys-1277.txt
@@ -1,0 +1,4 @@
+> result: Map(2) {size: 2, 1n => one, 2n => two}
+    size: 2
+    > [[Entries]]: Array(2)
+    > [[Prototype]]: Map

--- a/src/test/evaluate/evaluate.ts
+++ b/src/test/evaluate/evaluate.ts
@@ -494,4 +494,10 @@ describe('evaluate', () => {
     await evaluateAtReturn('undefined');
     r.assertLog();
   });
+
+  itIntegrates('supports bigint map keys (#1277)', async ({ r }) => {
+    const p = await r.launchUrlAndLoad('index.html');
+    await p.logger.evaluateAndLog(`new Map([[1n, 'one'], [2n, 'two']])`);
+    r.assertLog();
+  });
 });


### PR DESCRIPTION
Fixes #1277

One more bug since I had it open. Seems like V8 doesn't always send `unserializableValue`. Prefer it if it does, but try to use the description otherwise (since that seems to always be present)