### PR TITLE
fix: discover npm scripts in nested workspace folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - feat: add automatic support for nested sourcemaps ([#1390](https://github.com/microsoft/vscode-js-debug/issues/1390))
 - fix: breakpoints failing to set on paths with multibyte URL characters ([#1364](https://github.com/microsoft/vscode-js-debug/issues/1364))
 - fix: properly handle UNC paths ([#1148](https://github.com/microsoft/vscode-js-debug/issues/1148))
+- fix: discover npm scripts in nested workspace folders ([#1321](https://github.com/microsoft/vscode-js-debug/issues/1321))
 
 ## v1.72 (September 2022)
 

--- a/src/ui/configuration/nodeDebugConfigurationProvider.ts
+++ b/src/ui/configuration/nodeDebugConfigurationProvider.ts
@@ -90,7 +90,7 @@ export class NodeDynamicDebugConfigurationProvider extends BaseConfigurationProv
       return [openTerminal];
     }
 
-    const scripts = await findScripts([folder.uri.fsPath], true);
+    const scripts = await findScripts([folder], true);
     if (!scripts) {
       return [openTerminal];
     }


### PR DESCRIPTION
Uses the (relatively) new `findFiles` API to discover all package.json's, using the same overall logic as the built-in npm extension.

Fixes #1321