### PR TITLE
fix: webview debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - feat: make Deno easier to configure
 - fix: allow overriding resolution of workspaceFolder in pathMapping ([#1308](https://github.com/microsoft/vscode-js-debug/issues/1308))
 - fix: extraneous warnings when restarting debugging ([vscode#156432](https://github.com/microsoft/vscode/issues/156432))
+- fix: webview debugging ([#1344](https://github.com/microsoft/vscode-js-debug/issues/1344))
 
 ## v1.70 (July 2022)
 

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -235,7 +235,7 @@ export function stripTrailingSlash(aPath: string): string {
 }
 
 const vscodeWebviewResourceSchemeRe =
-  /^https:\/\/([a-z0-9\-]+)\+\.vscode-resource\.vscode-webview\.net\/(.+)/i;
+  /^https:\/\/([a-z0-9\-]+)\+\.vscode-resource\.vscode-(?:webview|cdn)\.net\/(.+)/i;
 
 /**
  * If urlOrPath is a file URL, removes the 'file:///', adjusting for platform differences

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -151,6 +151,10 @@ export const createTargetContainer = (
   container.bind(IBreakpointConditionFactory).to(BreakpointConditionFactory).inSingletonScope();
   container.bind(LogPointCompiler).toSelf().inSingletonScope();
 
+  if (target.sourcePathResolver) {
+    container.bind(ISourcePathResolver).toConstantValue(target.sourcePathResolver);
+  }
+
   container.bind(PerformanceProviderFactory).toSelf();
   container
     .bind(IPerformanceProvider)

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -55,7 +55,6 @@ export type PauseOnExceptionsState = 'none' | 'uncaught' | 'all';
 
 export class BrowserTarget implements ITarget {
   readonly parentTarget: BrowserTarget | undefined;
-  private _manager: BrowserTargetManager;
   private _cdp: Cdp.Api;
   private _ondispose: (t: BrowserTarget) => void;
   private _waitingForDebugger: boolean;
@@ -94,8 +93,10 @@ export class BrowserTarget implements ITarget {
 
   _children: Map<Cdp.Target.TargetID, BrowserTarget> = new Map();
 
+  public readonly sourcePathResolver = this._manager._sourcePathResolver;
+
   constructor(
-    targetManager: BrowserTargetManager,
+    private readonly _manager: BrowserTargetManager,
     private _targetInfo: Cdp.Target.TargetInfo,
     cdp: Cdp.Api,
     parentTarget: BrowserTarget | undefined,
@@ -108,7 +109,6 @@ export class BrowserTarget implements ITarget {
     this._cdp = cdp;
     cdp.pause();
 
-    this._manager = targetManager;
     this.parentTarget = parentTarget;
     this._waitingForDebugger = waitingForDebugger;
     this._updateFromInfo(_targetInfo);

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -6,6 +6,7 @@ import { CancellationToken } from 'vscode';
 import Cdp from '../cdp/api';
 import { IDisposable, IEvent } from '../common/events';
 import { ILogger } from '../common/logging';
+import { ISourcePathResolver } from '../common/sourcePathResolver';
 import { AnyLaunchConfiguration } from '../configuration';
 import Dap from '../dap/api';
 import { ITelemetryReporter } from '../telemetry/telemetryReporter';
@@ -42,6 +43,11 @@ export interface ITarget {
    * independently of its parents.
    */
   readonly independentLifeycle?: boolean;
+
+  /**
+   * Source path resolver, if a custom one should be used for this target.
+   */
+  readonly sourcePathResolver?: ISourcePathResolver;
 
   id(): string;
   name(): string;


### PR DESCRIPTION
Update to the new CDN URL, and make sure the right path resolver is used

Fixes https://github.com/microsoft/vscode-js-debug/issues/1344