### PR TITLE
Revert "Merge pull request #1481 from microsoft/complex-sourcemap-names"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: typeerror for users of vsDebugServer.bundle.js ([#1502](https://github.com/microsoft/vscode-js-debug/issues/1502))
 - fix: expansion of non-primitive getters not working ([#1525](https://github.com/microsoft/vscode-js-debug/issues/1525))
 - fix: support rich ANSI output for complex logs ([vscode#172868](https://github.com/microsoft/vscode/issues/172868))
+- fix: revert support for renamed property accessors ([#1561](https://github.com/microsoft/vscode-js-debug/issues/1561))
 
 ## v1.75 (January 2023)
 

--- a/src/common/sourceMaps/renameProvider.ts
+++ b/src/common/sourceMaps/renameProvider.ts
@@ -17,8 +17,8 @@ interface IRename {
   position: Base01Position;
 }
 
-/** Very approximate regex for JS identifiers, allowing member expressions as well */
-const identifierRe = /[$a-z_][$0-9A-Z_$.]*/iy;
+/** Very approximate regex for JS identifiers */
+const identifierRe = /[$a-z_][$0-9A-Z_$]*/iy;
 
 export interface IRenameProvider {
   /**

--- a/src/test/breakpoints/breakpoints-logpoints-basic.txt
+++ b/src/test/breakpoints/breakpoints-logpoints-basic.txt
@@ -1,4 +1,5 @@
 stdout> 123
+stdout> {foo: 'bar'}
 stdout> > {foo: 'bar'}
 stdout>     > arg1: {foo: 'bar'}
 stdout> 1

--- a/src/test/variables/variables-multiple-threads-worker.txt
+++ b/src/test/variables/variables-multiple-threads-worker.txt
@@ -1,3 +1,4 @@
+stderr> {foo: {…}}
 stderr> > {foo: {…}}
 stderr>     > arg0: {foo: {…}}
 stderr>
@@ -6,12 +7,14 @@ stderr>
 <anonymous> @ ${workspaceFolder}/web/worker.js:10:5
 ◀ Worker.postMessage ▶
 <anonymous> @ ${workspaceFolder}/web/worker.html:8:10
+stderr> {foo: {…}}
 stderr> > {foo: {…}}
 stderr>     > arg0: {foo: {…}}
 stderr>
 <anonymous> @ ${workspaceFolder}/web/worker.js:1:9
 ◀ Worker Created ▶
 <anonymous> @ ${workspaceFolder}/web/worker.html:2:12
+stderr> {foo: {…}}
 stderr> > {foo: {…}}
 stderr>     > arg0: {foo: {…}}
 stderr>


### PR DESCRIPTION
This reverts commit 7b5e81dbb0c6d4b7d8cbf4de18a46208bb39c6b1, reversing changes made to 6130f21c78719d9934ac4eca682f945a3904fe4e.

Fixes https://github.com/microsoft/vscode-js-debug/issues/1561

Just undo this change (made last release) in this one. I'm not sure if it's possible to support this, at least without changes upstream in Babel.