### PR TITLE
[blazor] When debugging C# code, a static method doesn't have this

### DIFF
--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -453,7 +453,7 @@ export class StackFrame implements IFrameElement {
 
     const extraProperties: IExtraProperty[] = [];
     if (scopeNumber === 0) {
-      extraProperties.push({ name: 'this', value: scope.thisObject });
+      if (scope.thisObject) extraProperties.push({ name: 'this', value: scope.thisObject });
       if (scope.returnValue)
         extraProperties.push({
           name: localize('scope.returnValue', 'Return value'),


### PR DESCRIPTION
As in C# static methods doesn't have this object, and this code was adding a null scope.thisObject, then it was throwing an error with this stacktrace:

![image](https://user-images.githubusercontent.com/4503299/191553327-620616f6-41d4-401f-82e1-5faec0167831.png)

So we weren't able to see locals of any static method in C#.
![image](https://user-images.githubusercontent.com/4503299/191553533-17c938af-ca7f-4f09-b5db-e04cb08c546b.png)
