### PR TITLE
Pass cwd to getVersionText

### DIFF
--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -266,6 +266,7 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
       EnvironmentVars.merge(EnvironmentVars.processEnv(), this.getConfiguredEnvironment(params)),
       executable,
       params.nodeVersionHint,
+      params.cwd,
     );
   }
 


### PR DESCRIPTION
[Volta](https://volta.sh/)'s shim relies on the project `package.json` to find the correct node executable version to be used. Because  `getVersionText` is not setting `cwd` when calling `node --version`, the shim responds with an error.

This PR fixes that by passing `cwd` all the way to `getVersion`. As far as I've seen, all the other calls `node` get the `cwd` set correctly. This was the only exception.