### PR TITLE
fix: improve resolution in Webpack HMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - feat: make Deno easier to configure
+- fix: improve breakpoint resolution in webpack HMR ([vscode#155331](https://github.com/microsoft/vscode/issues/155331))
 - fix: allow overriding resolution of workspaceFolder in pathMapping ([#1308](https://github.com/microsoft/vscode-js-debug/issues/1308))
 - fix: extraneous warnings when restarting debugging ([vscode#156432](https://github.com/microsoft/vscode/issues/156432))
 - fix: webview debugging ([#1344](https://github.com/microsoft/vscode-js-debug/issues/1344))


### PR DESCRIPTION
HMR "replaces" sources at runtime with new sources. V8 doesn't ever
unload parsed scripts, so they stick around but are unused. However, the
debugger wasn't aware of this, so if setting a breakpoint at a given
line it could end up displaying it at the wrong place if using an
outdated version of the file. (The breakpoint would still generally get
hit, since we resolve it to _all_ possible locations, but its display
is wrong).

Now, we add logic that identified webpack "hot reload" scripts. When
they come in, following webpack's logic of replacing any sourcemapped
scripts js-debug tracks with the one from the HMR bundle.

Fixes https://github.com/microsoft/vscode/issues/155331