### PR TITLE
fix: extraneous warnings when restarting debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - feat: make Deno easier to configure
+- fix: extraneous warnings when restarting debugging ([vscode#156432](https://github.com/microsoft/vscode/issues/156432))
 
 ## v1.70 (July 2022)
 

--- a/src/targets/node/killTree.ts
+++ b/src/targets/node/killTree.ts
@@ -27,6 +27,7 @@ export function killTree(
     try {
       execSync(
         `${TASK_KILL} ${behavior === KillBehavior.Forceful ? '/F' : ''} /T /PID ${processId}`,
+        { stdio: 'pipe' },
       );
       return true;
     } catch (err) {


### PR DESCRIPTION
I learned that execSync by default inherits stderr, which caused
warnings to be logged when they shouldn't have been.

Fixes https://github.com/microsoft/vscode/issues/156432