### PR TITLE
Allow specifying host:port on vsDebugServer.ts

### DIFF
--- a/src/adapter/portLeaseTracker.ts
+++ b/src/adapter/portLeaseTracker.ts
@@ -26,11 +26,12 @@ export const acquireTrackedServer = async (
   tracker: IPortLeaseTracker,
   onSocket: (s: net.Socket) => void,
   overridePort?: number,
+  host?: string,
   ct = NeverCancelled,
 ) => {
   const server = overridePort
-    ? await waitForServerToListen(net.createServer(onSocket).listen(overridePort, '127.0.0.1'), ct)
-    : await findOpenPort({ tester: makeAcquireTcpServer(onSocket) }, ct);
+    ? await waitForServerToListen(net.createServer(onSocket).listen(overridePort, host), ct)
+    : await findOpenPort({ tester: makeAcquireTcpServer(onSocket, host) }, ct);
   const dispose = tracker.register((server.address() as net.AddressInfo).port);
   server.on('close', () => dispose.dispose());
   server.on('error', () => dispose.dispose());

--- a/src/common/findOpenPort.ts
+++ b/src/common/findOpenPort.ts
@@ -97,10 +97,10 @@ export function acquirePortNumber(port: number, ct: CancellationToken = NeverCan
  * @returns the listening server
  */
 export const makeAcquireTcpServer =
-  (onSocket: (socket: net.Socket) => void): PortTesterFn<net.Server> =>
+  (onSocket: (socket: net.Socket) => void, host?: string): PortTesterFn<net.Server> =>
   (port, ct) => {
     const server = net.createServer(onSocket);
-    server.listen(port, '127.0.0.1');
+    server.listen(port, host);
     return waitForServerToListen(server, ct);
   };
 

--- a/src/serverSessionManager.ts
+++ b/src/serverSessionManager.ts
@@ -26,11 +26,15 @@ export class ServerSessionManager<T extends IDebugSessionLike> {
   private readonly portLeaseTracker: IPortLeaseTracker;
   private disposables: IDisposable[] = [];
   private servers = new Map<string, net.Server>();
+  private host = '127.0.0.1';
 
-  constructor(globalContainer: Container, sessionLauncher: ISessionLauncher<T>) {
+  constructor(globalContainer: Container, sessionLauncher: ISessionLauncher<T>, host?: string) {
     this.sessionManager = new SessionManager(globalContainer, sessionLauncher);
     this.portLeaseTracker = globalContainer.get(IPortLeaseTracker);
     this.disposables.push(this.sessionManager);
+    if (host) {
+      this.host = host;
+    }
   }
 
   /**
@@ -106,6 +110,7 @@ export class ServerSessionManager<T extends IDebugSessionLike> {
         deferredConnection.resolve(session.connection);
       },
       port,
+      this.host,
     );
 
     this.servers.set(debugSession.id, debugServer);

--- a/src/serverSessionManager.ts
+++ b/src/serverSessionManager.ts
@@ -26,15 +26,15 @@ export class ServerSessionManager<T extends IDebugSessionLike> {
   private readonly portLeaseTracker: IPortLeaseTracker;
   private disposables: IDisposable[] = [];
   private servers = new Map<string, net.Server>();
-  private host = '127.0.0.1';
 
-  constructor(globalContainer: Container, sessionLauncher: ISessionLauncher<T>, host?: string) {
+  constructor(
+    globalContainer: Container,
+    sessionLauncher: ISessionLauncher<T>,
+    private readonly host = '127.0.0.1',
+  ) {
     this.sessionManager = new SessionManager(globalContainer, sessionLauncher);
     this.portLeaseTracker = globalContainer.get(IPortLeaseTracker);
     this.disposables.push(this.sessionManager);
-    if (host) {
-      this.host = host;
-    }
   }
 
   /**

--- a/src/vsDebugServer.ts
+++ b/src/vsDebugServer.ts
@@ -128,15 +128,11 @@ class VsDebugServer implements ISessionLauncher<VSDebugSession> {
 
 let debugServerPort: number | undefined = undefined;
 let debugServerHost: string | undefined = undefined;
+
 if (process.argv.length >= 3) {
-  // Interpret the argument as either a port number, or 'address:port'.
-  const address = process.argv[2];
-  const colonIndex = address.lastIndexOf(':');
-  if (colonIndex === -1) {
-    debugServerPort = +address;
-  } else {
-    debugServerHost = address.substring(0, colonIndex);
-    debugServerPort = +address.substring(colonIndex + 1);
+  debugServerPort = +process.argv[2];
+  if (process.argv.length >= 4) {
+    debugServerHost = process.argv[3];
   }
 }
 


### PR DESCRIPTION
This PR addresses parts of https://github.com/microsoft/vscode-js-debug/issues/1328 by adding a new argument, `host`, that comes after specifying a `port`. When `host` is given, it is being propagated internally to where servers are being created. For backwards compatability reasons:
1. Only a port can still be given.
2. Default listen IP stays the same as previously, both on the initial server and on child session servers. 