### PR TITLE
fix: improve skipfile performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
-- fix: copying a date object resulting in an empty object ([vscode#162747](https://github.com/microsoft/vscode/issues/162747))
 - feat: add automatic support for nested sourcemaps ([#1390](https://github.com/microsoft/vscode-js-debug/issues/1390))
+- fix: copying a date object resulting in an empty object ([vscode#162747](https://github.com/microsoft/vscode/issues/162747))
+- fix: improve performance when using skipFiles in large projects ([#1179](https://github.com/microsoft/vscode-js-debug/issues/1179))
 - fix: breakpoints failing to set on paths with multibyte URL characters ([#1364](https://github.com/microsoft/vscode-js-debug/issues/1364))
 - fix: properly handle UNC paths ([#1148](https://github.com/microsoft/vscode-js-debug/issues/1148))
 - fix: discover npm scripts in nested workspace folders ([#1321](https://github.com/microsoft/vscode-js-debug/issues/1321))

--- a/src/adapter/exceptionPauseService.ts
+++ b/src/adapter/exceptionPauseService.ts
@@ -14,7 +14,6 @@ import { invalidBreakPointCondition } from '../dap/errors';
 import { ProtocolError } from '../dap/protocolError';
 import { wrapBreakCondition } from './breakpoints/conditions/expression';
 import { IEvaluator, PreparedCallFrameExpr } from './evaluator';
-import { ScriptSkipper } from './scriptSkipper/implementation';
 import { IScriptSkipper } from './scriptSkipper/scriptSkipper';
 import { SourceContainer } from './sources';
 
@@ -75,7 +74,7 @@ export class ExceptionPauseService implements IExceptionPauseService {
 
   constructor(
     @inject(IEvaluator) private readonly evaluator: IEvaluator,
-    @inject(IScriptSkipper) private readonly scriptSkipper: ScriptSkipper,
+    @inject(IScriptSkipper) private readonly scriptSkipper: IScriptSkipper,
     @inject(IDapApi) private readonly dap: Dap.Api,
     @inject(AnyLaunchConfiguration) launchConfig: AnyLaunchConfiguration,
     @inject(SourceContainer) private readonly sourceContainer: SourceContainer,

--- a/src/adapter/scriptSkipper/simpleGlobToRe.test.ts
+++ b/src/adapter/scriptSkipper/simpleGlobToRe.test.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { simpleGlobsToRe } from './simpleGlobToRe';
+
+describe('simpleGlobsToRe', () => {
+  const tt = [
+    {
+      globs: ['**/foo/**'],
+      matches: {
+        'file:///hello/foo/bar': true,
+        'file:///hello/baz/bar': false,
+      },
+    },
+    {
+      globs: ['**/fo$^o/**', '!**/fo$^o/bar/**'],
+      matches: {
+        'file:///hello/fo$^o/bin/baz': true,
+        'file:///hello/fo$^o/bar/baz': false,
+      },
+    },
+    {
+      globs: ['**/foo/**', '!**/foo/bar/**'],
+      matches: {
+        'file:///hello/foo/bin/baz': true,
+        'file:///hello/foo/bar/baz': false,
+      },
+    },
+    {
+      globs: ['**/foo/**', '!**/foo/bar/**', '**/other/**', '!**/filename.js'],
+      matches: {
+        'file:///hello/foo/bin/baz': true,
+        'file:///hello/foo/bar/baz': false,
+        'file:///other/thing': true,
+        'file:///other/filename.js': false,
+        'file:///hello/foo/bin/filename.js': false,
+      },
+    },
+  ];
+
+  for (const { globs, matches } of tt) {
+    it(globs.join(', '), () => {
+      const res = simpleGlobsToRe(globs);
+      for (const [url, expected] of Object.entries(matches)) {
+        const matching = res.find(re => re.test(url));
+        if (expected !== !!matching) {
+          if (expected) {
+            throw new Error(`Expected ${url} to match`);
+          } else {
+            throw new Error(`Expected ${url} to not match, but ${matching} did`);
+          }
+        }
+      }
+    });
+  }
+});

--- a/src/adapter/scriptSkipper/simpleGlobToRe.ts
+++ b/src/adapter/scriptSkipper/simpleGlobToRe.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { escapeRegexSpecialChars } from '../../common/stringUtils';
+
+/**
+ * Smashes a list of globs into a list of matching regexes. Only
+ * supports basic glob features:
+ *
+ * - Wildcards (**​/foo/bar and *.js)
+ * - Entire negations (!**​/foo/bar)
+ *
+ * This is used in the scriptSkipper because `Debugger.setBlackboxPatterns`
+ * only supports a list of regexes to match again.
+ */
+export function simpleGlobsToRe(globs: readonly string[]) {
+  const res: string[] = [];
+  for (let i = 0; i < globs.length; i++) {
+    const g = globs[i];
+    if (g.startsWith('!')) {
+      // Add each negation as a negative lookahead. This is not the fastest for
+      // regex engines to compute, but is far faster than previous approaches...
+      const re = globToRe(g.slice(1));
+      for (let i = 0; i < res.length; i++) {
+        res[i] = `^(?!${re.slice(1)})${res[i].slice(1)}`;
+      }
+    } else {
+      res.push(globToRe(g));
+    }
+  }
+
+  return res.map(re => new RegExp(re, 'i'));
+}
+
+/**
+ * Simple glob to re implementation. We could use micromatch.makeRe, but that
+ * inclues a lot of cruft we don't care about when matching against URLs.
+ */
+function globToRe(glob: string) {
+  const parts = glob.split('/');
+  const regexParts = [];
+  for (let j = 0; j < parts.length; j++) {
+    const p = parts[j];
+    if (p === '**') {
+      regexParts.push('.*');
+    } else if (p.includes('*')) {
+      const wildcards = p.split('*');
+      regexParts.push(wildcards.map(s => escapeRegexSpecialChars(s)).join('[^\\/]*'));
+    } else {
+      regexParts.push(escapeRegexSpecialChars(p));
+    }
+  }
+
+  return `^${regexParts.join('\\/')}$`;
+}

--- a/src/common/objUtils.ts
+++ b/src/common/objUtils.ts
@@ -239,6 +239,25 @@ export function memoize<T, R>(fn: (arg: T) => R): ((arg: T) => R) & { clear(): v
 }
 
 /**
+ * Memoizes the last call to a single-parameter function.
+ */
+export function memoizeLast<T, R>(fn: (arg: T) => R): ((arg: T) => R) & { clear(): void } {
+  let cached: { arg: T; val: R } | undefined;
+  const wrapper = (arg: T): R => {
+    if (cached?.arg === arg) {
+      return cached.val;
+    }
+
+    cached = { arg, val: fn(arg) };
+    return cached.val;
+  };
+
+  wrapper.clear = () => (cached = undefined);
+
+  return wrapper;
+}
+
+/**
  * Memoizes the single-parameter function using weak references.
  */
 export function memoizeWeak<T extends object, R>(fn: (arg: T) => R): (arg: T) => R {

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -418,17 +418,18 @@ export function urlToRegex(
     // fancy regex above), replace `file:///c:/` or simple `c:/` patterns with
     // an insensitive drive letter.
     patterns.push(
-      `${rePrefix}${re}${reSuffix}`
-        .replace(
-          /^(file:\\\/\\\/\\\/)?([a-z]):/i,
-          (_, file = '', letter) => `${file}[${letter.toUpperCase()}${letter.toLowerCase()}]:`,
-        )
-        .concat('($|\\?)'),
+      makeDriveLetterReCaseInsensitive(`${rePrefix}${re}${reSuffix}`).concat('($|\\?)'),
     );
   }
 
   return patterns.join('|');
 }
+
+export const makeDriveLetterReCaseInsensitive = (re: string) =>
+  re.replace(
+    /^(file:\\\/\\\/\\\/)?([a-z]):/i,
+    (_, file = '', letter) => `${file}[${letter.toUpperCase()}${letter.toLowerCase()}]:`,
+  );
 
 /**
  * Opaque typed used to indicate strings that are file URLs.


### PR DESCRIPTION
Previously, `skipFiles` applied a new regex and eventual call to `Debugger.setBlackboxPatterns` for every source. In #1179, this resulted in very bad performance, since a regex was sent for each file loaded in the user's `node_modules` (several thousand). We needed to do this since `setBlackboxPatterns` doesn't have a "negation", so we had to compute on the debugger side which files satisfied `skipFiles` and send those to the runtime.

This commit makes some things smarter, and some things less smart. It restricts `skipFiles` to very simple globs, allowing only wildcards and negations. But, in exchange, it's able to make a finite number of regexes based solely on those patterns. In most cases, this means that we never need to send further `setBlackboxPatterns` updates to the runtime after loading.

For example,

```js
{ skipFiles: ['**/node_modules/**', '!**/node_modules/my-library/**'] }
```

...compiles to...

```
/^(?!.*\/node_modules\/my-library\/.*$).*\/node_modules\/.*$/
```

We do still use the old strategy if a URL isn't skipped but maps to a path that does skip. We could eventually make this smarter if the SourcePathResolver's `absolutePathToUrlRegex` was mixed in somehow... but those can't be combined or negated as simply as glob patterns.

This does run the risk of breaking users who use advanced glob patterns in their `skipFiles`, but I haven't really encountered any of those and I believe the tradeoff is worth it.

Fixes https://github.com/microsoft/vscode-js-debug/issues/1179