### PR TITLE
fix: debugger freeze with self-referential sourcemaps

### DIFF
--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -1087,6 +1087,14 @@ export class SourceContainer {
         : map.computedSourceUrl(url);
 
       const existing = this._sourceMapSourcesByUrl.get(resolvedUrl);
+      // fix: some modules, like the current version of the 1DS SDK, managed to
+      // generate self-referential sourcemaps (sourcemaps with sourcesContent that
+      // have a sourceMappingUrl that refer to the same file). Avoid adding those
+      // in this check.
+      if (compiled === existing) {
+        continue;
+      }
+
       if (existing) {
         // In the case of a Webpack HMR, remove the old source entirely and
         // replace it with the new one.


### PR DESCRIPTION
Repro:

1. Debug an extension, like the hex editor, which use the 1DS SDK
2. Notice the debugger hard freezes

This is the result of sourcemaps like the following, which reference
themselves in the sourcesContent:

```json
{"version":3,"file":"IChannelControls.js.map","sources":["IChannelControls.js"],"sourcesContent":["\"use strict\";\r\nexport var MinChannelPriorty = 100;\r\n//# sourceMappingURL=IChannelControls.js.map"],"names":[],"mappings":";;;;AAAA;AACA;AACA"}
```

This 'broke' when we added support for nested sourcemap resolution.