### PR TITLE
fix: freezes when debugging vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: debugged child processes in ext host causing teardown ([#1289](https://github.com/microsoft/vscode-js-debug/issues/1289))
 - fix: errors thrown in process tree lookup not being visible ([vscode#150754](https://github.com/microsoft/vscode/issues/150754))
 - fix: extension debugging not working with two ipv6 interfaces ([vscode#144315](https://github.com/microsoft/vscode/issues/144315))
+- fix: rare freezes if browsers logged information to stdout
 - chore: adopt new restartFrame semantics from Chrome 104 ([#1283](https://github.com/microsoft/vscode-js-debug/issues/1283))
 
 ## v1.68 (May 2022)

--- a/src/targets/browser/launcher.ts
+++ b/src/targets/browser/launcher.ts
@@ -123,6 +123,9 @@ export async function launch(
   if (dumpio) {
     browserProcess.stderr?.on('data', d => onStderr(d.toString()));
     browserProcess.stdout?.on('data', d => onStdout(d.toString()));
+  } else {
+    browserProcess.stderr?.resume();
+    browserProcess.stdout?.resume();
   }
 
   let exitListener = () => {


### PR DESCRIPTION
The stdout buffer can get full, leading to freezes. We didn't hit this with normal browsers, since they don't log very much. Also, when trace logging is turned on, dumpsio=true is used to add info to logs.