### PR TITLE
fix: perScriptSourcemaps not reliably breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 - fix: breakpoints not setting in paths with special glob characters ([vscode#166400](https://github.com/microsoft/vscode/issues/166400))
 - fix: skipFiles making catastrophic regexes ([#1469](https://github.com/microsoft/vscode-js-debug/issues/1469))
+- fix: perScriptSourcemaps not reliably breaking ([vscode#166369](https://github.com/microsoft/vscode/issues/166369))
 
 ## v1.74 (November 2022)
 

--- a/src/adapter/breakpoints/entryBreakpoint.ts
+++ b/src/adapter/breakpoints/entryBreakpoint.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------*/
 
 import { basename, extname } from 'path';
+import { escapeRegexSpecialChars } from '../../common/stringUtils';
 import Dap from '../../dap/api';
 import { BreakpointManager, EntryBreakpointMode } from '../breakpoints';
 import { Thread } from '../threads';
@@ -35,7 +36,7 @@ export class EntryBreakpoint extends Breakpoint {
 
     const key = EntryBreakpoint.getModeKeyForSource(this.mode, this.source.path);
     return this.mode === EntryBreakpointMode.Greedy
-      ? super._setByUrl(thread, key, lineColumn)
+      ? super._setByUrlRegexp(thread, escapeRegexSpecialChars(key), lineColumn)
       : super._setByPath(thread, lineColumn);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/166369

At one point the implementation of _setByUrl changed which broke that.