### PR TITLE
Allow for URL as sourceRoot

### DIFF
--- a/src/adapter/scriptSkipper/implementation.ts
+++ b/src/adapter/scriptSkipper/implementation.ts
@@ -260,6 +260,7 @@ export class ScriptSkipper {
     if (
       !skipped &&
       source.absolutePath &&
+      urlUtils.isAbsolute(source.absolutePath) &&
       this._testSkipAuthored(urlUtils.absolutePathToFileUrl(source.absolutePath))
     ) {
       this.setIsUrlBlackboxSkipped(url, true);

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -1082,9 +1082,10 @@ export class SourceContainer {
     const todo: Promise<unknown>[] = [];
     for (const url of map.sources) {
       const absolutePath = await this.sourcePathResolver.urlToAbsolutePath({ url, map });
-      const resolvedUrl = absolutePath
-        ? utils.absolutePathToFileUrl(absolutePath)
-        : map.computedSourceUrl(url);
+      const resolvedUrl =
+        absolutePath && utils.isAbsolute(absolutePath)
+          ? utils.absolutePathToFileUrl(absolutePath)
+          : map.computedSourceUrl(url);
 
       const existing = this._sourceMapSourcesByUrl.get(resolvedUrl);
       if (existing) {
@@ -1106,7 +1107,6 @@ export class SourceContainer {
         resolvedUrl,
       });
 
-      const fileUrl = absolutePath && utils.absolutePathToFileUrl(absolutePath);
       const smContent = this.sourceMapFactory.guardSourceMapFn(
         map,
         () => map.sourceContentFor(url, true),
@@ -1129,6 +1129,10 @@ export class SourceContainer {
         }
       }
 
+      const fileUrl =
+        absolutePath && utils.isAbsolute(absolutePath)
+          ? utils.absolutePathToFileUrl(absolutePath)
+          : absolutePath;
       const source = new SourceFromMap(
         this,
         resolvedUrl,
@@ -1146,6 +1150,7 @@ export class SourceContainer {
       );
       source.compiledToSourceUrl.set(compiled, url);
       compiled.sourceMap.sourceByUrl.set(url, source);
+
       todo.push(this._addSource(source));
     }
 

--- a/src/common/sourceMaps/sourceMapResolutionUtils.ts
+++ b/src/common/sourceMaps/sourceMapResolutionUtils.ts
@@ -20,7 +20,6 @@ export function getFullSourceEntry(sourceRoot: string | undefined, sourcePath: s
   if (!sourceRoot.endsWith('/')) {
     sourceRoot += '/';
   }
-
   return sourceRoot + sourcePath;
 }
 
@@ -35,12 +34,13 @@ export async function getComputedSourceRoot(
   logger: ILogger,
 ): Promise<string> {
   generatedPath = utils.fileUrlToAbsolutePath(generatedPath) || generatedPath;
-
   let absSourceRoot: string;
   if (sourceRoot) {
     if (utils.isFileUrl(sourceRoot)) {
       // sourceRoot points to a local path like "file:///c:/project/src", make it an absolute path
       absSourceRoot = utils.fileUrlToAbsolutePath(sourceRoot);
+    } else if (utils.isURL(sourceRoot)) {
+      absSourceRoot = sourceRoot;
     } else if (utils.isAbsolute(sourceRoot)) {
       // sourceRoot is like "/src", should be like http://localhost/src, resolve to a local path using pathMaping.
       // If path mappings do not apply (e.g. node), assume that sourceRoot is actually a local absolute path.
@@ -79,9 +79,13 @@ export async function getComputedSourceRoot(
     );
   }
 
-  absSourceRoot = utils.stripTrailingSlash(absSourceRoot);
-  absSourceRoot = fixDriveLetterAndSlashes(absSourceRoot);
-
+  if (!utils.isURL(absSourceRoot)) {
+    absSourceRoot = utils.stripTrailingSlash(absSourceRoot);
+    absSourceRoot = fixDriveLetterAndSlashes(absSourceRoot);
+  } else {
+    //guarantees one slash in the end for later join with sources files
+    absSourceRoot = new URL(absSourceRoot).href;
+  }
   return absSourceRoot;
 }
 

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -301,6 +301,11 @@ export function fileUrlToNetworkPath(urlOrPath: string): string {
 
 // TODO: this does not escape/unescape special characters, but it should.
 export function absolutePathToFileUrl(absolutePath: string): string {
+  if (absolutePath.includes('://')) {
+    throw new Error(
+      `You call the absolutePathToFileUrl on a path starting containg a different protocol: ${absolutePath}`,
+    );
+  }
   if (platform === 'win32') {
     return 'file:///' + platformPathToUrlPath(absolutePath);
   }
@@ -312,6 +317,18 @@ export function absolutePathToFileUrl(absolutePath: string): string {
  */
 export function isAbsolute(_path: string): boolean {
   return path.posix.isAbsolute(_path) || path.win32.isAbsolute(_path);
+}
+
+/**
+ * Returns whether the path is a Windows or posix path.
+ */
+export function isURL(input: string): boolean {
+  try {
+    const url = new URL(input);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch (_) {
+    return false;
+  }
 }
 
 /**

--- a/src/test/sources/sources-supports-remote-sources-1424.txt
+++ b/src/test/sources/sources-supports-remote-sources-1424.txt
@@ -1,0 +1,23 @@
+
+Source event for
+{
+    reason : new
+    source : {
+        name : localhost꞉8001/remote-test/string.ts
+        path : localhost꞉8001/remote-test/string.ts
+        sourceReference : <number>
+    }
+}
+text/javascript
+---------
+let i = 0;
+i++;
+debugger;
+i++;
+i++;
+i++;
+i++;
+i++;
+console.log(i);//ts file
+
+---------

--- a/src/test/sources/sourcesTest.ts
+++ b/src/test/sources/sourcesTest.ts
@@ -102,6 +102,16 @@ describe('sources', () => {
     handle.assertLog({ substring: true });
   });
 
+  itIntegrates('supports remote sources (#1424)', async ({ r }) => {
+    const p = await r.launchUrlAndLoad('index.html');
+    p.addScriptTag('remote-test/string.js');
+
+    const source = await p.waitForSource('string.ts');
+    await dumpSource(p, source, '');
+
+    p.assertLog();
+  });
+
   itIntegrates('works with relative webpack sourcemaps (#479)', async ({ r }) => {
     const p = await r.launchUrl('webpack/relative-paths.html');
 

--- a/testWorkspace/web/remote-test/string.js
+++ b/testWorkspace/web/remote-test/string.js
@@ -1,0 +1,10 @@
+let i = 0;
+i++;
+debugger;
+i++;
+i++;
+i++;
+i++;
+i++;
+console.log('123');
+//# sourceMappingURL=string.js.map

--- a/testWorkspace/web/remote-test/string.js.map
+++ b/testWorkspace/web/remote-test/string.js.map
@@ -1,0 +1,3 @@
+{"version":3,"file":"string.js","sourceRoot":"http://localhost:8001/remote-test/","sources":["string.ts"],"names":[],"mappings":";AAAA,IAAI,CAAC,GAAG,CAAC,CAAC;AACV,CAAC,EAAE,CAAC;AACJ,QAAQ,CAAC;AACT,CAAC,EAAE,CAAC;AACJ,CAAC,EAAE,CAAC;AACJ,CAAC,EAAE,CAAC;AACJ,CAAC,EAAE,CAAC;AACJ,CAAC,EAAE,CAAC;AACJ,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC"}
+
+

--- a/testWorkspace/web/remote-test/string.ts
+++ b/testWorkspace/web/remote-test/string.ts
@@ -1,0 +1,9 @@
+let i = 0;
+i++;
+debugger;
+i++;
+i++;
+i++;
+i++;
+i++;
+console.log(i);//ts file


### PR DESCRIPTION
Relates to #1424.

@connor4312 I created a small PR. I was a bit lost in the code base. The whole SourceContainer has so much state that I could not get a unit test running. I then just added a test and checked that the `fetchHttp` is called and the sources are really loaded from the local host.

The behaviour in the `getComputedSourceRoot` is now a bit inconsistent for the `file://` the protocol  is removed and later added, which should of course not happen if it is a `http://` source. A proper solution would perhaps to have an object not only a string for the URL. Then the object could hold the information I am `file`, `data`, `http`, `ftp` or whatever.

I did not want to change much so I added just minimal checks.