### PR TITLE
fix: typeerror for users of vsDebugServer.bundle.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
-Nothing, yet
+- fix: typeerror for users of vsDebugServer.bundle.js ([#1502](https://github.com/microsoft/vscode-js-debug/issues/1502))
 
 ## v1.75 (January 2023)
 

--- a/src/vsDebugServer.ts
+++ b/src/vsDebugServer.ts
@@ -90,7 +90,7 @@ class VsDebugServer implements ISessionLauncher<VSDebugSession> {
   }
 
   async launchRoot(deferredConnection: IDeferred<DapConnection>, session: VSDebugSession) {
-    const result = await this.sessionServer.createRootDebugServer(session, debugServerPort);
+    const result = await this.sessionServer.createRootDebugServer(session, debugServerPort ?? 0);
     result.connectionPromise.then(x => deferredConnection.resolve(x));
     console.log((result.server.address() as net.AddressInfo).port.toString());
   }


### PR DESCRIPTION
Fixes #1502