### PR TITLE
fix: don't hardcode generated source types as javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: reduce number of ports used by debugger ([vscode#169182](https://github.com/microsoft/vscode/issues/169182))
 - fix: support launching chrome dev/beta as default fallbacks ([#1489](https://github.com/microsoft/vscode-js-debug/issues/1489))
 - fix: show memory refrence button for top-level watch expressions ([vscode#164124](https://github.com/microsoft/vscode/issues/164124))
+- fix: don't hardcode generated source types as javascript ([vscode#168013](https://github.com/microsoft/vscode/issues/168013))
 - refactor: improve breakpoint scanning speed 2-3x ([#1498](https://github.com/microsoft/vscode-js-debug/issues/1498))
 
 ## v1.74 (November 2022)

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -338,7 +338,7 @@ export class DebugAdapter implements IDisposable {
       );
     }
 
-    return { content, mimeType: source.mimeType() };
+    return { content };
   }
 
   async _onThreads(): Promise<Dap.ThreadsResult | Dap.Error> {

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -229,10 +229,6 @@ export class Source {
     return content;
   }
 
-  mimeType(): string {
-    return 'text/javascript';
-  }
-
   /**
    * Pretty-prints the source. Generates a beauitified source map if possible
    * and it hasn't already been done, and returns the created map and created

--- a/src/test/sources/sources-basic-source-map.txt
+++ b/src/test/sources/sources-basic-source-map.txt
@@ -8,8 +8,6 @@ Source event for
         sourceReference : <number>
     }
 }
-text/javascript
----------
 import * as m1 from './module1';
 import * as m2 from './module2';
 
@@ -32,8 +30,6 @@ Source event for
         sourceReference : <number>
     }
 }
-text/javascript
----------
 export const kModule1 = 1;
 export function foo() {
   debugger;
@@ -56,8 +52,6 @@ Source event for
         sourceReference : <number>
     }
 }
-text/javascript
----------
 export const kModule2 = 2;
 export function bar(callback) {
   callback();

--- a/src/test/sources/sources-basic-sources.txt
+++ b/src/test/sources/sources-basic-sources.txt
@@ -8,8 +8,6 @@ Source event for inline
         sourceReference : <number>
     }
 }
-text/javascript
----------
 
 
     console.log('inline script');
@@ -25,8 +23,6 @@ Source event for empty.js
         sourceReference : <number>
     }
 }
-text/javascript
----------
 "111111111111111111111111111111111111111111111111111"
 
 ---------
@@ -41,8 +37,6 @@ Source event for does not exist
         sourceReference : <number>
     }
 }
-text/javascript
----------
 17
 //# sourceURL=http://localhost:8001/doesnotexist.js
 ---------
@@ -56,8 +50,6 @@ Source event for dir/helloworld
         sourceReference : <number>
     }
 }
-text/javascript
----------
 console.log('Hello, world!');
 
 ---------
@@ -72,8 +64,6 @@ Source event for eval
         sourceReference : <number>
     }
 }
-text/javascript
----------
 42
 
 ---------

--- a/src/test/sources/sources-updated-content.txt
+++ b/src/test/sources/sources-updated-content.txt
@@ -8,8 +8,6 @@ Source event for test.js
         sourceReference : <number>
     }
 }
-text/javascript
----------
 content1//# sourceURL=test.js
 ---------
 
@@ -22,8 +20,6 @@ Source event for test.js updated
         sourceReference : <number>
     }
 }
-text/javascript
----------
 content2//# sourceURL=test.js
 ---------
 

--- a/src/test/sources/sources-url-and-hash.txt
+++ b/src/test/sources/sources-url-and-hash.txt
@@ -8,8 +8,6 @@ Source event for foo.js
         sourceReference : <number>
     }
 }
-text/javascript
----------
 a
 //# sourceURL=foo.js
 ---------
@@ -23,8 +21,6 @@ Source event for foo.js
         sourceReference : <number>
     }
 }
-text/javascript
----------
 b
 //# sourceURL=foo.js
 ---------
@@ -38,8 +34,6 @@ Source event for empty.js
         sourceReference : <number>
     }
 }
-text/javascript
----------
 "111111111111111111111111111111111111111111111111111"
 
 ---------
@@ -53,8 +47,6 @@ Source event for empty2.js
         sourceReference : <number>
     }
 }
-text/javascript
----------
 
 ---------
 

--- a/src/test/sources/sourcesTest.ts
+++ b/src/test/sources/sourcesTest.ts
@@ -20,8 +20,6 @@ describe('sources', () => {
         sourceReference: event.source.sourceReference,
       },
     });
-    p.log(`${content.mimeType}`);
-    p.log('---------');
     p.log(content.content);
     p.log('---------');
   }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/168013

We don't know if a source type is actually JavaScript. Just let the editor guess instead of reimplementing mimetype detection ourselves