### PR TITLE
fix: make variable renames scope-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: typeerror for users of vsDebugServer.bundle.js ([#1502](https://github.com/microsoft/vscode-js-debug/issues/1502))
 - fix: expansion of non-primitive getters not working ([#1525](https://github.com/microsoft/vscode-js-debug/issues/1525))
 - fix: support rich ANSI output for complex logs ([vscode#172868](https://github.com/microsoft/vscode/issues/172868))
+- fix: make variable renames scope-aware ([#1542](https://github.com/microsoft/vscode-js-debug/issues/1542))
 
 ## v1.75 (January 2023)
 

--- a/src/adapter/evaluator.test.ts
+++ b/src/adapter/evaluator.test.ts
@@ -5,7 +5,7 @@
 import { expect } from 'chai';
 import Cdp from '../cdp/api';
 import { stubbedCdpApi, StubCdpApi } from '../cdp/stubbedApi';
-import { Base01Position } from '../common/positions';
+import { Base01Position, PositionRange } from '../common/positions';
 import { RenameMapping } from '../common/sourceMaps/renameProvider';
 import { Evaluator } from './evaluator';
 
@@ -56,7 +56,7 @@ describe('Evaluator', () => {
       isInternalScript: false,
       renames: {
         mapping: new RenameMapping([
-          { original: 'foo', compiled: 'bar', position: new Base01Position(0, 1) },
+          { original: 'foo', compiled: 'bar', scope: PositionRange.Infinite },
         ]),
         position: new Base01Position(0, 1),
       },
@@ -81,7 +81,7 @@ try {} catch ({ foo }) {}`,
         isInternalScript: false,
         renames: {
           mapping: new RenameMapping([
-            { original: 'foo', compiled: 'bar', position: new Base01Position(0, 1) },
+            { original: 'foo', compiled: 'bar', scope: PositionRange.Infinite },
           ]),
           position: new Base01Position(0, 1),
         },

--- a/src/common/positions.test.ts
+++ b/src/common/positions.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+import { expect } from 'chai';
+import {
+  Base01Position,
+  Base0Position,
+  Base1Position,
+  comparePositions,
+  PositionRange,
+} from './positions';
+
+describe('IPosition', () => {
+  describe('compare', () => {
+    it('should return a negative number if the current position is before the other position', () => {
+      const position = new Base0Position(1, 1);
+      const other = new Base0Position(2, 2);
+      expect(position.compare(other)).to.be.lessThan(0);
+    });
+    it('should return a positive number if the current position is after the other position', () => {
+      const position = new Base0Position(2, 2);
+      const other = new Base0Position(1, 1);
+      expect(position.compare(other)).to.be.greaterThan(0);
+    });
+    it('should return 0 if the current position is equal to the other position', () => {
+      const position = new Base0Position(1, 1);
+      const other = new Base0Position(1, 1);
+      expect(position.compare(other)).to.equal(0);
+    });
+
+    it('compares across bases', () => {
+      expect(comparePositions(new Base0Position(1, 1), new Base1Position(2, 2))).to.equal(0);
+      expect(comparePositions(new Base0Position(1, 1), new Base01Position(2, 1))).to.equal(0);
+      expect(comparePositions(new Base1Position(2, 2), new Base01Position(2, 1))).to.equal(0);
+    });
+  });
+
+  it('range.contains', () => {
+    const range = new PositionRange(new Base0Position(1, 0), new Base1Position(5, 5));
+
+    expect(range.contains(new Base0Position(1, 0))).to.be.true;
+    expect(range.contains(new Base0Position(2, 0))).to.be.true;
+    expect(range.contains(new Base0Position(4, 0))).to.be.true;
+    expect(range.contains(new Base0Position(5.5, 0))).to.be.false;
+    expect(range.contains(new Base0Position(4, 6))).to.be.false;
+
+    expect(range.contains(new Base1Position(4.5, 0))).to.be.true;
+  });
+});

--- a/src/common/positions.ts
+++ b/src/common/positions.ts
@@ -22,9 +22,9 @@ export const comparePositions = (a: IPosition, b: IPosition) => {
   if (a instanceof Base0Position) {
     return a.compare(b.base0);
   } else if (a instanceof Base01Position) {
-    return b.compare(b.base01);
+    return a.compare(b.base01);
   } else if (a instanceof Base1Position) {
-    return b.compare(b.base1);
+    return a.compare(b.base1);
   } else {
     throw new Error(`Invalid position ${a}`);
   }
@@ -81,7 +81,7 @@ export class Base1Position implements IPosition {
 }
 
 /**
- * A position that starts a line 0 and column 1 (used by sourcemaps).
+ * A position that starts a line 1 and column 0 (used by sourcemaps).
  */
 export class Base01Position implements IPosition {
   declare readonly __isBase01: undefined;
@@ -102,5 +102,18 @@ export class Base01Position implements IPosition {
 
   public compare(other: Base01Position) {
     return this.lineNumber - other.lineNumber || this.columnNumber - other.columnNumber || 0;
+  }
+}
+
+export class PositionRange {
+  public static readonly Infinite = new PositionRange(
+    new Base0Position(0, 0),
+    new Base0Position(Infinity, Infinity),
+  );
+
+  constructor(public readonly start: IPosition, public readonly end: IPosition) {}
+
+  public contains(position: IPosition) {
+    return comparePositions(this.start, position) <= 0 && comparePositions(this.end, position) > 0;
   }
 }

--- a/src/test/variables/variables-setvariable-name-mapping.txt
+++ b/src/test/variables/variables-setvariable-name-mapping.txt
@@ -1,6 +1,6 @@
 
-hitDebugger @ ${workspaceFolder}/web/minified/index.js:13:5
-  > scope #0: Local: hitDebugger
+c @ ${workspaceFolder}/web/minified/index.js:13:5
+  > scope #0: Local: c
       arg1: 2
       arg2: 3
       > this: Window
@@ -8,17 +8,25 @@ hitDebugger @ ${workspaceFolder}/web/minified/index.js:13:5
 
 test @ ${workspaceFolder}/web/minified/index.js:6:5
   > scope #0: Block: test
-      inner1: 2
       inner2: 3
+      outer: 2
       > this: Window
   > scope #1: Local: test
-
-> hitDebugger: ƒ hitDebugger(arg1, arg2) {
-    debugger;
-  }
-      later: undefined
+      > hitDebugger: ƒ c(n,t){debugger}
+      inner2: undefined
       outer: 1
   scope #2: Global [expensive]
 
 <anonymous> @ <eval>/VM<xx>:1:1
   scope #0: Global [expensive]
+Evaluating "arg1"{
+    result : 2
+    type : number
+    variablesReference : <number>
+}
+Evaluating "((arg1) => arg1)(true)"{
+    result : true
+    type : boolean
+    variablesReference : <number>
+}
+Evaluating "inner2"Uncaught ReferenceError: inner2 is not defined

--- a/src/test/variables/variablesTest.ts
+++ b/src/test/variables/variablesTest.ts
@@ -366,6 +366,29 @@ describe('variables', () => {
       p.cdp.Runtime.evaluate({ expression: `test()` });
       const event = await p.dap.once('stopped');
       await p.logger.logStackTrace(event.threadId!, true);
+
+      const frameId = await p.dap
+        .stackTrace({ threadId: event.threadId! })
+        .then(x => x.stackFrames[0].id);
+
+      const exprs = [
+        // simple evaluate rename
+        'arg1',
+        // test for invalid contexts
+        '((arg1) => arg1)(true)',
+        // does not rename variables not in this scope
+        'inner2',
+      ];
+      for (const expr of exprs) {
+        p.log(
+          await p.dap.evaluate({
+            expression: expr,
+            frameId,
+          }),
+          `Evaluating "${expr}"`,
+        );
+      }
+
       await p.dap.continue({ threadId: event.threadId! });
       p.assertLog();
     });

--- a/testWorkspace/web/minified/index.html
+++ b/testWorkspace/web/minified/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script src='index.js'></script>
+  <script src='index.min.js'></script>
 </head>
 <body>
 </body>


### PR DESCRIPTION
Fixes #1542

Prototype code. It works, but I want to move parsing blocks to a worker, since parsing large files (like Typescript's `run.js`) takes about a second, which will stall the extension host.