### PR TITLE
fix: completions not returning stack variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - fix: performance improvements for setting breakpoints in large projects ([vscode#153470](https://github.com/microsoft/vscode/issues/153470))
+- fix: completions not returning stack variables ([vscode#153651](https://github.com/microsoft/vscode/issues/153651))
 
 ## v1.69 (June 2022)
 

--- a/src/adapter/completions.ts
+++ b/src/adapter/completions.ts
@@ -376,15 +376,18 @@ export class Completions {
         isInGlobalScope: true,
       });
 
-      if (!items.length) {
-        continue;
-      }
-
       if (options.stackFrame) {
         // When evaluating on a call frame, also autocomplete with scope variables.
+        const lowerPrefix = prefix.toLowerCase();
         const names = new Set(items.map(item => item.label));
         for (const completion of await options.stackFrame.completions()) {
-          if (names.has(completion.label)) continue;
+          if (
+            names.has(completion.label) ||
+            !completion.label.toLowerCase().includes(lowerPrefix)
+          ) {
+            continue;
+          }
+
           names.add(completion.label);
           items.push(completion as ICompletionWithSort);
         }


### PR DESCRIPTION
We were just bailing out too soon. VS Code's behavior of reusing previous completions helped hide this bug.

Fixes https://github.com/microsoft/vscode/issues/153651