### PR TITLE
feat: support console.profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 - feat: add automatic support for nested sourcemaps ([#1390](https://github.com/microsoft/vscode-js-debug/issues/1390))
 - feat: add an `ignoreLaunchArgs` option ([vscode#162957](https://github.com/microsoft/vscode/issues/162957))
+- feat: add support for `console.profile` ([#1443](https://github.com/microsoft/vscode-js-debug/issues/1443))
 - fix: copying a date object resulting in an empty object ([vscode#162747](https://github.com/microsoft/vscode/issues/162747))
 - fix: improve performance when using skipFiles in large projects ([#1179](https://github.com/microsoft/vscode-js-debug/issues/1179))
 - fix: breakpoints failing to set on paths with multibyte URL characters ([#1364](https://github.com/microsoft/vscode-js-debug/issues/1364))

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -20,6 +20,7 @@ import { ProtocolError } from '../dap/protocolError';
 import { disposeContainer, FS, FsPromises } from '../ioc-extras';
 import { ITarget } from '../targets/targets';
 import { ITelemetryReporter } from '../telemetry/telemetryReporter';
+import { IShutdownParticipants } from '../ui/shutdownParticipants';
 import { IAsyncStackPolicy } from './asyncStackPolicy';
 import { BreakpointManager } from './breakpoints';
 import { ICdpProxyProvider } from './cdpProxy';
@@ -437,6 +438,7 @@ export class DebugAdapter implements IDisposable {
       this._services.get(IConsole),
       this._services.get(IExceptionPauseService),
       this._services.get(SmartStepper),
+      this._services.get(IShutdownParticipants),
     );
 
     const profile = this._services.get<IProfileController>(IProfileController);

--- a/src/adapter/profiling/index.ts
+++ b/src/adapter/profiling/index.ts
@@ -92,6 +92,24 @@ export interface IProfilerFactory {
 }
 
 /**
+ * Gets a default profile file name (without an extension)
+ */
+export const getDefaultProfileName = () => {
+  const now = new Date();
+  return [
+    'vscode-profile',
+    now.getFullYear(),
+    now.getMonth() + 1,
+    now.getDate(),
+    now.getHours(),
+    now.getMinutes(),
+    now.getSeconds(),
+  ]
+    .map(n => String(n).padStart(2, '0'))
+    .join('-');
+};
+
+/**
  * Simple class that gets profilers
  */
 @injectable()

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -113,6 +113,7 @@ import { IExperimentationService } from './telemetry/experimentationService';
 import { NullExperimentationService } from './telemetry/nullExperimentationService';
 import { NullTelemetryReporter } from './telemetry/nullTelemetryReporter';
 import { ITelemetryReporter } from './telemetry/telemetryReporter';
+import { IShutdownParticipants, ShutdownParticipants } from './ui/shutdownParticipants';
 
 /**
  * Contains IOC container factories for the extension. We use Inverisfy, which
@@ -184,7 +185,8 @@ export const createTargetContainer = (
   container.bind(IExceptionPauseService).to(ExceptionPauseService).inSingletonScope();
   container.bind(ICompletions).to(Completions).inSingletonScope();
   container.bind(IEvaluator).to(Evaluator).inSingletonScope();
-  container.bind(IConsole).to(Console).inSingletonScope(); // dispose is handled by the Thread
+  container.bind(IConsole).to(Console).inSingletonScope();
+  container.bind(IShutdownParticipants).to(ShutdownParticipants).inSingletonScope();
 
   container.bind(BasicCpuProfiler).toSelf();
   container.bind(BasicHeapProfiler).toSelf();

--- a/src/targets/node/subprocessProgramLauncher.ts
+++ b/src/targets/node/subprocessProgramLauncher.ts
@@ -34,7 +34,7 @@ export class SubprocessProgramLauncher implements IProgramLauncher {
     // the terminal, for cosmetic purposes.
     context.dap.output({
       category: 'console',
-      output: [executable, ...args].join(' '),
+      output: [executable, ...args].join(' ') + '\n',
     });
 
     const child = spawn(executable, args, {

--- a/src/ui/profiling/uiProfileManager.ts
+++ b/src/ui/profiling/uiProfileManager.ts
@@ -7,7 +7,7 @@ import { homedir } from 'os';
 import { basename, join } from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { ProfilerFactory } from '../../adapter/profiling';
+import { getDefaultProfileName, ProfilerFactory } from '../../adapter/profiling';
 import { Commands, ContextKey, setContextKey } from '../../common/contributionUtils';
 import { DisposableList, IDisposable } from '../../common/disposable';
 import { moveFile } from '../../common/fsUtils';
@@ -234,20 +234,7 @@ export class UiProfileManager implements IDisposable {
       vscode.workspace.workspaceFolders?.[0].uri.fsPath ??
       homedir();
 
-    const now = new Date();
-    const filename =
-      [
-        'vscode-profile',
-        now.getFullYear(),
-        now.getMonth() + 1,
-        now.getDate(),
-        now.getHours(),
-        now.getMinutes(),
-        now.getSeconds(),
-      ]
-        .map(n => String(n).padStart(2, '0'))
-        .join('-') + uiSession.impl.extension;
-
+    const filename = getDefaultProfileName() + uiSession.impl.extension;
     // todo: open as untitled, see: https://github.com/microsoft/vscode/issues/93441
     const fileUri = vscode.Uri.file(join(directory, filename));
     await moveFile(this.fs, sourceFile, fileUri.fsPath);

--- a/src/ui/shutdownParticipants.ts
+++ b/src/ui/shutdownParticipants.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { injectable } from 'inversify';
+import { IDisposable, noOpDisposable } from '../common/disposable';
+
+/** Order of shutdown participants. */
+export const enum ShutdownOrder {
+  // Participant is awaited before loaded scripts are cleared.
+  BeforeScripts = 0,
+  // Participant is run after everything else.
+  Final = 1,
+}
+
+export interface IShutdownParticipants {
+  /**
+   * Registers the function to be called in the specified order.
+   */
+  register(order: ShutdownOrder, p: () => Promise<void>): IDisposable;
+
+  /**
+   * Runs all shutdown participants.
+   */
+  shutdown(): Promise<void>;
+}
+
+export const IShutdownParticipants = Symbol('IShutdownParticipants');
+
+@injectable()
+export class ShutdownParticipants implements IShutdownParticipants {
+  private participants: Set<() => Promise<void>>[] = [];
+  private shutdownStage: ShutdownOrder | undefined;
+
+  register(order: ShutdownOrder, p: () => Promise<void>): IDisposable {
+    if (this.shutdownStage !== undefined && this.shutdownStage >= order) {
+      p();
+      return noOpDisposable;
+    }
+
+    while (this.participants.length <= order) {
+      this.participants.push(new Set());
+    }
+
+    this.participants[order].add(p);
+    return { dispose: () => this.participants[order].delete(p) };
+  }
+
+  async shutdown(): Promise<void> {
+    for (
+      this.shutdownStage = 0;
+      this.shutdownStage < this.participants.length;
+      this.shutdownStage++
+    ) {
+      await Promise.all([...this.participants[this.shutdownStage]].map(p => p()));
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1443

By default, the profile is saved (using a date-stamped name) in the workspace folder. If the user gives the profile a name by passing an argument to `console.profile`, then that is appended with .cpuprofile and used instead.