### PR TITLE
chore: mark prefixed debug types as deprecated

### DIFF
--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -1060,6 +1060,7 @@ function buildDebuggers() {
       const entry = ensureEntryForType(preferred, d);
       delete entry.languages;
       entries.unshift(entry);
+      primary.deprecated = `Please use type ${preferred} instead`;
     }
 
     entries[0].configurationSnippets.push(...d.configurationSnippets);

--- a/src/common/contributionUtils.ts
+++ b/src/common/contributionUtils.ts
@@ -63,6 +63,9 @@ export const preferredDebugTypes: ReadonlyMap<DebugType, string> = new Map([
   [DebugType.Edge, 'msedge'],
 ]);
 
+export const getPreferredOrDebugType = <T extends DebugType>(t: T) =>
+  (preferredDebugTypes.get(t) as T) || t;
+
 export const enum DebugType {
   ExtensionHost = 'pwa-extensionHost',
   Terminal = 'node-terminal',

--- a/src/ui/configuration/nodeDebugConfigurationProvider.ts
+++ b/src/ui/configuration/nodeDebugConfigurationProvider.ts
@@ -6,7 +6,7 @@ import { injectable } from 'inversify';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { DebugType } from '../../common/contributionUtils';
+import { DebugType, getPreferredOrDebugType } from '../../common/contributionUtils';
 import { flatten } from '../../common/objUtils';
 import {
   AnyNodeConfiguration,
@@ -80,7 +80,7 @@ export class NodeDynamicDebugConfigurationProvider extends BaseConfigurationProv
    */
   protected async getFromNpmScripts(folder?: vscode.WorkspaceFolder): Promise<DynamicConfig[]> {
     const openTerminal: AnyResolvingConfiguration = {
-      type: DebugType.Terminal,
+      type: getPreferredOrDebugType(DebugType.Terminal),
       name: localize('debug.terminal.label', 'JavaScript Debug Terminal'),
       request: 'launch',
       cwd: folder?.uri.fsPath,
@@ -98,7 +98,7 @@ export class NodeDynamicDebugConfigurationProvider extends BaseConfigurationProv
     const packageManager = await getPackageManager(folder);
     return scripts
       .map<DynamicConfig>(script => ({
-        type: DebugType.Terminal,
+        type: getPreferredOrDebugType(DebugType.Terminal),
         name: localize('node.launch.script', 'Run Script: {0}', script.name),
         request: 'launch',
         command: `${packageManager} run ${script.name}`,
@@ -122,7 +122,7 @@ export class NodeDynamicDebugConfigurationProvider extends BaseConfigurationProv
 
     return [
       {
-        type: DebugType.Node,
+        type: getPreferredOrDebugType(DebugType.Node),
         name: localize('node.launch.currentFile', 'Run Current File'),
         request: 'launch',
         program: editor.document.uri.fsPath,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/151910
Depends on https://github.com/microsoft/vscode/pull/151973