### PR TITLE
Fix hex typo

### DIFF
--- a/src/adapter/templates/readMemory.ts
+++ b/src/adapter/templates/readMemory.ts
@@ -24,7 +24,7 @@ export const readMemory = remoteFunction(function (
   return encodeHex(new Uint8Array(buffer, readStart, readCount));
 
   function encodeHex(buffer: Uint8Array) {
-    const dictionary = '0123456789abcedf';
+    const dictionary = '0123456789abcdef';
     let output = '';
     for (let i = 0; i < buffer.length; i++) {
       const b = buffer[i];


### PR DESCRIPTION
Memory inspector swapped "E" and "D" nibbles.  
It happened because there was a typo in hex decoding.  
Problem was only with reading memory, written memory was correct.  
![](https://user-images.githubusercontent.com/11680949/187035715-d8455f9b-0b8a-4f03-9b35-355f0c989e1a.jpg)