### PR TITLE
fix: support rich ANSI output for complex logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 - fix: typeerror for users of vsDebugServer.bundle.js ([#1502](https://github.com/microsoft/vscode-js-debug/issues/1502))
 - fix: expansion of non-primitive getters not working ([#1525](https://github.com/microsoft/vscode-js-debug/issues/1525))
+- fix: support rich ANSI output for complex logs ([vscode#172868](https://github.com/microsoft/vscode/issues/172868))
 
 ## v1.75 (January 2023)
 

--- a/src/adapter/console/textualMessage.ts
+++ b/src/adapter/console/textualMessage.ts
@@ -117,7 +117,7 @@ export abstract class TextualMessage<T extends { stackTrace?: Cdp.Runtime.StackT
       includeStackInVariables ? this.stackTrace(thread) : undefined,
     );
 
-    return { output: '', variablesReference: outputVar.id };
+    return { output, variablesReference: outputVar.id };
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/172868

This now works as of https://github.com/microsoft/vscode/pull/172880