### PR TITLE
fix: better handling of multiple/relative outFiles

### DIFF
--- a/.ci/pipeline.yml
+++ b/.ci/pipeline.yml
@@ -14,7 +14,7 @@ jobs:
 
 - job: Linux
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - template: common-validation.yml
   variables:
@@ -22,7 +22,7 @@ jobs:
 
 - job: LinuxMinspec
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - template: common-validation.yml
   variables:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - fix: breakpoints not setting in paths with special glob characters ([vscode#166400](https://github.com/microsoft/vscode/issues/166400))
+- fix: better handling of multiple glob patterns and negations ([#1479](https://github.com/microsoft/vscode-js-debug/issues/1479))
 - fix: skipFiles making catastrophic regexes ([#1469](https://github.com/microsoft/vscode-js-debug/issues/1469))
 - fix: perScriptSourcemaps not reliably breaking ([vscode#166369](https://github.com/microsoft/vscode/issues/166369))
 - fix: custom object `toString()` previews being too short ([vscode#155142](https://github.com/microsoft/vscode/issues/155142))

--- a/src/adapter/breakpointPredictor.ts
+++ b/src/adapter/breakpointPredictor.ts
@@ -211,7 +211,7 @@ export class BreakpointsPredictor implements IBreakpointsPredictor {
       this.logger.warn(LogTag.RuntimeSourceMap, 'Long breakpoint predictor runtime', {
         type: this.repo.constructor.name,
         longPredictionWarning,
-        patterns: this.outFiles.patterns,
+        patterns: [...this.outFiles.explode()].join(', '),
       });
     }, longPredictionWarning);
 

--- a/src/common/sourceMaps/nodeSearchStrategy.ts
+++ b/src/common/sourceMaps/nodeSearchStrategy.ts
@@ -6,7 +6,7 @@ import globStream from 'glob-stream';
 import { inject, injectable } from 'inversify';
 import { FileGlobList } from '../fileGlobList';
 import { ILogger, LogTag } from '../logging';
-import { fixDriveLetterAndSlashes, forceForwardSlashes } from '../pathUtils';
+import { fixDriveLetterAndSlashes } from '../pathUtils';
 import { ISourceMapMetadata } from './sourceMap';
 import { createMetadataForFile, ISearchStrategy } from './sourceMapRepository';
 
@@ -26,13 +26,8 @@ export class NodeSearchStrategy implements ISearchStrategy {
   ): Promise<T[]> {
     const todo: (T | Promise<T>)[] = [];
 
-    await new Promise((resolve, reject) =>
-      this.globForFiles(files)
-        .on('data', (value: globStream.Entry) =>
-          todo.push(onChild(fixDriveLetterAndSlashes(value.path))),
-        )
-        .on('finish', resolve)
-        .on('error', reject),
+    await this.globForFiles(files, value =>
+      todo.push(onChild(fixDriveLetterAndSlashes(value.path))),
     );
 
     // Type annotation is necessary for https://github.com/microsoft/TypeScript/issues/47144
@@ -49,22 +44,17 @@ export class NodeSearchStrategy implements ISearchStrategy {
   ): Promise<T[]> {
     const todo: (T | Promise<T | void>)[] = [];
 
-    await new Promise((resolve, reject) =>
-      this.globForFiles(files)
-        .on('data', (value: globStream.Entry) =>
-          todo.push(
-            createMetadataForFile(fixDriveLetterAndSlashes(value.path))
-              .then(parsed => parsed && onChild(parsed))
-              .catch(error =>
-                this.logger.warn(LogTag.SourceMapParsing, 'Error parsing source map', {
-                  error,
-                  file: value.path,
-                }),
-              ),
+    await this.globForFiles(files, value =>
+      todo.push(
+        createMetadataForFile(fixDriveLetterAndSlashes(value.path))
+          .then(parsed => parsed && onChild(parsed))
+          .catch(error =>
+            this.logger.warn(LogTag.SourceMapParsing, 'Error parsing source map', {
+              error,
+              file: value.path,
+            }),
           ),
-        )
-        .on('finish', resolve)
-        .on('error', reject),
+      ),
     );
 
     // Type annotation is necessary for https://github.com/microsoft/TypeScript/issues/47144
@@ -72,19 +62,30 @@ export class NodeSearchStrategy implements ISearchStrategy {
     return results.filter((t): t is T => t !== undefined);
   }
 
-  private globForFiles(files: FileGlobList) {
-    return globStream(
-      [
-        ...files.patterns.map(forceForwardSlashes),
-        // Avoid reading asar files: electron patches in support for them, but
-        // if we see an invalid one then it throws a synchronous error that
-        // breaks glob. We don't care about asar's here, so just skip that:
-        '!**/*.asar/**',
-      ],
-      {
-        matchBase: true,
-        cwd: files.rootPath,
-      },
+  private async globForFiles(files: FileGlobList, onFile: (file: globStream.Entry) => void) {
+    await Promise.all(
+      [...files.explode()].map(
+        glob =>
+          new Promise((resolve, reject) =>
+            globStream(
+              [
+                glob.pattern,
+                // Avoid reading asar files: electron patches in support for them, but
+                // if we see an invalid one then it throws a synchronous error that
+                // breaks glob. We don't care about asar's here, so just skip that:
+                '!**/*.asar/**',
+              ],
+              {
+                ignore: glob.negations,
+                matchBase: true,
+                cwd: glob.cwd,
+              },
+            )
+              .on('data', onFile)
+              .on('finish', resolve)
+              .on('error', reject),
+          ),
+      ),
     );
   }
 }

--- a/src/test/common/sourceMapRepository.test.ts
+++ b/src/test/common/sourceMapRepository.test.ts
@@ -4,16 +4,16 @@
 
 import { expect } from 'chai';
 import { join } from 'path';
-import { testFixturesDir, workspaceFolder, testFixturesDirName } from '../test';
-import { createFileTree } from '../createFileTree';
-import { absolutePathToFileUrl } from '../../common/urlUtils';
 import * as vscode from 'vscode';
-import { fixDriveLetter } from '../../common/pathUtils';
-import { NodeSearchStrategy } from '../../common/sourceMaps/nodeSearchStrategy';
-import { CodeSearchStrategy } from '../../common/sourceMaps/codeSearchStrategy';
-import { Logger } from '../../common/logging/logger';
-import { ISearchStrategy } from '../../common/sourceMaps/sourceMapRepository';
 import { FileGlobList } from '../../common/fileGlobList';
+import { Logger } from '../../common/logging/logger';
+import { fixDriveLetter } from '../../common/pathUtils';
+import { CodeSearchStrategy } from '../../common/sourceMaps/codeSearchStrategy';
+import { NodeSearchStrategy } from '../../common/sourceMaps/nodeSearchStrategy';
+import { ISearchStrategy } from '../../common/sourceMaps/sourceMapRepository';
+import { absolutePathToFileUrl } from '../../common/urlUtils';
+import { createFileTree } from '../createFileTree';
+import { testFixturesDir, testFixturesDirName, workspaceFolder } from '../test';
 
 describe('ISourceMapRepository', () => {
   [
@@ -52,29 +52,30 @@ describe('ISourceMapRepository', () => {
           patterns: [`${firstIncludeSegment}/**/*.js`, '!**/node_modules/**'],
         });
 
-      const gatherSm = (rootPath: string, firstIncludeSegment: string) => {
-        return r
-          .streamChildrenWithSourcemaps(gatherFileList(rootPath, firstIncludeSegment), async m => {
-            const { cacheKey, ...rest } = m;
-            expect(cacheKey).to.be.within(Date.now() - 60 * 1000, Date.now() + 1000);
-            rest.compiledPath = fixDriveLetter(rest.compiledPath);
-            return rest;
-          })
-          .then(r => r.sort((a, b) => a.compiledPath.length - b.compiledPath.length));
+      const gatherSm = async (list: FileGlobList) => {
+        const result = await r.streamChildrenWithSourcemaps(list, async m => {
+          const { cacheKey, ...rest } = m;
+          expect(cacheKey).to.be.within(Date.now() - 60 * 1000, Date.now() + 1000);
+          rest.compiledPath = fixDriveLetter(rest.compiledPath);
+          return rest;
+        });
+        return result.sort((a, b) => a.compiledPath.length - b.compiledPath.length);
+      };
+      const gatherSmNames = async (list: FileGlobList) => {
+        const result = await gatherSm(list);
+        return result.map(r => r.compiledPath);
       };
 
-      const gatherAll = (rootPath: string, firstIncludeSegment: string) => {
-        return r
-          .streamAllChildren(gatherFileList(rootPath, firstIncludeSegment), m => m)
-          .then(r => r.sort());
+      const gatherAll = (list: FileGlobList) => {
+        return r.streamAllChildren(list, m => m).then(r => r.sort());
       };
 
       it('no-ops for non-existent directories', async () => {
-        expect(await gatherSm(__dirname, 'does-not-exist')).to.be.empty;
+        expect(await gatherSm(gatherFileList(__dirname, 'does-not-exist'))).to.be.empty;
       });
 
       it('discovers source maps and applies negated globs', async () => {
-        expect(await gatherSm(workspaceFolder, testFixturesDirName)).to.deep.equal([
+        expect(await gatherSm(gatherFileList(workspaceFolder, testFixturesDirName))).to.deep.equal([
           {
             compiledPath: fixDriveLetter(join(testFixturesDir, 'a.js')),
             sourceMapUrl: absolutePathToFileUrl(join(testFixturesDir, 'a.js.map')),
@@ -92,28 +93,95 @@ describe('ISourceMapRepository', () => {
         ]);
       });
 
-      it('streams all children', async () => {
-        expect(await gatherAll(workspaceFolder, testFixturesDirName)).to.deep.equal([
-          fixDriveLetter(join(testFixturesDir, 'a.js')),
-          fixDriveLetter(join(testFixturesDir, 'c.js')),
-          fixDriveLetter(join(testFixturesDir, 'defaultSearchExcluded', 'f.js')),
-          fixDriveLetter(join(testFixturesDir, 'nested', 'd.js')),
+      it('applies second patterns (vscode#168635)', async () => {
+        createFileTree(testFixturesDir, {
+          rootPath: {
+            'd.js': '//# sourceMappingURL=d.js.map',
+            'd.js.map': 'content2',
+          },
+          otherFolder: {
+            'f.js': '//# sourceMappingURL=f.js.map',
+            'f.js.map': 'content3',
+          },
+        });
+
+        expect(
+          await gatherSmNames(
+            new FileGlobList({
+              patterns: ['rootPath/*.js', 'otherFolder/*.js'],
+              rootPath: testFixturesDir,
+            }),
+          ),
+        ).to.deep.equal([
+          fixDriveLetter(join(testFixturesDir, 'rootPath', 'd.js')),
+          fixDriveLetter(join(testFixturesDir, 'otherFolder', 'f.js')),
         ]);
       });
 
-      // todo: better absolute pathing support
-      if (tcase.name !== 'CodeSearchSourceMapRepository') {
-        it('greps inside node_modules explicitly', async () => {
-          expect(await gatherSm(join(testFixturesDir, 'node_modules'), '.')).to.deep.equal([
-            {
-              compiledPath: fixDriveLetter(join(testFixturesDir, 'node_modules', 'e.js')),
-              sourceMapUrl: absolutePathToFileUrl(
-                join(testFixturesDir, 'node_modules', 'e.js.map'),
-              ),
-            },
-          ]);
+      it('globs for a single file', async () => {
+        expect(
+          await gatherSmNames(
+            new FileGlobList({
+              patterns: ['nested/d.js'],
+              rootPath: testFixturesDir,
+            }),
+          ),
+        ).to.deep.equal([fixDriveLetter(join(testFixturesDir, 'nested', 'd.js'))]);
+      });
+
+      it('applies negated globs outside rootPath (#1479)', async () => {
+        // also tests https://github.com/microsoft/vscode/issues/104889#issuecomment-993722692
+        const nodeModules = {
+          'e.js': '//# sourceMappingURL=e.js.map',
+          'e.js.map': 'content3',
+        };
+        createFileTree(testFixturesDir, {
+          rootPath: {
+            'd.js': '//# sourceMappingURL=d.js.map',
+            'd.js.map': 'content2',
+            node_modules: nodeModules,
+          },
+          otherFolder: {
+            'f.js': '//# sourceMappingURL=f.js.map',
+            'f.js.map': 'content3',
+            node_modules: nodeModules,
+          },
         });
-      }
+
+        expect(
+          await gatherSmNames(
+            new FileGlobList({
+              patterns: ['**/*.js', '../otherFolder/**/*.js', '!**/node_modules/**'],
+              rootPath: join(testFixturesDir, 'rootPath'),
+            }),
+          ),
+        ).to.deep.equal([
+          fixDriveLetter(join(testFixturesDir, 'rootPath', 'd.js')),
+          fixDriveLetter(join(testFixturesDir, 'otherFolder', 'f.js')),
+        ]);
+      });
+
+      it('streams all children', async () => {
+        expect(await gatherAll(gatherFileList(workspaceFolder, testFixturesDirName))).to.deep.equal(
+          [
+            fixDriveLetter(join(testFixturesDir, 'a.js')),
+            fixDriveLetter(join(testFixturesDir, 'c.js')),
+            fixDriveLetter(join(testFixturesDir, 'defaultSearchExcluded', 'f.js')),
+            fixDriveLetter(join(testFixturesDir, 'nested', 'd.js')),
+          ],
+        );
+      });
+
+      it('greps inside node_modules explicitly', async () => {
+        expect(
+          await gatherSm(gatherFileList(join(testFixturesDir, 'node_modules'), '.')),
+        ).to.deep.equal([
+          {
+            compiledPath: fixDriveLetter(join(testFixturesDir, 'node_modules', 'e.js')),
+            sourceMapUrl: absolutePathToFileUrl(join(testFixturesDir, 'node_modules', 'e.js.map')),
+          },
+        ]);
+      });
     }),
   );
 });


### PR DESCRIPTION
Fixes #1479
Relates to https://github.com/microsoft/vscode/issues/168635

Previously, we naively joined all incoming globs together and ran a
single search for them. However, there are two problems:

- vscode's findTextInFiles doesn't really support multiple globs
- **-prefixed negations, like `!**/node_modules/**`, should apply
  everywhere, but globbing behavior is to only apply that to the base
  path, which led to confusion (#1479)

This PR redoes the logic. If there are N positive globs, we'll do N
searches in parallel, and apply relevant negations to each one.