### PR TITLE
fix: skipFiles creating catastrophic regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - fix: breakpoints not setting in paths with special glob characters ([vscode#166400](https://github.com/microsoft/vscode/issues/166400))
+- fix: skipFiles making catastrophic regexes ([#1469](https://github.com/microsoft/vscode-js-debug/issues/1469))
 
 ## v1.74 (November 2022)
 

--- a/src/adapter/scriptSkipper/simpleGlobToRe.test.ts
+++ b/src/adapter/scriptSkipper/simpleGlobToRe.test.ts
@@ -2,10 +2,11 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { expect } from 'chai';
 import { simpleGlobsToRe } from './simpleGlobToRe';
 
 describe('simpleGlobsToRe', () => {
-  const tt = [
+  const truthTable = [
     {
       globs: ['**/foo/**'],
       matches: {
@@ -47,7 +48,7 @@ describe('simpleGlobsToRe', () => {
     },
   ];
 
-  for (const { globs, matches } of tt) {
+  for (const { globs, matches } of truthTable) {
     it(globs.join(', '), () => {
       const res = simpleGlobsToRe(globs);
       for (const [url, expected] of Object.entries(matches)) {
@@ -60,6 +61,21 @@ describe('simpleGlobsToRe', () => {
           }
         }
       }
+    });
+
+    it(`is not catastrophic: ${globs.join(', ')}`, () => {
+      const testStr =
+        'file:///users/connor/github/vscode-remotehub/common/node_modules/%40opentelemetry/api/build/esm/trace/internal/../../../../src/trace/internal/tracestate-validators.ts';
+      const res = simpleGlobsToRe(globs);
+
+      const start = performance.now();
+      for (let i = 0; i < 100; i++) {
+        for (const re of res) {
+          re.test(testStr);
+        }
+      }
+
+      expect(performance.now() - start).to.be.lessThan(500);
     });
   }
 });

--- a/src/adapter/scriptSkipper/simpleGlobToRe.ts
+++ b/src/adapter/scriptSkipper/simpleGlobToRe.ts
@@ -43,7 +43,13 @@ function globToRe(glob: string) {
   for (let j = 0; j < parts.length; j++) {
     const p = parts[j];
     if (p === '**') {
-      regexParts.push('(.+(\\/|$))*');
+      if (j === 0) {
+        regexParts.push('(.+/)?'); // match start, or any slash preceeding what's next...
+      } else if (j === parts.length - 1) {
+        // nothing more needed!
+      } else {
+        regexParts.push('.*/');
+      }
     } else {
       if (p.includes('*')) {
         const wildcards = p.split('*');
@@ -51,11 +57,10 @@ function globToRe(glob: string) {
       } else {
         regexParts.push(escapeRegexSpecialChars(p));
       }
-      if (j < parts.length - 1) {
-        regexParts.push('\\/');
-      }
+
+      regexParts.push(j < parts.length - 1 ? '\\/' : '$');
     }
   }
 
-  return `^${regexParts.join('')}$`;
+  return `^${regexParts.join('')}`;
 }


### PR DESCRIPTION
The default skipFiles for extension host debugging create a pair of
regexes, which compile down to something like:

```
/^(.+(\\/|$))*node_modules\\.asar\\/(.+(\\/|$))*$/i
```

The former part of this regex is a catastrophic lookahead, taking ~250ms
to test against the string included in the unit tests in this PR.

This fixes that and also adds a sanity unit test to ensure regexes run
reasonably fast.

Fixes https://github.com/microsoft/vscode-js-debug/issues/1469