### PR TITLE
Bump the timeout of setting the auto attach child processes env vars in extensionHost debugging

### DIFF
--- a/src/targets/node/extensionHostAttacher.ts
+++ b/src/targets/node/extensionHostAttacher.ts
@@ -149,7 +149,7 @@ export class ExtensionHostAttacher extends NodeAttacherBase<IExtensionHostAttach
       { openerId: targetId },
     );
 
-    for (let retries = 0; retries < 5; retries++) {
+    for (let retries = 0; retries < 200; retries++) {
       const result = await cdp.Runtime.evaluate({
         contextId: 1,
         returnByValue: true,


### PR DESCRIPTION
This might still race if the extension host starts proccesses fast enough, but that's a separate issue

Fixes #1374