### PR TITLE
Fix adding a breakpoint in a JS file while debugging a blazor app

### DIFF
--- a/src/targets/browser/blazorSourcePathResolver.ts
+++ b/src/targets/browser/blazorSourcePathResolver.ts
@@ -55,8 +55,8 @@ export class BlazorSourcePathResolver extends BrowserSourcePathResolver {
       // Blazor files have a file:/// url. Override the default absolutePathToUrlRegexp which returns an http based regexp
       const fileUrl = utils.absolutePathToFileUrl(absolutePath);
       const fileRegexp = utils.urlToRegex(fileUrl);
-      if (this.options.baseUrl)
-        return `${fileRegexp}|${super.absolutePathToUrlRegexp(absolutePath)}`;
+      const fileRegexpSuper = super.absolutePathToUrlRegexp(absolutePath);
+      if (!fileRegexp.includes(fileRegexpSuper)) return `${fileRegexp}|${fileRegexpSuper}`;
       return fileRegexp;
     }
 

--- a/src/targets/browser/blazorSourcePathResolver.ts
+++ b/src/targets/browser/blazorSourcePathResolver.ts
@@ -55,7 +55,7 @@ export class BlazorSourcePathResolver extends BrowserSourcePathResolver {
       // Blazor files have a file:/// url. Override the default absolutePathToUrlRegexp which returns an http based regexp
       const fileUrl = utils.absolutePathToFileUrl(absolutePath);
       const fileRegexp = utils.urlToRegex(fileUrl);
-      return fileRegexp;
+      return `${fileRegexp}|${super.absolutePathToUrlRegexp(absolutePath)}`;
     }
 
     return super.absolutePathToUrlRegexp(absolutePath);

--- a/src/targets/browser/blazorSourcePathResolver.ts
+++ b/src/targets/browser/blazorSourcePathResolver.ts
@@ -55,7 +55,9 @@ export class BlazorSourcePathResolver extends BrowserSourcePathResolver {
       // Blazor files have a file:/// url. Override the default absolutePathToUrlRegexp which returns an http based regexp
       const fileUrl = utils.absolutePathToFileUrl(absolutePath);
       const fileRegexp = utils.urlToRegex(fileUrl);
-      return `${fileRegexp}|${super.absolutePathToUrlRegexp(absolutePath)}`;
+      if (this.options.baseUrl)
+        return `${fileRegexp}|${super.absolutePathToUrlRegexp(absolutePath)}`;
+      return fileRegexp;
     }
 
     return super.absolutePathToUrlRegexp(absolutePath);

