### PR TITLE
fix: dynamic debug configs sometimes having the wrong type

### DIFF
--- a/src/ui/configuration/baseConfigurationProvider.ts
+++ b/src/ui/configuration/baseConfigurationProvider.ts
@@ -44,7 +44,9 @@ export abstract class BaseConfigurationProvider<T extends AnyLaunchConfiguration
       const preferredType = preferredDebugTypes.get(this.type);
       if (preferredType) {
         for (const config of configs) {
-          config.type = preferredType as T['type'];
+          if (config.type === this.type) {
+            config.type = preferredType as T['type'];
+          }
         }
       }
 


### PR DESCRIPTION
I added logic to rename the dynamic type to the "preferred" type (such as from pwa-node to node), but didn't take into account that sometimes the config providers return a different type to their main type. For npm scripts, for example, they return a `node-terminal` type instead of `pwa-node`. Changing the type to `node` resulted in broken configs.