### PR TITLE
fix: provide memory reference for evaluate expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: breakpoint in blazor files set in JS not applying ([#1488](https://github.com/microsoft/vscode-js-debug/issues/1488))
 - fix: reduce number of ports used by debugger ([vscode#169182](https://github.com/microsoft/vscode/issues/169182))
 - fix: support launching chrome dev/beta as default fallbacks ([#1489](https://github.com/microsoft/vscode-js-debug/issues/1489))
+- fix: show memory refrence button for top-level watch expressions ([vscode#164124](https://github.com/microsoft/vscode/issues/164124))
+- refactor: improve breakpoint scanning speed 2-3x ([#1498](https://github.com/microsoft/vscode-js-debug/issues/1498))
 
 ## v1.74 (November 2022)
 

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -546,6 +546,7 @@ export class Thread implements IVariableStoreLocationProvider {
       variablesReference: variable.variablesReference,
       namedVariables: variable.namedVariables,
       indexedVariables: variable.indexedVariables,
+      memoryReference: variable.memoryReference,
     };
   }
 


### PR DESCRIPTION
Found when looking at https://github.com/microsoft/vscode/issues/164124