--- a/src/test/browser/blazorSourcePathResolverTest.ts
+++ b/src/test/browser/blazorSourcePathResolverTest.ts
@@ -57,7 +57,8 @@ describe('BlazorSourcePathResolver.absolutePathToUrlRegexp', () => {
     if (getCaseSensitivePaths()) {
       expect(regexp).to.equal(
         'file:\\/\\/\\/c\\/Users\\/digeff\\/source\\/repos\\/MyBlazorApp\\/MyBlazorApp\\/Pages\\/Counter\\.razor($|\\?)' +
-          '|\\/c\\/Users\\/digeff\\/source\\/repos\\/MyBlazorApp\\/MyBlazorApp\\/Pages\\/Counter\\.razor($|\\?)',
+          '|\\/c\\/Users\\/digeff\\/source\\/repos\\/MyBlazorApp\\/MyBlazorApp\\/Pages\\/Counter\\.razor($|\\?)' +
+          '|http:\\/\\/localhost:1234\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/c\\/Users\\/digeff\\/source\\/repos\\/MyBlazorApp/MyBlazorApp/Pages/Counter.razor($|?)',
       );
     } else {
       // This regexp was generated from running the real scenario, verifying that the breakpoint with this regexp works, and then copying it here

--- a/src/test/browser/blazorSourcePathResolverTest.ts
+++ b/src/test/browser/blazorSourcePathResolverTest.ts
@@ -58,7 +58,7 @@ describe('BlazorSourcePathResolver.absolutePathToUrlRegexp', () => {
       expect(regexp).to.equal(
         'file:\\/\\/\\/c\\/Users\\/digeff\\/source\\/repos\\/MyBlazorApp\\/MyBlazorApp\\/Pages\\/Counter\\.razor($|\\?)' +
           '|\\/c\\/Users\\/digeff\\/source\\/repos\\/MyBlazorApp\\/MyBlazorApp\\/Pages\\/Counter\\.razor($|\\?)' +
-          '|http:\\/\\/localhost:1234\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/c\\/Users\\/digeff\\/source\\/repos\\/MyBlazorApp/MyBlazorApp/Pages/Counter.razor($|?)',
+          '|http:\\/\\/localhost:1234\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/c\\/Users\\/digeff\\/source\\/repos\\/MyBlazorApp/MyBlazorApp/Pages/Counter.razor($|\\?)',
       );
     } else {
       // This regexp was generated from running the real scenario, verifying that the breakpoint with this regexp works, and then copying it here


### PR DESCRIPTION
When adding a breakpoint the urlRegex passed to a blazor app for a js app before this PR was:
"[fF][iI][lL][eE]:\\/\\/\\/[tT]:\\/[tT][hH][aA][yY][sS]\\/[oO][fF][fF][iI][cC][eE]-[aA][dD][dD]-[iI][nN]-[sS][aA][mM][pP][lL][eE][sS]\\/[sS][aA][mM][pP][lL][eE][sS]\\/[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\/[eE][xX][cC][eE][lL]-[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\/[eE][xX][cC][eE][lL]-[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\/[pP][aA][gG][eE][sS]\\/[iI][nN][dD][eE][xX]\\.[rR][aA][zZ][oO][rR]\\.[jJ][sS]($|\\?)|[tT]:\\\\[tT][hH][aA][yY][sS]\\\\[oO][fF][fF][iI][cC][eE]-[aA][dD][dD]-[iI][nN]-[sS][aA][mM][pP][lL][eE][sS]\\\\[sS][aA][mM][pP][lL][eE][sS]\\\\[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\\\[eE][xX][cC][eE][lL]-[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\\\[eE][xX][cC][eE][lL]-[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\\\[pP][aA][gG][eE][sS]\\\\[iI][nN][dD][eE][xX]\\.[rR][aA][zZ][oO][rR]\\.[jJ][sS]($|\\?)"

And using this PR will be:
[fF][iI][lL][eE]:\\/\\/\\/[tT]:\\/[tT][hH][aA][yY][sS]\\/[oO][fF][fF][iI][cC][eE]-[aA][dD][dD]-[iI][nN]-[sS][aA][mM][pP][lL][eE][sS]\\/[sS][aA][mM][pP][lL][eE][sS]\\/[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\/[eE][xX][cC][eE][lL]-[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\/[eE][xX][cC][eE][lL]-[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\/[pP][aA][gG][eE][sS]\\/[iI][nN][dD][eE][xX]\\.[rR][aA][zZ][oO][rR]\\.[jJ][sS]($|\\?)|[tT]:\\\\[tT][hH][aA][yY][sS]\\\\[oO][fF][fF][iI][cC][eE]-[aA][dD][dD]-[iI][nN]-[sS][aA][mM][pP][lL][eE][sS]\\\\[sS][aA][mM][pP][lL][eE][sS]\\\\[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\\\[eE][xX][cC][eE][lL]-[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\\\[eE][xX][cC][eE][lL]-[bB][lL][aA][zZ][oO][rR]-[aA][dD][dD]-[iI][nN]\\\\[pP][aA][gG][eE][sS]\\\\[iI][nN][dD][eE][xX]\\.[rR][aA][zZ][oO][rR]\\.[jJ][sS]($|\\?)|[hH][tT][tT][pP][sS]:\\/\\/[lL][oO][cC][aA][lL][hH][oO][sS][tT]:7287\\/[pP][aA][gG][eE][sS]\\/[iI][nN][dD][eE][xX]\\.[rR][aA][zZ][oO][rR]\\.[jJ][sS]($|\\?)"

Adding the https://localhost:7287/pages/index.razor.js as it's done when debugging without using blazorSourcePath.

Without the PR it was necessary to disable and enable the breakpoint after the APP is already started to bind the breakpoint.


Related to https://github.com/OfficeDev/Office-Add-in-samples/issues/444