### PR TITLE
fix: debugged child processes in ext host causing teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog records changes to stable releases since 1.50.2. "TBA" changes here may be available in the [nightly release](https://github.com/microsoft/vscode-js-debug/#nightly-extension) before they're in stable. Note that the minor version (`v1.X.0`) corresponds to the VS Code version js-debug is shipped in, but the patch version (`v1.50.X`) is not meaningful.
 
+## Nightly (only)
+
+- fix: debugged child processes in ext host causing teardown ([#1289](https://github.com/microsoft/vscode-js-debug/issues/1289))
+
 ## v1.68 (May 2022)
 
 ### v1.68.0 - 2022-05-30

--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -142,7 +142,7 @@ export default class Connection {
     if (this._closed) return;
     this._closed = true;
     this._transport.dispose();
-    this.logger.info(LogTag.CdpReceive, undefined, { connectionId: this._connectionId });
+    this.logger.info(LogTag.CdpReceive, 'Connection closed', { connectionId: this._connectionId });
     for (const session of this._sessions.values()) session._onClose();
     this._sessions.clear();
     this._onDisconnectedEmitter.fire();

--- a/src/targets/node/extensionHostAttacher.ts
+++ b/src/targets/node/extensionHostAttacher.ts
@@ -101,7 +101,7 @@ export class ExtensionHostAttacher extends NodeAttacherBase<IExtensionHostAttach
     run: IRunData<IExtensionHostAttachConfiguration>,
     target: Cdp.Target.TargetInfo,
   ) {
-    return target.openerId ? {} : { initialized: () => this.onFirstInitialize(cdp, run) };
+    return target.openerId ? {} : { initialized: () => this.onFirstInitialize(cdp, run, target) };
   }
 
   /**
@@ -111,8 +111,9 @@ export class ExtensionHostAttacher extends NodeAttacherBase<IExtensionHostAttach
   protected async onFirstInitialize(
     cdp: Cdp.Api,
     run: IRunData<IExtensionHostAttachConfiguration>,
+    target: Cdp.Target.TargetInfo,
   ) {
-    this.setEnvironmentVariables(cdp, run);
+    this.setEnvironmentVariables(cdp, run, target.targetId);
     const telemetry = await this.gatherTelemetryFromCdp(cdp, run);
 
     // Monitor the process ID we read from the telemetry. Once the VS Code
@@ -136,6 +137,7 @@ export class ExtensionHostAttacher extends NodeAttacherBase<IExtensionHostAttach
   private async setEnvironmentVariables(
     cdp: Cdp.Api,
     run: IRunData<IExtensionHostAttachConfiguration>,
+    targetId: string,
   ) {
     if (!run.params.autoAttachChildProcesses) {
       return;
@@ -144,6 +146,7 @@ export class ExtensionHostAttacher extends NodeAttacherBase<IExtensionHostAttach
     const vars = await this.resolveEnvironment(
       run,
       new NodeBinary('node', Semver.parse(process.versions.node)),
+      { openerId: targetId },
     );
 
     for (let retries = 0; retries < 5; retries++) {


### PR DESCRIPTION
Fixes #1289

We weren't properly attributing child processes in the extension host to
the extension host process that created them. This caused them all to
be treated as if they _were_ the extension host process, so closing
any one of them resulted in the debugger thinking the extension host had
gone away and clearing up all sessions.