### PR TITLE
fix: resolveSourceMapLocations not being auto-filled for ext host debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: expansion of non-primitive getters not working ([#1525](https://github.com/microsoft/vscode-js-debug/issues/1525))
 - fix: support rich ANSI output for complex logs ([vscode#172868](https://github.com/microsoft/vscode/issues/172868))
 - fix: revert support for renamed property accessors ([#1561](https://github.com/microsoft/vscode-js-debug/issues/1561))
+- fix: resolveSourceMapLocations not being auto-filled for ext host debug ([#1554 comment](https://github.com/microsoft/vscode-js-debug/issues/1554#issuecomment-1420520834))
 
 ## v1.75 (January 2023)
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -961,8 +961,11 @@ export function defaultSourceMapPathOverrides(webRoot: string): { [key: string]:
   };
 }
 
-const applyNodeishDefaults = (
-  config: ResolvingNodeConfiguration | ResolvingTerminalConfiguration,
+export const applyNodeishDefaults = (
+  config:
+    | ResolvingNodeConfiguration
+    | ResolvingTerminalConfiguration
+    | ResolvingExtensionHostConfiguration,
 ) => {
   if (!config.sourceMapPathOverrides && config.cwd) {
     config.sourceMapPathOverrides = defaultSourceMapPathOverrides(config.cwd);

--- a/src/ui/configuration/extensionHostConfigurationResolver.ts
+++ b/src/ui/configuration/extensionHostConfigurationResolver.ts
@@ -8,6 +8,7 @@ import { join } from 'path';
 import * as vscode from 'vscode';
 import { DebugType } from '../../common/contributionUtils';
 import {
+  applyNodeishDefaults,
   extensionHostConfigDefaults,
   IExtensionHostLaunchConfiguration,
   resolveVariableInConfig,
@@ -38,6 +39,8 @@ export class ExtensionHostConfigurationResolver
     if (config.debugWebWorkerHost) {
       config.outFiles = []; // will have a runtime script offset which invalidates any predictions
     }
+
+    applyNodeishDefaults(config);
 
     return Promise.resolve({
       ...extensionHostConfigDefaults,


### PR DESCRIPTION
See https://github.com/microsoft/vscode-js-debug/issues/1554#issuecomment-1420520834