### PR TITLE
fix: use platform preferred case in launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: properly handle UNC paths ([#1148](https://github.com/microsoft/vscode-js-debug/issues/1148))
 - fix: discover npm scripts in nested workspace folders ([#1321](https://github.com/microsoft/vscode-js-debug/issues/1321))
 - chore: loosen restriction around enabling auto attach ([#1392](https://github.com/microsoft/vscode-js-debug/issues/1392))
+- fix: use platform preferred case in launcher ([#1448](https://github.com/microsoft/vscode-js-debug/1448)) Contributed on behalf of STMicroelectronics
 
 ## v1.72 (September 2022)
 

--- a/src/targets/node/subprocessProgramLauncher.ts
+++ b/src/targets/node/subprocessProgramLauncher.ts
@@ -6,6 +6,7 @@ import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { inject, injectable } from 'inversify';
 import { EnvironmentVars } from '../../common/environmentVars';
 import { ILogger } from '../../common/logging';
+import * as urlUtils from '../../common/urlUtils';
 import { INodeLaunchConfiguration, OutputSource } from '../../configuration';
 import Dap from '../../dap/api';
 import { ILaunchContext } from '../targets';
@@ -28,7 +29,11 @@ export class SubprocessProgramLauncher implements IProgramLauncher {
     config: INodeLaunchConfiguration,
     context: ILaunchContext,
   ) {
-    const { executable, args, shell } = formatArguments(binary, getNodeLaunchArgs(config));
+    const { executable, args, shell, cwd } = formatArguments(
+      binary,
+      getNodeLaunchArgs(config),
+      config.cwd,
+    );
 
     // Send an appoximation of the command we're running to
     // the terminal, for cosmetic purposes.
@@ -39,7 +44,7 @@ export class SubprocessProgramLauncher implements IProgramLauncher {
 
     const child = spawn(executable, args, {
       shell,
-      cwd: config.cwd,
+      cwd: cwd,
       env: EnvironmentVars.merge(EnvironmentVars.processEnv(), config.env).defined(),
     });
 
@@ -111,14 +116,19 @@ export class SubprocessProgramLauncher implements IProgramLauncher {
 // Fix for: https://github.com/microsoft/vscode/issues/45832,
 // which still seems to be a thing according to the issue tracker.
 // From: https://github.com/microsoft/vscode-node-debug/blob/47747454bc6e8c9e48d8091eddbb7ffb54a19bbe/src/node/nodeDebug.ts#L1120
-const formatArguments = (executable: string, args: ReadonlyArray<string>) => {
-  if (process.platform === 'win32' && executable.endsWith('.ps1')) {
-    args = ['-File', executable, ...args];
-    executable = 'powershell.exe';
+const formatArguments = (executable: string, args: ReadonlyArray<string>, cwd: string) => {
+  if (process.platform === 'win32') {
+    executable = urlUtils.platformPathToPreferredCase(executable);
+    cwd = urlUtils.platformPathToPreferredCase(cwd);
+
+    if (executable.endsWith('.ps1')) {
+      args = ['-File', executable, ...args];
+      executable = 'powershell.exe';
+    }
   }
 
   if (process.platform !== 'win32' || !executable.includes(' ')) {
-    return { executable, args, shell: false };
+    return { executable, args, shell: false, cwd };
   }
 
   let foundArgWithSpace = false;
@@ -135,8 +145,8 @@ const formatArguments = (executable: string, args: ReadonlyArray<string>) => {
   }
 
   if (foundArgWithSpace) {
-    return { executable: `"${executable}"`, args: output, shell: true };
+    return { executable: `"${executable}"`, args: output, shell: true, cwd: cwd };
   }
 
-  return { executable, args, shell: false };
+  return { executable, args, shell: false, cwd };
 };


### PR DESCRIPTION
Launching NodeJS processes on Windows requires us to handle casing of drive letters carefully because NodeJS is case sensitive.

The already existing utility function `urlUtils.platformPathToPreferredCase()` is used to adjust paths of the executable and the current working directory.

Fixes https://github.com/microsoft/vscode-js-debug/issues/1448

Contributed on behalf of STMicroelectronics

Signed-off-by: Olaf Lessenich <olessenich@eclipsesource.com>