### PR TITLE
Revert "Merge pull request #1361 from microsoft/feat/use-preview-builds"

### DIFF
--- a/.ci/publish-nightly.yml
+++ b/.ci/publish-nightly.yml
@@ -1,13 +1,4 @@
-trigger: none
 pr: none
-
-schedules:
-  - cron: '0 9 * * Mon-Thu'
-    displayName: Nightly Release Schedule
-    always: true
-    branches:
-      include:
-        - main
 
 resources:
   repositories:
@@ -17,10 +8,17 @@ resources:
       ref: main
       endpoint: Monaco
 
+parameters:
+  - name: publishExtension
+    displayName: 🚀 Publish Extension
+    type: boolean
+    default: true
+
 extends:
   template: azure-pipelines/extension/pre-release.yml@templates
   parameters:
     workingDirectory: dist
+    usePreReleaseChannel: false
     vscePackageArgs: --no-dependencies
     cgIgnoreDirectories: 'testdata,demos,.vscode-test'
     buildSteps:
@@ -28,4 +26,4 @@ extends:
         displayName: Install dependencies
 
       - script: npm run compile -- package:prepare --nightly
-        displayName: Package Stable
+        displayName: Package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-This changelog records changes to stable releases since 1.50.2. "TBA" changes here may be available in the pre-release version of the extension before they're in stable. Note that the minor version (`v1.X.0`) corresponds to the VS Code version js-debug is shipped in, but the patch version (`v1.50.X`) is not meaningful.
+This changelog records changes to stable releases since 1.50.2. "TBA" changes here may be available in the [nightly release](https://github.com/microsoft/vscode-js-debug/#nightly-extension) before they're in stable. Note that the minor version (`v1.X.0`) corresponds to the VS Code version js-debug is shipped in, but the patch version (`v1.50.X`) is not meaningful.
 
-## Prerelease (only)
+## Nightly (only)
 
 - feat: make Deno easier to configure
 - fix: path display issues in breakpoint diagnostic tool ([#1343](https://github.com/microsoft/vscode-js-debug/issues/1343))

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ This is a [DAP](https://microsoft.github.io/debug-adapter-protocol/)-based JavaS
 
 ### Nightly Extension
 
-The shipped version of VS Code includes the js-debug version at the time of its release, however you may want to install our pre-release build to get the latest fixes and features. The build runs at 5PM PST on each day that there are changes ([see pipeline](https://dev.azure.com/vscode/VS%20Code%20debug%20adapters/_build?definitionId=28)). To get the build:
+The shipped version of VS Code includes the js-debug version at the time of its release, however you may want to install our nightly build to get the latest fixes and features. The nightly build runs at 5PM PST on each day that there are changes ([see pipeline](https://dev.azure.com/vscode/VS%20Code%20debug%20adapters/_build?definitionId=28)). To get the build:
 
 1. Open the extensions view (ctrl+shift+x) and search for `@builtin @id:ms-vscode.js-debug`
-2. Right click on the `JavaScript Debugger` extension and select `Switch to Pre-Release Version`.
-3. Reload VS Code
+2. Right click on the `JavaScript Debugger` extension and `Disable` it.
+3. Search for `@id:ms-vscode.js-debug-nightly` in the extensions view.
+4. Install that extension.
 
 ## What's new?
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "description": "An extension for debugging Node.js programs and Chrome.",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.71.0-insider",
+    "vscode": "^1.67.0-insider",
     "node": ">=10"
   },
   "icon": "resources/logo.png",

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -503,7 +503,7 @@ function warnNightly(dap: Dap.Api): void {
   if (isNightly) {
     dap.output({
       category: 'console',
-      output: `Note: Using the pre-release version of js-debug\n`,
+      output: `Note: Using the "preview" debug extension\n`,
     });
   }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1134,5 +1134,5 @@ export const breakpointLanguages: ReadonlyArray<string> = [
 export const packageName: string = pkg.name;
 export const packageVersion: string = pkg.version;
 export const packagePublisher: string = pkg.publisher;
-export const isNightly = !!pkg.isNightly;
+export const isNightly = packageName.includes('nightly');
 export const extensionId = `${packagePublisher}.${packageName}`;


### PR DESCRIPTION
This reverts commit 8363c62bb8205515bfeabea8789aee6b1361ab32, reversing
changes made to 4294f65e087dc3634776478f39d2c8131dd1ab8b.

Currently, users cannot switch to prerelease extensions, and there is also desire to disallow built-in extension updates--currently allowed on insiders--which would make pre-release builds unsuitable for js-debug.

Go back to having a 'nightly' build pending these conversations (and engineering in core to let js-debug have a good prerelease experience).