### PR TITLE
fix: reduce number of ports used by debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: add ipv4->6 fallback ([vscode#167353](https://github.com/microsoft/vscode/issues/167353))
 - fix: js-debug in the browser showing extraneous error ([#1440](https://github.com/microsoft/vscode-js-debug/issues/1440))
 - fix: sourcemap renames not resolving property accessors ([#1383](https://github.com/microsoft/vscode-js-debug/issues/1383))
+- fix: breakpoint in blazor files set in JS not applying ([#1488](https://github.com/microsoft/vscode-js-debug/issues/1488))
+- fix: reduce number of ports used by debugger ([vscode#169182](https://github.com/microsoft/vscode/issues/169182))
 
 ## v1.74 (November 2022)
 

--- a/src/common/pathUtils.ts
+++ b/src/common/pathUtils.ts
@@ -3,11 +3,20 @@
  *--------------------------------------------------------*/
 
 import execa from 'execa';
+import { tmpdir } from 'os';
 import * as path from 'path';
 import { FsPromises } from '../ioc-extras';
 import { EnvironmentVars } from './environmentVars';
 import { existsInjected } from './fsUtils';
 import { removeNulls } from './objUtils';
+
+/** Platform-specific path for named sockets */
+export const namedSocketDirectory = process.platform === 'win32' ? '\\\\.\\pipe\\' : tmpdir();
+
+let pipeCounter = 0;
+
+export const getRandomPipe = () =>
+  path.join(namedSocketDirectory, `node-cdp.${process.pid}-${pipeCounter++}.sock`);
 
 /*
  * Lookup the given program on the PATH and return its absolute path on success and undefined otherwise.

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -22,7 +22,7 @@ import { EnvironmentVars } from '../../common/environmentVars';
 import { EventEmitter } from '../../common/events';
 import { ILogger, LogTag } from '../../common/logging';
 import { once } from '../../common/objUtils';
-import { findInPath, forceForwardSlashes } from '../../common/pathUtils';
+import { findInPath, forceForwardSlashes, getRandomPipe } from '../../common/pathUtils';
 import { delay } from '../../common/promiseUtil';
 import { AnyLaunchConfiguration, AnyNodeConfiguration } from '../../configuration';
 import { cannotLoadEnvironmentVars } from '../../dap/errors';
@@ -81,8 +81,6 @@ export interface IRunData<T> {
   logger: ILogger;
   params: T;
 }
-
-let counter = 0;
 
 @injectable()
 export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implements ILauncher {
@@ -354,8 +352,7 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
   }
 
   protected async _startServer(telemetryReporter: ITelemetryReporter) {
-    const pipePrefix = process.platform === 'win32' ? '\\\\.\\pipe\\' : os.tmpdir();
-    const pipe = path.join(pipePrefix, `node-cdp.${process.pid}-${++counter}.sock`);
+    const pipe = getRandomPipe();
     const server = await new Promise<net.Server>((resolve, reject) => {
       const s = net
         .createServer(socket => this._startSession(socket, telemetryReporter))

--- a/src/ui/companionBrowserLaunch.ts
+++ b/src/ui/companionBrowserLaunch.ts
@@ -84,12 +84,12 @@ const launchCompanionBrowser = async (
   }
 };
 
-const killCompanionBrowser = (
+const killCompanionBrowser = async (
   session: vscode.DebugSession,
   tunnels: DebugSessionTunnels,
   { launchId }: Dap.KillCompanionBrowserEventParams,
 ) => {
-  vscode.commands.executeCommand('js-debug-companion.kill', { launchId });
+  await vscode.commands.executeCommand('js-debug-companion.kill', { launchId });
   tunnels.destroySession(session.id);
 };
 

--- a/src/ui/vsCodeSessionManager.ts
+++ b/src/ui/vsCodeSessionManager.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import { Container } from 'inversify';
-import * as net from 'net';
 import * as vscode from 'vscode';
 import { IDisposable } from '../common/events';
 import { IPseudoAttachConfiguration } from '../configuration';
@@ -62,7 +61,7 @@ export class VSCodeSessionManager implements vscode.DebugAdapterDescriptorFactor
     debugSession: vscode.DebugSession,
   ): Promise<vscode.DebugAdapterDescriptor> {
     const result = await this.sessionServerManager.createDebugServer(debugSession);
-    return new vscode.DebugAdapterServer((result.server.address() as net.AddressInfo).port);
+    return new vscode.DebugAdapterNamedPipeServer(result.server.address() as string);
   }
 
   /**


### PR DESCRIPTION
A debt item I've been meaning to address for a while anyway. Though we still want to support port servers for VS debug.

Should fix https://github.com/microsoft/vscode/issues/169182