### PR TITLE
feat: make deno easier to configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog records changes to stable releases since 1.50.2. "TBA" changes here may be available in the [nightly release](https://github.com/microsoft/vscode-js-debug/#nightly-extension) before they're in stable. Note that the minor version (`v1.X.0`) corresponds to the VS Code version js-debug is shipped in, but the patch version (`v1.50.X`) is not meaningful.
 
+## Nightly (only)
+
+- feat: make Deno easier to configure
+
 ## v1.70 (July 2022)
 
 ### v1.70.0 - 2022-07-27

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -786,7 +786,10 @@ export class Thread implements IVariableStoreLocationProvider {
     );
     // "Break on start" is not actually a by-spec reason in CDP, it's added on from Node.js, so cast `as string`:
     // https://github.com/nodejs/node/blob/9cbf6af5b5ace0cc53c1a1da3234aeca02522ec6/src/node_contextify.cc#L913
-    const isInspectBrk = (event.reason as string) === 'Break on start';
+    // And Deno uses `debugCommand:
+    // https://github.com/denoland/deno/blob/2703996dea73c496d79fcedf165886a1659622d1/core/inspector.rs#L571
+    const isInspectBrk =
+      (event.reason as string) === 'Break on start' || event.reason === 'debugCommand';
     const location = event.callFrames[0].location;
     const scriptId = event.data?.scriptId || location.scriptId;
     const isSourceMapPause =

--- a/src/common/urlUtils.test.ts
+++ b/src/common/urlUtils.test.ts
@@ -7,6 +7,7 @@ import { SinonStub, stub } from 'sinon';
 import {
   createTargetFilter,
   fileUrlToAbsolutePath,
+  getNormalizedBinaryName,
   isLoopback,
   overridePlatform,
   resetCaseSensitivePaths,
@@ -306,6 +307,17 @@ describe('urlUtils', () => {
 
     for (const [ip, expected] of Object.entries(ttable)) {
       it(ip, async () => expect(await isLoopback(ip)).to.equal(expected));
+    }
+  });
+
+  it('getNormalizedBinaryName', () => {
+    if (process.platform === 'win32') {
+      expect(getNormalizedBinaryName('baR')).to.equal('bar');
+      expect(getNormalizedBinaryName('baR.exe')).to.equal('bar');
+      expect(getNormalizedBinaryName('C:\\foo\\BAR.exe')).to.equal('bar');
+    } else {
+      expect(getNormalizedBinaryName('/foo/bar')).to.equal('bar');
+      expect(getNormalizedBinaryName('bar')).to.equal('bar');
     }
   });
 });

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -57,6 +57,26 @@ export function caseNormalizedMap<V>(): Map<string, V> {
   return getCaseSensitivePaths() ? new Map() : new MapUsingProjection(lowerCaseInsensitivePath);
 }
 
+const win32PathExt =
+  process.platform === 'win32' ? process.env.PATHEXT?.toLowerCase().split(';') : undefined;
+
+/**
+ * Gets a case-normalized binary name suitable for comparison. On Windows,
+ * removes any executable extension.
+ */
+export const getNormalizedBinaryName = (binaryPath: string) => {
+  const filename = lowerCaseInsensitivePath(path.basename(binaryPath));
+  if (win32PathExt) {
+    for (const ext of win32PathExt) {
+      if (filename.endsWith(ext)) {
+        return filename.slice(0, -ext.length);
+      }
+    }
+  }
+
+  return filename;
+};
+
 /**
  * Returns the closest parent directory where the predicate returns true.
  */

