### PR TITLE
chore: loosen restriction around enabling auto attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: breakpoints failing to set on paths with multibyte URL characters ([#1364](https://github.com/microsoft/vscode-js-debug/issues/1364))
 - fix: properly handle UNC paths ([#1148](https://github.com/microsoft/vscode-js-debug/issues/1148))
 - fix: discover npm scripts in nested workspace folders ([#1321](https://github.com/microsoft/vscode-js-debug/issues/1321))
+- chore: loosen restriction around enabling auto attach ([#1392](https://github.com/microsoft/vscode-js-debug/issues/1392))
 
 ## v1.72 (September 2022)
 

--- a/src/targets/node/autoAttachLauncher.ts
+++ b/src/targets/node/autoAttachLauncher.ts
@@ -175,14 +175,7 @@ export class AutoAttachLauncher
     const storagePath =
       this.extensionContext.storagePath || this.extensionContext.globalStoragePath;
     if (storagePath.includes(' ')) {
-      if (!binary.isPreciselyKnown) {
-        throw new AutoAttachPreconditionFailed(
-          'We did not find `node` on your PATH, so we cannot enable auto-attach in your environment',
-          'https://github.com/microsoft/vscode-js-debug/issues/708',
-        );
-      }
-
-      if (!binary.has(Capability.UseSpacesInRequirePath)) {
+      if (binary.isPreciselyKnown && !binary.has(Capability.UseSpacesInRequirePath)) {
         throw new AutoAttachPreconditionFailed(
           `The \`node\` version on your PATH is too old (${binary.version?.major}), so we cannot enable auto-attach in your environment`,
           'https://github.com/microsoft/vscode-js-debug/issues/708',


### PR DESCRIPTION
Now that Node 12 is EOL and its usage is continuing to decrease in VS Code, I think we can loosen the restriction to allow turning auto attach on with spaces in the path.

Previously we would not allow turning on auto attach if there were spaces in the path, and the Node.js version could not be determined exactly (#708).

Fixes https://github.com/microsoft/vscode-js-debug/issues/1392