### PR TITLE
performance improvements for setting breakpoints in large projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
-Nothing (yet)
+- fix: performance improvements for setting breakpoints in large projects ([vscode#153470](https://github.com/microsoft/vscode/issues/153470))
 
 ## v1.69 (June 2022)
 

--- a/src/adapter/breakpointPredictor.ts
+++ b/src/adapter/breakpointPredictor.ts
@@ -217,7 +217,7 @@ export class BreakpointsPredictor implements IBreakpointsPredictor {
 
     try {
       await this.repo.streamChildrenWithSourcemaps(this.outFiles, async metadata => {
-        const cached = await this.cache?.lookup(metadata.compiledPath, metadata.mtime);
+        const cached = await this.cache?.lookup(metadata.compiledPath, metadata.cacheKey);
         if (cached) {
           cached.forEach(c => addDiscovery({ ...c, ...metadata }));
           return;
@@ -247,7 +247,7 @@ export class BreakpointsPredictor implements IBreakpointsPredictor {
 
         this.cache?.store(
           metadata.compiledPath,
-          metadata.mtime,
+          metadata.cacheKey,
           discovered.map(d => ({ resolvedPath: d.resolvedPath, sourceUrl: d.sourceUrl })),
         );
       });

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1706,11 +1706,7 @@ export class Thread implements IVariableStoreLocationProvider {
   }
 
   private _shouldEnablePerScriptSms(event: Cdp.Debugger.PausedEvent) {
-    if (
-      event.reason !== 'instrumentation' ||
-      !event.data ||
-      !event.data.sourceMapURL?.startsWith('data:')
-    ) {
+    if (event.reason !== 'instrumentation' || !urlUtils.isDataUri(event.data?.sourceMapURL)) {
       return false;
     }
 

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1663,10 +1663,16 @@ export class Thread implements IVariableStoreLocationProvider {
     );
   }
 
+  /**
+   * Based on whether `pause` is true, sets or unsets an instrumentation
+   * breakpoint in the runtime that is hit before sources with scripts.
+   * Returns true if the breakpoint was able to be set, which is usually
+   * (always?) `false` in Node runtimes.
+   */
   public async setScriptSourceMapHandler(
     pause: boolean,
     handler?: ScriptWithSourceMapHandler,
-  ): Promise<void> {
+  ): Promise<boolean> {
     this._scriptWithSourceMapHandler = handler;
 
     const needsPause =
@@ -1681,6 +1687,8 @@ export class Thread implements IVariableStoreLocationProvider {
       this._pauseOnSourceMapBreakpointId = undefined;
       await this._cdp.Debugger.removeBreakpoint({ breakpointId });
     }
+
+    return !!this._pauseOnSourceMapBreakpointId;
   }
 
   /**

--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -6,6 +6,7 @@ import { IDisposable } from '../common/disposable';
 import { EventEmitter, ListenerMap } from '../common/events';
 import { HrTime } from '../common/hrnow';
 import { ILogger, LogTag } from '../common/logging';
+import { isDataUri } from '../common/urlUtils';
 import { ITelemetryReporter } from '../telemetry/telemetryReporter';
 import Cdp from './api';
 import { CdpProtocol } from './protocol';
@@ -87,8 +88,7 @@ export default class Connection {
     } else if (
       object.method === 'Debugger.scriptParsed' &&
       object.params &&
-      object.params.sourceMapURL &&
-      object.params.sourceMapURL.startsWith('data:')
+      isDataUri(object.params.sourceMapURL)
     ) {
       objectToLog = {
         ...object,

--- a/src/common/sourceMaps/sourceMap.ts
+++ b/src/common/sourceMaps/sourceMap.ts
@@ -13,11 +13,11 @@ import {
   SourceMapConsumer,
 } from 'source-map';
 import { fixDriveLetterAndSlashes } from '../pathUtils';
-import { completeUrlEscapingRoot } from '../urlUtils';
+import { completeUrlEscapingRoot, isDataUri } from '../urlUtils';
 
 export interface ISourceMapMetadata {
   sourceMapUrl: string;
-  mtime?: number;
+  cacheKey?: number;
   compiledPath: string;
 }
 
@@ -80,7 +80,7 @@ export class SourceMap implements SourceMapConsumer {
   public computedSourceUrl(sourceUrl: string) {
     return fixDriveLetterAndSlashes(
       completeUrlEscapingRoot(
-        this.metadata.sourceMapUrl.startsWith('data:')
+        isDataUri(this.metadata.sourceMapUrl)
           ? this.metadata.compiledPath
           : this.metadata.sourceMapUrl,
         this.sourceRoot + sourceUrl,

--- a/src/common/sourceMaps/sourceMapFactory.ts
+++ b/src/common/sourceMaps/sourceMapFactory.ts
@@ -248,11 +248,11 @@ export class CachingSourceMapFactory extends SourceMapFactory {
       return this.loadNewSourceMap(metadata);
     }
 
-    const curTime = metadata.mtime;
-    const prevTime = existing.metadata.mtime;
+    const curKey = metadata.cacheKey;
+    const prevKey = existing.metadata.cacheKey;
     // If asked to reload, do so if either map is missing a mtime, or they aren't the same
     if (existing.reloadIfNoMtime) {
-      if (!(curTime && prevTime && curTime === prevTime)) {
+      if (!(curKey && prevKey && curKey === prevKey)) {
         this.overwrittenSourceMaps.push(existing.prom);
         return this.loadNewSourceMap(metadata);
       } else {
@@ -262,7 +262,7 @@ export class CachingSourceMapFactory extends SourceMapFactory {
     }
 
     // Otherwise, only reload if times are present and the map definitely changed.
-    if (prevTime && curTime && curTime !== prevTime) {
+    if (prevKey && curKey && curKey !== prevKey) {
       this.overwrittenSourceMaps.push(existing.prom);
       return this.loadNewSourceMap(metadata);
     }

--- a/src/common/sourceUtils.ts
+++ b/src/common/sourceUtils.ts
@@ -230,17 +230,7 @@ export function parseSourceMappingUrl(content: string): string | undefined {
   let sourceMapUrl = content.substring(equalSignPos + 1);
   const newLine = sourceMapUrl.indexOf('\n');
   if (newLine !== -1) sourceMapUrl = sourceMapUrl.substring(0, newLine);
-  sourceMapUrl = sourceMapUrl.trim();
-  for (let i = 0; i < sourceMapUrl.length; ++i) {
-    if (
-      sourceMapUrl[i] === '"' ||
-      sourceMapUrl[i] === "'" ||
-      sourceMapUrl[i] === ' ' ||
-      sourceMapUrl[i] === '\t'
-    )
-      return;
-  }
-  return sourceMapUrl;
+  return sourceMapUrl.trim();
 }
 
 const hasher = new Hasher();

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -286,8 +286,8 @@ export function isAbsolute(_path: string): boolean {
 /**
  * Returns whether the uri looks like a data URI.
  */
-export function isDataUri(uri: string): boolean {
-  return /^data:[a-z]+\/[a-z]/.test(uri);
+export function isDataUri(uri: string | undefined | null): uri is string {
+  return !!uri && uri.startsWith('data:');
 }
 
 const urlToRegexChar = (char: string, arr: Set<string>, escapeRegex: boolean) => {

--- a/src/test/breakpoints/breakpointsTest.ts
+++ b/src/test/breakpoints/breakpointsTest.ts
@@ -121,7 +121,6 @@ describe('breakpoints', () => {
     itIntegrates('source map predicted', async ({ r }) => {
       // Breakpoint in source mapped script set before launch use breakpoints predictor.
       const p = await r.launchUrl('browserify/pause.html');
-      p.adapter.breakpointManager.setSourceMapPauseDisabledForTest();
       p.adapter.breakpointManager.setPredictorDisabledForTest(false);
       const source: Dap.Source = {
         path: p.workspacePath('web/browserify/module2.ts'),

--- a/src/test/common/sourceMapRepository.test.ts
+++ b/src/test/common/sourceMapRepository.test.ts
@@ -55,8 +55,8 @@ describe('ISourceMapRepository', () => {
       const gatherSm = (rootPath: string, firstIncludeSegment: string) => {
         return r
           .streamChildrenWithSourcemaps(gatherFileList(rootPath, firstIncludeSegment), async m => {
-            const { mtime, ...rest } = m;
-            expect(mtime).to.be.within(Date.now() - 60 * 1000, Date.now() + 1000);
+            const { cacheKey, ...rest } = m;
+            expect(cacheKey).to.be.within(Date.now() - 60 * 1000, Date.now() + 1000);
             rest.compiledPath = fixDriveLetter(rest.compiledPath);
             return rest;
           })


### PR DESCRIPTION
**refactor: improve performance of bp predictor for inline maps**

- Avoid parsing data URIs, since doing so is expensive
- For inline maps, we can hash the map for our cache key instead of using stat+mtime

In VS Code, this reduces the predictor runtime by 25-30%.

**fix: avoid blocking or activating the BP predictor when unnecessary**

Previously, we always waited on the breakpoint predictor unless it was
explicitly disabled. This was unnecessary in two cases:

- If we were able to set an instrumentation breakpoint, this was
  redundant since we use that to ensure breakpoints get set before
  scripts run.
- We used it even if the source in question was already loaded. This is,
  while _technically_ useful if a source was present in multiple scripts
  (e.g. present in multiple webpack bundles), usually not practically
  necessary, as we do still set the breakpoint if/when that script is parsed.