--- a/src/targets/node/nodeBinaryProvider.test.ts
+++ b/src/targets/node/nodeBinaryProvider.test.ts
@@ -136,12 +136,14 @@ describe('NodeBinaryProvider', function () {
     });
 
     it('remaps to node version on electron with .cmd', async () => {
-      getVersionText.withArgs('/foo/electron.cmd').resolves('\nv6.1.2\n');
-      getVersionText.withArgs('/node').resolves('v14.5.0');
-      resolveBinaryLocation.withArgs('electron').returns('/foo/electron.cmd');
+      if (process.platform === 'win32') {
+        getVersionText.withArgs('/foo/electron.cmd').resolves('\nv6.1.2\n');
+        getVersionText.withArgs('/node').resolves('v14.5.0');
+        resolveBinaryLocation.withArgs('electron').returns('/foo/electron.cmd');
 
-      const binary = await p.resolveAndValidate(EnvironmentVars.empty, 'electron');
-      expect(binary.version).to.deep.equal(new Semver(12, 0, 0));
+        const binary = await p.resolveAndValidate(EnvironmentVars.empty, 'electron');
+        expect(binary.version).to.deep.equal(new Semver(12, 0, 0));
+      }
     });
 
     it('remaps to node version on electron with no ext', async () => {

--- a/src/test/extension/nodeConfigurationProvider.test.ts
+++ b/src/test/extension/nodeConfigurationProvider.test.ts
@@ -421,4 +421,60 @@ describe('NodeDebugConfigurationProvider', () => {
       expect(result?.outFiles).to.deep.equal(['${workspaceFolder}/**/*.js', '!**/node_modules/**']);
     });
   });
+
+  describe('deno', () => {
+    it('fills in default deno options', async () => {
+      const result = (await provider.resolveDebugConfiguration(folder, {
+        type: DebugType.Node,
+        name: '',
+        request: 'launch',
+        program: 'hello.js',
+        runtimeExecutable: 'deno',
+      })) as INodeLaunchConfiguration;
+
+      const port = result.attachSimplePort!;
+      expect(port).to.be.a('number');
+      expect(result.runtimeArgs).to.deep.equal([
+        'run',
+        `--inspect-brk=127.0.0.1:${port}`,
+        '--allow-all',
+      ]);
+      expect(result.continueOnAttach).to.be.true;
+    });
+
+    it('allows manual application', async () => {
+      const result = (await provider.resolveDebugConfiguration(folder, {
+        type: DebugType.Node,
+        name: '',
+        request: 'launch',
+        program: 'hello.js',
+        runtimeExecutable: 'deno',
+        runtimeArgs: ['run', '--inspect-brk=9229'],
+        attachSimplePort: 9229,
+      })) as INodeLaunchConfiguration;
+
+      expect(result.attachSimplePort).to.equal(9229);
+      expect(result.runtimeArgs).to.deep.equal(['run', `--inspect-brk=9229`]);
+    });
+
+    it('allows partial run args', async () => {
+      const result = (await provider.resolveDebugConfiguration(folder, {
+        type: DebugType.Node,
+        name: '',
+        request: 'launch',
+        program: 'hello.js',
+        runtimeExecutable: 'deno',
+        runtimeArgs: ['--some-arg'],
+      })) as INodeLaunchConfiguration;
+
+      const port = result.attachSimplePort!;
+      expect(port).to.be.a('number');
+      expect(result.runtimeArgs).to.deep.equal([
+        'run',
+        `--inspect-brk=127.0.0.1:${port}`,
+        '--allow-all',
+        '--some-arg',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Previously deno required manually configuring runtimeArgs and port
flags, with manual selection of the debug port to use[1]

This adds a little bit of extra logic so that all the necessary
configuration for Deno is automatically wired up whenever the user sets
their runtimeExectuable to `deno`. For example, this now works:

```json
{
  "type": "node"
  "name": "Launch Program",
  "program": "${workspaceFolder}/hello.ts",
  "runtimeExecutable": "deno",
  "request": "launch",
}
```

Where previously it was:

```json
{
  "type": "node"
  "name": "Launch Program",
  "program": "${workspaceFolder}/hello.ts",
  "runtimeExecutable": "deno",
  "request": "launch",
  "attachSimplePort": "9229",
  "continueOnAttach": true,
  "runtimeArgs": ["run", "--inspect-brk=127.0.0.1:9229", "--allow-all"]
}
```

~~Note that `continueOnAttach` doesn't quite work pending https://github.com/denoland/deno/issues/15360~~

1. https://medium.com/deno-the-complete-reference/run-and-debug-deno-applications-in-vscode-b6e3bff217f