### PR TITLE
feat: simplify pretty print to align with devtools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
+- feat: simplify pretty print to align with devtools ([vscode#151410](https://github.com/microsoft/vscode/issues/151410))
 - fix: debugged child processes in ext host causing teardown ([#1289](https://github.com/microsoft/vscode-js-debug/issues/1289))
 - fix: errors thrown in process tree lookup not being visible ([vscode#150754](https://github.com/microsoft/vscode/issues/150754))
 

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -102,7 +102,6 @@ export class DebugAdapter implements IDisposable {
     this.dap.on('enableCustomBreakpoints', params => this.enableCustomBreakpoints(params));
     this.dap.on('toggleSkipFileStatus', params => this._toggleSkipFileStatus(params));
     this.dap.on('disableCustomBreakpoints', params => this._disableCustomBreakpoints(params));
-    this.dap.on('canPrettyPrintSource', params => this._canPrettyPrintSource(params));
     this.dap.on('prettyPrintSource', params => this._prettyPrintSource(params));
     this.dap.on('revealPage', () => this._withThread(thread => thread.revealPage()));
     this.dap.on('getPerformance', () =>
@@ -436,20 +435,6 @@ export class DebugAdapter implements IDisposable {
     await this._services.get<ScriptSkipper>(IScriptSkipper).toggleSkippingFile(params);
     await this._refreshStackTrace();
     return {};
-  }
-
-  async _canPrettyPrintSource(
-    params: Dap.CanPrettyPrintSourceParams,
-  ): Promise<Dap.CanPrettyPrintSourceResult | Dap.Error> {
-    if (!params.source) {
-      return { canPrettyPrint: false };
-    }
-
-    params.source.path = urlUtils.platformPathToPreferredCase(params.source.path);
-    const source = this.sourceContainer.source(params.source);
-    if (!source)
-      return errors.createSilentError(localize('error.sourceNotFound', 'Source not found'));
-    return { canPrettyPrint: source.canPrettyPrint() };
   }
 
   async _prettyPrintSource(

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -224,19 +224,12 @@ export class Source {
   }
 
   /**
-   * Gets whether this source is able to be pretty-printed.
-   */
-  public canPrettyPrint(): boolean {
-    return this._container && !this._name.endsWith('-pretty.js');
-  }
-
-  /**
    * Pretty-prints the source. Generates a beauitified source map if possible
    * and it hasn't already been done, and returns the created map and created
    * ephemeral source. Returns undefined if the source can't be beautified.
    */
   public async prettyPrint(): Promise<{ map: SourceMap; source: Source } | undefined> {
-    if (!this._container || !this.canPrettyPrint()) {
+    if (!this._container) {
       return undefined;
     }
 

--- a/src/build/dapCustom.ts
+++ b/src/build/dapCustom.ts
@@ -107,29 +107,6 @@ const dapCustom: JSONSchema4 = {
       required: ['ids'],
     }),
 
-    ...makeRequest(
-      'canPrettyPrintSource',
-      'Returns whether particular source can be pretty-printed.',
-      {
-        properties: {
-          source: {
-            $ref: '#/definitions/Source',
-            description: 'Source to be pretty printed.',
-          },
-        },
-        required: ['source'],
-      },
-      {
-        required: ['canPrettyPrint'],
-        properties: {
-          canPrettyPrint: {
-            type: 'boolean',
-            description: 'Whether source can be pretty printed.',
-          },
-        },
-      },
-    ),
-
     ...makeRequest('prettyPrintSource', 'Pretty prints source for debugging.', {
       properties: {
         source: {

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -8,6 +8,7 @@ import {
   AutoAttachMode,
   Commands,
   Configuration,
+  ContextKey,
   Contributions,
   CustomViews,
   DebugType,
@@ -1110,11 +1111,6 @@ const configurationSchema: ConfigurationAttributes<IConfigurationTypes> = {
     default: {},
     properties: nodeTerminalConfiguration.configurationAttributes as { [key: string]: JSONSchema6 },
   },
-  [Configuration.SuggestPrettyPrinting]: {
-    type: 'boolean',
-    description: refString('configuration.suggestPrettyPrinting'),
-    default: true,
-  },
   [Configuration.AutoServerTunnelOpen]: {
     type: 'boolean',
     description: refString('configuration.automaticallyTunnelRemoteServer'),
@@ -1209,6 +1205,7 @@ const commands: ReadonlyArray<{
     command: Commands.PrettyPrint,
     title: refString('pretty.print.script'),
     category: 'Debug',
+    icon: '$(json)',
   },
   {
     command: Commands.ToggleSkipping,
@@ -1450,6 +1447,13 @@ const menus: Menus = {
       command: Commands.CallersRemove,
       group: 'inline',
       when: `view == ${CustomViews.ExcludedCallers}`,
+    },
+  ],
+  'editor/title': [
+    {
+      command: Commands.PrettyPrint,
+      group: 'navigation',
+      when: `resource in ${ContextKey.CanPrettyPrint}`,
     },
   ],
 };

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -280,8 +280,6 @@ const strings = {
     'Where a "Run" and "Debug" code lens should be shown in your npm scripts. It may be on "all", scripts, on "top" of the script section, or "never".',
   'configuration.terminalOptions':
     'Default launch options for the JavaScript debug terminal and npm scripts.',
-  'configuration.suggestPrettyPrinting':
-    'Whether to suggest pretty printing JavaScript code that looks minified when you step into it.',
   'configuration.automaticallyTunnelRemoteServer':
     'When debugging a remote web app, configures whether to automatically tunnel the remote server to your local machine.',
   'configuration.debugByLinkOptions':

--- a/src/common/contributionUtils.ts
+++ b/src/common/contributionUtils.ts
@@ -134,7 +134,6 @@ export const enum Configuration {
   TerminalDebugConfig = 'debug.javascript.terminalOptions',
   PickAndAttachDebugOptions = 'debug.javascript.pickAndAttachOptions',
   DebugByLinkOptions = 'debug.javascript.debugByLinkOptions',
-  SuggestPrettyPrinting = 'debug.javascript.suggestPrettyPrinting',
   AutoServerTunnelOpen = 'debug.javascript.automaticallyTunnelRemoteServer',
   AutoAttachMode = 'debug.javascript.autoAttachFilter',
   AutoAttachSmartPatterns = 'debug.javascript.autoAttachSmartPattern',
@@ -153,7 +152,6 @@ export interface IConfigurationTypes {
   [Configuration.NpmScriptLens]: 'all' | 'top' | 'never';
   [Configuration.TerminalDebugConfig]: Partial<ITerminalLaunchConfiguration>;
   [Configuration.PickAndAttachDebugOptions]: Partial<INodeAttachConfiguration>;
-  [Configuration.SuggestPrettyPrinting]: boolean;
   [Configuration.AutoServerTunnelOpen]: boolean;
   [Configuration.DebugByLinkOptions]:
     | DebugByLinkState
@@ -256,3 +254,21 @@ export const writeConfig = <K extends keyof IConfigurationTypes>(
   value: IConfigurationTypes[K],
   target?: ConfigurationTarget,
 ) => wsp.getConfiguration().update(key, value, target);
+
+export const enum ContextKey {
+  HasExcludedCallers = 'jsDebugHasExcludedCallers',
+  CanPrettyPrint = 'jsDebugCanPrettyPrint',
+  IsProfiling = 'jsDebugIsProfiling',
+}
+
+export interface IContextKeyTypes {
+  [ContextKey.HasExcludedCallers]: boolean;
+  [ContextKey.CanPrettyPrint]: string[];
+  [ContextKey.IsProfiling]: boolean;
+}
+
+export const setContextKey = async <K extends keyof IContextKeyTypes>(
+  ns: typeof commands,
+  key: K,
+  value: IContextKeyTypes[K] | null,
+) => await ns.executeCommand('setContext', key, value);

--- a/src/dap/api.d.ts
+++ b/src/dap/api.d.ts
@@ -843,20 +843,6 @@ export namespace Dap {
     ): Promise<DisableCustomBreakpointsResult>;
 
     /**
-     * Returns whether particular source can be pretty-printed.
-     */
-    on(
-      request: 'canPrettyPrintSource',
-      handler: (params: CanPrettyPrintSourceParams) => Promise<CanPrettyPrintSourceResult | Error>,
-    ): () => void;
-    /**
-     * Returns whether particular source can be pretty-printed.
-     */
-    canPrettyPrintSourceRequest(
-      params: CanPrettyPrintSourceParams,
-    ): Promise<CanPrettyPrintSourceResult>;
-
-    /**
      * Pretty prints source for debugging.
      */
     on(
@@ -1602,11 +1588,6 @@ export namespace Dap {
     ): Promise<DisableCustomBreakpointsResult>;
 
     /**
-     * Returns whether particular source can be pretty-printed.
-     */
-    canPrettyPrintSource(params: CanPrettyPrintSourceParams): Promise<CanPrettyPrintSourceResult>;
-
-    /**
      * Pretty prints source for debugging.
      */
     prettyPrintSource(params: PrettyPrintSourceParams): Promise<PrettyPrintSourceResult>;
@@ -1879,20 +1860,6 @@ export namespace Dap {
      * Sorted set of possible breakpoint locations.
      */
     breakpoints: BreakpointLocation[];
-  }
-
-  export interface CanPrettyPrintSourceParams {
-    /**
-     * Source to be pretty printed.
-     */
-    source: Source;
-  }
-
-  export interface CanPrettyPrintSourceResult {
-    /**
-     * Whether source can be pretty printed.
-     */
-    canPrettyPrint: boolean;
   }
 
   export interface CancelParams {

--- a/src/dap/telemetryClassification.d.ts
+++ b/src/dap/telemetryClassification.d.ts
@@ -96,8 +96,6 @@ interface IDAPOperationClassification {
   '!enablecustombreakpoints.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
   disablecustombreakpoints: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
   '!disablecustombreakpoints.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-  canprettyprintsource: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
-  '!canprettyprintsource.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
   prettyprintsource: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
   '!prettyprintsource.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
   toggleskipfilestatus: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,6 @@ import { registerCustomBreakpointsUI } from './ui/customBreakpointsUI';
 import { debugNpmScript } from './ui/debugNpmScript';
 import { DebugSessionTracker } from './ui/debugSessionTracker';
 import { registerDebugTerminalUI } from './ui/debugTerminalUI';
-import { PrettyPrintTrackerFactory } from './ui/prettyPrint';
 import { attachProcess, pickProcess } from './ui/processPicker';
 import { registerProfilingCommand } from './ui/profiling';
 import { registerRequestCDPProxy } from './ui/requestCDPProxy';
@@ -87,7 +86,6 @@ export function activate(context: vscode.ExtensionContext) {
   const debugSessionTracker = services.get(DebugSessionTracker);
   debugSessionTracker.attach();
 
-  context.subscriptions.push(PrettyPrintTrackerFactory.register(debugSessionTracker));
   registerCompanionBrowserLaunch(context);
   registerCustomBreakpointsUI(context, debugSessionTracker);
   registerDebugTerminalUI(

--- a/src/ui/debugSessionTracker.ts
+++ b/src/ui/debugSessionTracker.ts
@@ -57,6 +57,13 @@ export class DebugSessionTracker implements vscode.Disposable {
   public onSessionEnded = this._onSessionEndedEmitter.event;
 
   /**
+   * Gets whether there's any active JS debug session.
+   */
+  public get isDebugging() {
+    return this.sessions.size > 0;
+  }
+
+  /**
    * Returns the session with the given ID.
    */
   public getById(id: string) {

--- a/src/ui/excludedCallersUI.ts
+++ b/src/ui/excludedCallersUI.ts
@@ -6,7 +6,13 @@ import { createHash } from 'crypto';
 import { inject, injectable } from 'inversify';
 import { basename } from 'path';
 import * as vscode from 'vscode';
-import { Commands, CustomViews, registerCommand } from '../common/contributionUtils';
+import {
+  Commands,
+  ContextKey,
+  CustomViews,
+  registerCommand,
+  setContextKey,
+} from '../common/contributionUtils';
 import type Dap from '../dap/api';
 import { IExtensionContribution } from '../ioc-extras';
 import { DebugSessionTracker } from './debugSessionTracker';
@@ -155,7 +161,7 @@ export class ExcludedCallersUI
 
     const hasCallers = this.allCallers.size > 0;
     if (hasCallers !== this.lastHadCallers) {
-      vscode.commands.executeCommand('setContext', 'jsDebugHasExcludedCallers', hasCallers);
+      setContextKey(vscode.commands, ContextKey.HasExcludedCallers, hasCallers);
       this.lastHadCallers = hasCallers;
     }
   }

--- a/src/ui/manageContextKey.ts
+++ b/src/ui/manageContextKey.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { ContextKey, IContextKeyTypes } from '../common/contributionUtils';
+
+export class ManagedContextKey<T extends ContextKey> {
+  private _value: IContextKeyTypes[T] | undefined;
+
+  public set value(value: IContextKeyTypes[T] | undefined) {
+    if (value !== this._value) {
+      this._value = value;
+      vscode.commands.executeCommand('setContext', this.key, value);
+    }
+  }
+
+  public get value() {
+    return this._value;
+  }
+
+  constructor(private readonly key: T) {}
+}

--- a/src/ui/prettyPrint.ts
+++ b/src/ui/prettyPrint.ts
@@ -2,63 +2,29 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { inject, injectable } from 'inversify';
 import * as qs from 'querystring';
 import * as vscode from 'vscode';
-import { ConfigurationTarget } from 'vscode';
-import * as nls from 'vscode-nls';
-import {
-  allDebugTypes,
-  Commands,
-  Configuration,
-  readConfig,
-  registerCommand,
-  writeConfig,
-} from '../common/contributionUtils';
-import { DisposableList, IDisposable } from '../common/disposable';
+import { Commands, ContextKey, registerCommand } from '../common/contributionUtils';
 import Dap from '../dap/api';
-import { Message as DapMessage } from '../dap/transport';
+import { IExtensionContribution } from '../ioc-extras';
 import { DebugSessionTracker } from './debugSessionTracker';
+import { ManagedContextKey } from './manageContextKey';
 
-const localize = nls.loadMessageBundle();
+@injectable()
+export class PrettyPrintUI implements IExtensionContribution {
+  private readonly canPrettyPrintKey = new ManagedContextKey(ContextKey.CanPrettyPrint);
 
-export class PrettyPrintTrackerFactory implements vscode.DebugAdapterTrackerFactory, IDisposable {
-  private readonly sessions = new DisposableList();
+  constructor(@inject(DebugSessionTracker) private readonly tracker: DebugSessionTracker) {}
 
-  /**
-   * Attaches the tracker to the VS Code workspace.
-   */
-  public static register(tracker: DebugSessionTracker): PrettyPrintTrackerFactory {
-    const factory = new PrettyPrintTrackerFactory(tracker);
-    for (const debugType of allDebugTypes) {
-      vscode.debug.registerDebugAdapterTrackerFactory(debugType, factory);
-    }
-
-    registerCommand(vscode.commands, Commands.PrettyPrint, () => factory.prettifyActive());
-
-    return factory;
-  }
-
-  constructor(private readonly tracker: DebugSessionTracker) {}
-
-  /**
-   * @inheritdoc
-   */
-  public createDebugAdapterTracker(
-    session: vscode.DebugSession,
-  ): vscode.ProviderResult<vscode.DebugAdapterTracker> {
-    if (!readConfig(vscode.workspace, Configuration.SuggestPrettyPrinting)) {
-      return;
-    }
-
-    const tracker = new PrettyPrintSession(session);
-    this.sessions.push(tracker);
-    vscode.debug.onDidTerminateDebugSession(s => {
-      if (s === session) {
-        this.sessions.disposeObject(tracker);
-      }
-    });
-
-    return tracker;
+  /** @inheritdoc */
+  public register(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+      registerCommand(vscode.commands, Commands.PrettyPrint, () => this.prettifyActive()),
+      vscode.window.onDidChangeActiveTextEditor(editor => this.updateEditorState(editor)),
+      this.tracker.onSessionAdded(() => this.updateEditorState(vscode.window.activeTextEditor)),
+      this.tracker.onSessionEnded(() => this.updateEditorState(vscode.window.activeTextEditor)),
+    );
   }
 
   /**
@@ -66,7 +32,7 @@ export class PrettyPrintTrackerFactory implements vscode.DebugAdapterTrackerFact
    */
   public async prettifyActive() {
     const editor = vscode.window.activeTextEditor;
-    if (editor?.document.languageId !== 'javascript') {
+    if (!editor || !this.canPrettyPrint(editor)) {
       return;
     }
 
@@ -85,118 +51,25 @@ export class PrettyPrintTrackerFactory implements vscode.DebugAdapterTrackerFact
     }
   }
 
-  /**
-   * @inheritdoc
-   */
-  public dispose() {
-    this.sessions.dispose();
-  }
-}
-
-/**
- * Session tracker for pretty printing. It monitors open files in the editor,
- * and suggests formatting ones that look minified.
- *
- * It can suggest printing ephemeral files that have a source reference set.
- * It will also suggest printing
- */
-class PrettyPrintSession implements IDisposable, vscode.DebugAdapterTracker {
-  private readonly candidatePaths = new Set<string>();
-  private readonly disposable = new DisposableList();
-  private readonly suggested = new Set<string | number>();
-
-  constructor(private readonly session: vscode.DebugSession) {
-    this.disposable.push(
-      vscode.window.onDidChangeActiveTextEditor(editor => this.onEditorChange(editor)),
+  private canPrettyPrint(editor: vscode.TextEditor) {
+    return (
+      this.tracker.isDebugging &&
+      editor.document.languageId === 'javascript' &&
+      !editor.document.fileName.endsWith('-pretty.js')
     );
   }
 
-  /**
-   * @inheritdoc
-   */
-  public onDidSendMessage(message: DapMessage) {
-    if (message.type !== 'response' || message.command !== 'stackTrace' || !message.body) {
+  private updateEditorState(editor: vscode.TextEditor | undefined) {
+    if (!this.tracker.isDebugging) {
+      this.canPrettyPrintKey.value = undefined;
       return;
     }
 
-    const frames = (message.body as Dap.StackTraceResult).stackFrames;
-    if (!frames) {
-      return;
-    }
-
-    for (const frame of frames) {
-      const path = frame.source?.path;
-      if (path) {
-        this.candidatePaths.add(path);
+    if (editor && this.canPrettyPrint(editor)) {
+      const value = editor.document.uri.toString();
+      if (value !== this.canPrettyPrintKey.value?.[0]) {
+        this.canPrettyPrintKey.value = [editor.document.uri.toString()];
       }
-    }
-
-    // If the file that's currently opened is the top of the stacktrace,
-    // indicating we're probably about to break on it, then prompt immediately.
-    const first = frames[0]?.source?.path;
-    if (first && vscode.window.activeTextEditor?.document.uri.path === first) {
-      this.onEditorChange(vscode.window.activeTextEditor);
-    }
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public dispose() {
-    this.disposable.dispose();
-  }
-
-  private onEditorChange(editor: vscode.TextEditor | undefined) {
-    if (editor?.document.languageId !== 'javascript') {
-      return;
-    }
-
-    const { source } = sourceForUri(editor.document.uri);
-    if (!this.candidatePaths.has(source.path) && source.sourceReference === 0) {
-      return;
-    }
-
-    const key = source.sourceReference || source.path;
-    if (this.suggested.has(key)) {
-      return;
-    }
-
-    this.suggested.add(key);
-    if (!isMinified(editor.document)) {
-      return;
-    }
-
-    return this.trySuggestPrinting(source, editor.selection.start);
-  }
-
-  private async trySuggestPrinting(source: Dap.Source, cursor: vscode.Position) {
-    const canPrettyPrint = await this.session.customRequest('canPrettyPrintSource', {
-      source,
-    });
-
-    if (!canPrettyPrint?.canPrettyPrint) {
-      return;
-    }
-
-    const yes = localize('yes', 'Yes');
-    const no = localize('no', 'No');
-    const never = localize('never', 'Never');
-    const response = await vscode.window.showInformationMessage(
-      'This JavaScript file seems to be minified.\nWould you like to pretty print it?',
-      yes,
-      no,
-      never,
-    );
-
-    if (response === yes) {
-      sendPrintCommand(this.session, source, cursor);
-    } else if (response === never) {
-      writeConfig(
-        vscode.workspace,
-        Configuration.SuggestPrettyPrinting,
-        false,
-        ConfigurationTarget.Global,
-      );
     }
   }
 }
@@ -225,19 +98,3 @@ const sourceForUri = (uri: vscode.Uri) => {
 
   return { sessionId, source };
 };
-
-/**
- * Heuristic check to see if a document is minified.
- */
-function isMinified(document: vscode.TextDocument): boolean {
-  const maxNonMinifiedLength = 500;
-  const linesToCheck = 10;
-  for (let i = 0; i < linesToCheck && i < document.lineCount; ++i) {
-    const line = document.lineAt(i).text;
-    if (line.length > maxNonMinifiedLength && !line.startsWith('//#')) {
-      return true;
-    }
-  }
-
-  return false;
-}

--- a/src/ui/profiling/uiProfileManager.ts
+++ b/src/ui/profiling/uiProfileManager.ts
@@ -8,7 +8,7 @@ import { basename, join } from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { ProfilerFactory } from '../../adapter/profiling';
-import { Commands } from '../../common/contributionUtils';
+import { Commands, ContextKey, setContextKey } from '../../common/contributionUtils';
 import { DisposableList, IDisposable } from '../../common/disposable';
 import { moveFile } from '../../common/fsUtils';
 import { AnyLaunchConfiguration } from '../../configuration';
@@ -264,7 +264,7 @@ export class UiProfileManager implements IDisposable {
   private updateStatusBar() {
     if (this.activeSessions.size === 0) {
       this.statusBarItem?.hide();
-      vscode.commands.executeCommand('setContext', 'jsDebugIsProfiling', false);
+      setContextKey(vscode.commands, ContextKey.IsProfiling, false);
       return;
     }
 
@@ -273,7 +273,7 @@ export class UiProfileManager implements IDisposable {
       this.statusBarItem.command = Commands.StopProfile;
     }
 
-    vscode.commands.executeCommand('setContext', 'jsDebugIsProfiling', true);
+    setContextKey(vscode.commands, ContextKey.IsProfiling, true);
 
     if (this.activeSessions.size === 1) {
       const session: UiProfileSession = this.activeSessions.values().next().value;

--- a/src/ui/ui-ioc.ts
+++ b/src/ui/ui-ioc.ts
@@ -21,6 +21,7 @@ import { ILinkedBreakpointLocation } from './linkedBreakpointLocation';
 import { LinkedBreakpointLocationUI } from './linkedBreakpointLocationUI';
 import { LongPredictionUI } from './longPredictionUI';
 import { JsDebugPortAttributesProvider } from './portAttributesProvider';
+import { PrettyPrintUI } from './prettyPrint';
 import { BreakpointTerminationConditionFactory } from './profiling/breakpointTerminationCondition';
 import { DurationTerminationConditionFactory } from './profiling/durationTerminationCondition';
 import { ManualTerminationConditionFactory } from './profiling/manualTerminationCondition';
@@ -51,6 +52,7 @@ export const registerUiComponents = (container: Container) => {
   container.bind(IExtensionContribution).to(JsDebugPortAttributesProvider).inSingletonScope();
   container.bind(IExtensionContribution).to(EdgeDevToolOpener).inSingletonScope();
   container.bind(IExtensionContribution).to(ExcludedCallersUI).inSingletonScope();
+  container.bind(IExtensionContribution).to(PrettyPrintUI).inSingletonScope();
   container.bind(ILinkedBreakpointLocation).to(LinkedBreakpointLocationUI).inSingletonScope();
   container.bind(DebugSessionTracker).toSelf().inSingletonScope().onActivation(trackDispose);
   container.bind(UiProfileManager).toSelf().inSingletonScope().onActivation(trackDispose);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/151410

Now there's always a `{}` icon (similar to what's in devtools, which is not super expressive, but I don't know of a better icon...) in the title bar of `.js` files when debugging JavaScript.

<img width="570" alt="image" src="https://user-images.githubusercontent.com/2230985/172388241-ee5400af-8cfa-41d0-bc63-e8d372dd21ae.png">

This should also make things a little faster since this was our last usage of the `DebugAdapterTracker`. Decent negative diff.