### PR TITLE
fix: Rename identifier for source map

### DIFF
--- a/src/common/sourceMaps/renameProvider.ts
+++ b/src/common/sourceMaps/renameProvider.ts
@@ -114,7 +114,7 @@ export class RenameProvider implements IRenameProvider {
       const start = toOffset.convert(startPos);
 
       const lastGeneratedColumn = (mapping as MappingItem & { lastGeneratedColumn: number })
-        .lastGeneratedColumn as number;
+        .lastGeneratedColumn;
 
       const endPos = new Base01Position(mapping.generatedLine, lastGeneratedColumn + 1);
       const end = toOffset.convert(endPos);


### PR DESCRIPTION
I found that `computeColumnSpans` can be used to get a more accurate identifier.
I only did a simple test locally, but this should theoretically be fine.

Fixed: #1383 