### PR TITLE
Double check if native tostring is [object *]

### DIFF
--- a/src/adapter/templates/getStringyProps.ts
+++ b/src/adapter/templates/getStringyProps.ts
@@ -15,7 +15,12 @@ export const getStringyProps = remoteFunction(function (this: unknown, maxLength
   }
 
   for (const [key, value] of Object.entries(this)) {
-    if (typeof value === 'object' && value && !String(value.toString).includes('[native code]')) {
+    if (
+      typeof value === 'object' &&
+      value &&
+      !String(value.toString).includes('[native code]') &&
+      !String(this).includes('[object ')
+    ) {
       out[key] = String(value).slice(0, maxLength);
     }
   }
@@ -24,7 +29,12 @@ export const getStringyProps = remoteFunction(function (this: unknown, maxLength
 });
 
 export const getToStringIfCustom = remoteFunction(function (this: unknown, maxLength: number) {
-  if (typeof this === 'object' && this && !String(this.toString).includes('[native code]')) {
+  if (
+    typeof this === 'object' &&
+    this &&
+    !String(this.toString).includes('[native code]') &&
+    !String(this).includes('[object ')
+  ) {
     return String(this).slice(0, maxLength);
   }
 });

--- a/src/adapter/templates/getStringyProps.ts
+++ b/src/adapter/templates/getStringyProps.ts
@@ -15,13 +15,11 @@ export const getStringyProps = remoteFunction(function (this: unknown, maxLength
   }
 
   for (const [key, value] of Object.entries(this)) {
-    if (
-      typeof value === 'object' &&
-      value &&
-      !String(value.toString).includes('[native code]') &&
-      !String(this).includes('[object ')
-    ) {
-      out[key] = String(value).slice(0, maxLength);
+    if (typeof value === 'object' && value && !String(value.toString).includes('[native code]')) {
+      const str = String(value);
+      if (!str.startsWith('[object ')) {
+        out[key] = str.slice(0, maxLength);
+      }
     }
   }
 
@@ -29,12 +27,10 @@ export const getStringyProps = remoteFunction(function (this: unknown, maxLength
 });
 
 export const getToStringIfCustom = remoteFunction(function (this: unknown, maxLength: number) {
-  if (
-    typeof this === 'object' &&
-    this &&
-    !String(this.toString).includes('[native code]') &&
-    !String(this).includes('[object ')
-  ) {
-    return String(this).slice(0, maxLength);
+  if (typeof this === 'object' && this && !String(this.toString).includes('[native code]')) {
+    const str = String(this);
+    if (!str.startsWith('[object ')) {
+      return str.slice(0, maxLength);
+    }
   }
 });


### PR DESCRIPTION
This PR fixes #1338 

As mentioned in the vscode repo (see https://github.com/microsoft/vscode/issues/155718#issuecomment-1190550755) it might make sense to doublecheck and avoid using the native toString if the output is `[object *]` and there is a better alternative.