### PR TITLE
fix: improve repl/variable/completion performance for TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: perScriptSourcemaps not reliably breaking ([vscode#166369](https://github.com/microsoft/vscode/issues/166369))
 - fix: custom object `toString()` previews being too short ([vscode#155142](https://github.com/microsoft/vscode/issues/155142))
 - fix: show warning if console output length is hit ([vscode#154479](https://github.com/microsoft/vscode/issues/154479))
+- fix: improve variable and repl performance in large projects ([#1433](https://github.com/microsoft/vscode-js-debug/issues/1433))
 
 ## v1.74 (November 2022)
 

--- a/src/adapter/completions.ts
+++ b/src/adapter/completions.ts
@@ -324,7 +324,7 @@ export class Completions {
         ...params,
         returnByValue: true,
         throwOnSideEffect: false,
-        expression: enumeratePropertiesTemplate(
+        expression: enumeratePropertiesTemplate.expr(
           `(${expression})`,
           JSON.stringify(prefix),
           JSON.stringify(isInGlobalScope),

--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -482,7 +482,7 @@ export class StackFrame implements IFrameElement {
           const variables = await variableStore.getVariableNames({
             variablesReference: scopeVariable.id,
           });
-          return variables.map(label => ({ label: label, type: 'property' }));
+          return variables.map(label => ({ label, type: 'property' }));
         }),
       );
     }

--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -468,7 +468,7 @@ export class StackFrame implements IFrameElement {
     return (scope.variables[scopeNumber] = variable);
   }
 
-  async completions(): Promise<Dap.CompletionItem[]> {
+  public readonly completions = once(async (): Promise<Dap.CompletionItem[]> => {
     if (!this._scope) return [];
     const variableStore = this._thread.pausedVariables();
     if (!variableStore) {
@@ -479,14 +479,14 @@ export class StackFrame implements IFrameElement {
     for (let scopeNumber = 0; scopeNumber < this._scope.chain.length; scopeNumber++) {
       promises.push(
         this._scopeVariable(scopeNumber, this._scope).then(async scopeVariable => {
-          const variables = await variableStore.getVariables({
+          const variables = await variableStore.getVariableNames({
             variablesReference: scopeVariable.id,
           });
-          return variables.map(variable => ({ label: variable.name, type: 'property' }));
+          return variables.map(label => ({ label: label, type: 'property' }));
         }),
       );
     }
     const completions = await Promise.all(promises);
     return ([] as Dap.CompletionItem[]).concat(...completions);
-  }
+  });
 }

--- a/src/adapter/templates/getStringyProps.ts
+++ b/src/adapter/templates/getStringyProps.ts
@@ -28,7 +28,7 @@ export const getStringyProps = templateFunction(function (
           continue;
         }
       } catch (e) {
-        out[key] = `${e} (couldn't describe ${key})`;
+        out[key] = `<<indescribable>>${JSON.stringify([String(e), key])}`;
         continue;
       }
     }
@@ -58,7 +58,7 @@ export const getToStringIfCustom = templateFunction(function (
         return String(repr);
       }
     } catch (e) {
-      return `${e} (couldn't describe object)`;
+      return `<<indescribable>>${JSON.stringify([String(e), 'object'])}`;
     }
   }
 

--- a/src/adapter/templates/getStringyProps.ts
+++ b/src/adapter/templates/getStringyProps.ts
@@ -2,23 +2,42 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { remoteFunction } from '.';
+import { templateFunction } from '.';
 
 /**
  * Gets a mapping of property names with a custom `.toString()` method
  * to their string representations.
  */
-export const getStringyProps = remoteFunction(function (this: unknown, maxLength: number) {
+export const getStringyProps = templateFunction(function (
+  this: unknown,
+  maxLength: number,
+  customToString: (defaultRepr: string) => unknown,
+) {
   const out: Record<string, string> = {};
+  const defaultPlaceholder = '<<default preview>>';
   if (typeof this !== 'object' || !this) {
     return out;
   }
 
   for (const [key, value] of Object.entries(this)) {
+    if (customToString) {
+      try {
+        const repr = customToString.call(value, defaultPlaceholder);
+        if (repr !== defaultPlaceholder) {
+          out[key] = String(repr);
+          continue;
+        }
+      } catch (e) {
+        out[key] = `${e} (couldn't describe ${key})`;
+        continue;
+      }
+    }
+
     if (typeof value === 'object' && value && !String(value.toString).includes('[native code]')) {
       const str = String(value);
       if (!str.startsWith('[object ')) {
         out[key] = str.length >= maxLength ? str.slice(0, maxLength) + '…' : str;
+        continue;
       }
     }
   }
@@ -26,7 +45,23 @@ export const getStringyProps = remoteFunction(function (this: unknown, maxLength
   return out;
 });
 
-export const getToStringIfCustom = remoteFunction(function (this: unknown, maxLength: number) {
+export const getToStringIfCustom = templateFunction(function (
+  this: unknown,
+  maxLength: number,
+  customToString: (defaultRepr: string) => unknown,
+) {
+  if (customToString) {
+    try {
+      const defaultPlaceholder = '<<default preview>>';
+      const repr = customToString.call(this, defaultPlaceholder);
+      if (repr !== defaultPlaceholder) {
+        return String(repr);
+      }
+    } catch (e) {
+      return `${e} (couldn't describe object)`;
+    }
+  }
+
   if (typeof this === 'object' && this && !String(this.toString).includes('[native code]')) {
     const str = String(this);
     if (!str.startsWith('[object ')) {

--- a/src/adapter/templates/serializeForClipboard.ts
+++ b/src/adapter/templates/serializeForClipboard.ts
@@ -141,7 +141,7 @@ export const serializeForClipboardTmpl = templateFunction(function (
 
 export const serializeForClipboard = remoteFunction<[number], string>(`
   function(spaces2) {
-    const result = ${serializeForClipboardTmpl('this', 'spaces2')};
+    const result = ${serializeForClipboardTmpl.expr('this', 'spaces2')};
     return result;
   }
 `);

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -471,7 +471,7 @@ export class Thread implements IVariableStoreLocationProvider {
     const params: Cdp.Runtime.EvaluateParams =
       args.context === 'clipboard'
         ? {
-            expression: serializeForClipboardTmpl(args.expression, '2'),
+            expression: serializeForClipboardTmpl.expr(args.expression, '2'),
             includeCommandLineAPI: true,
             returnByValue: true,
             objectGroup: 'console',

--- a/src/test/variables/variables-object-customdescriptiongenerator-shows-errors.txt
+++ b/src/test/variables/variables-object-customdescriptiongenerator-shows-errors.txt
@@ -1,0 +1,3 @@
+> result: Error: oh no! (couldn't describe: object)
+    > getter: (...)
+    > [[Prototype]]: Foo

--- a/src/test/variables/variables-object-customdescriptiongenerator-using-function-declaration.txt
+++ b/src/test/variables/variables-object-customdescriptiongenerator-using-function-declaration.txt
@@ -1,3 +1,3 @@
 > result: using function: Instance of bar
     > getter: (...)
-    > [[Prototype]]: using function: Instance of bar
+    > [[Prototype]]: Foo

--- a/src/test/variables/variables-object-customdescriptiongenerator-using-statement-syntax.txt
+++ b/src/test/variables/variables-object-customdescriptiongenerator-using-statement-syntax.txt
@@ -1,3 +1,3 @@
 > result: using statement: Instance of bar
     > getter: (...)
-    > [[Prototype]]: using statement: Instance of bar
+    > [[Prototype]]: Foo

--- a/src/test/variables/variables-object-customdescriptiongenerator-using-statement-with-return-syntax.txt
+++ b/src/test/variables/variables-object-customdescriptiongenerator-using-statement-with-return-syntax.txt
@@ -1,3 +1,3 @@
 > result: using statement return: Instance of bar
     > getter: (...)
-    > [[Prototype]]: using statement return: Instance of bar
+    > [[Prototype]]: Foo

--- a/src/test/variables/variables-object-customdescriptiongenerator-with-arrays.txt
+++ b/src/test/variables/variables-object-customdescriptiongenerator-with-arrays.txt
@@ -1,8 +1,8 @@
-> result: I'm an array
+> result: (4) [Bar, Foo, 5, 'test']
     > 0: Instance of bar
     > 1: Foo
     2: 5
     3: 'test'
     length: 4
-    > [[Prototype]]: I'm an array
+    > [[Prototype]]: Array(0)
     > [[Prototype]]: Object

--- a/src/test/variables/variablesTest.ts
+++ b/src/test/variables/variablesTest.ts
@@ -108,6 +108,18 @@ describe('variables', () => {
         p.assertLog();
       });
 
+      itIntegrates('shows errors', async ({ r }) => {
+        const p = await r.launchAndLoad('blank', {
+          customDescriptionGenerator:
+            'function (def) { if (this.customDescription) throw new Error("oh no!"); else return def }',
+        });
+        await p.logger.evaluateAndLog(`
+          class Foo { get getter() {} }
+          class Bar extends Foo { customDescription() { return 'Instance of bar'} }
+          new Bar();`);
+        p.assertLog();
+      });
+
       itIntegrates('using statement syntax', async ({ r }) => {
         const p = await r.launchAndLoad('blank', {
           customDescriptionGenerator:


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-js-debug/issues/1433

There were a couple problems:

- TS uses a `customDescriptionGenerator`. Previously this was being invoked on each individual property. I've merged this with the logic we added for custom `toString()` representations, so that we run it only once for an object and return a map of its properties.
- TS has thousands of variables in each scope. We call `Runtime.getProperties` to get scope variables to use in completions. It seems like getProperties, which does not have any 'limit' parameter, is blocking. We still need this to do sensible completions, but now each stacktrace caches its completions instead of getting new ones on every request.

With these changes, there may still be a little REPL stall on the first evaluation (until the first completions call finishes, which takes 3-5s on my macbook), but after that it should be appropriately snappy.