### PR TITLE
Avoid trimMiddle when double click in a variable from VisualStudio

### DIFF
--- a/src/adapter/objectPreview/contexts.ts
+++ b/src/adapter/objectPreview/contexts.ts
@@ -42,7 +42,7 @@ const hover: IPreviewContext = {
 };
 const copy: IPreviewContext = { budget: Infinity, quoted: false };
 const watch: IPreviewContext = { budget: 1000, quoted: true, postProcess: escape };
-const fallback: IPreviewContext = { budget: Infinity, quoted: true };
+const fallback: IPreviewContext = { budget: 100_000, quoted: true };
 
 export const getContextForType = (type: PreviewContextType | string | undefined) => {
   switch (type) {

--- a/src/adapter/objectPreview/contexts.ts
+++ b/src/adapter/objectPreview/contexts.ts
@@ -42,7 +42,7 @@ const hover: IPreviewContext = {
 };
 const copy: IPreviewContext = { budget: Infinity, quoted: false };
 const watch: IPreviewContext = { budget: 1000, quoted: true, postProcess: escape };
-const fallback: IPreviewContext = { budget: 100, quoted: true };
+const fallback: IPreviewContext = { budget: Infinity, quoted: true };
 
 export const getContextForType = (type: PreviewContextType | string | undefined) => {
   switch (type) {

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -529,6 +529,8 @@ export class Thread implements IVariableStoreLocationProvider {
       );
     }
 
+    if (args.context == undefined) args.context = 'watch';
+
     const variable = await variableStore
       .createFloatingVariable(response.result)
       .toDap(args.context as PreviewContextType, args.format);

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -529,8 +529,6 @@ export class Thread implements IVariableStoreLocationProvider {
       );
     }
 
-    if (args.context == undefined) args.context = 'watch';
-
     const variable = await variableStore
       .createFloatingVariable(response.result)
       .toDap(args.context as PreviewContextType, args.format);

--- a/src/test/evaluate/evaluate-default.txt
+++ b/src/test/evaluate/evaluate-default.txt
@@ -14,7 +14,7 @@ result: 3
 
 <error>: Uncaught ReferenceError: baz is not defined
 
-> result: Uint8Array(3) [1, 2, 3, buffer: ArrayBuffer(3), byteLength: 3, byteOffset: 0, length: 3, Symbo…]
+> result: Uint8Array(3) [1, 2, 3, buffer: ArrayBuffer(3), byteLength: 3, byteOffset: 0, length: 3, Symbol(Symbol.toStringTag): 'Uint8Array']
     0: 1
     1: 2
     2: 3


### PR DESCRIPTION
First of all I'm sorry to open a PR and don't open a issue before, we can discuss the solution here and if this is not the right approach I can close this PR.
I have already discussed offline with people from VS team and they told me that they cannot change their side because this could break other clients that implements DAP.

Trying to fix double click in a variable that has more than 100 characteres when debugging from VisualStudio.

As vscode-js-debug extension receives a message from dap like this: 
`{"tag":"dap.receive","timestamp":1659118931254,"metadata":{"connectionId":1,"message":{"type":"request","command":"evaluate","arguments":{"expression":"str","frameId":185,"timeout":1500},"seq":13}},"level":0}`

And there is no context, the default behavior for vscode-js-debug extension is to trim the variable in the middle, then the user cannot see the correct content of the variable.

My suggestion is: if vscode-js-debug receives no context information from dap in evaluate command, considers it as a watch and trim only if the len is higher than 1000.

If you don't think this is the right approach, we can also check if `clientID === 'visualstudio'` to do this change.

Fix https://github.com/dotnet/runtime/issues/71552