### PR TITLE
fix: don't fail on dynamic config provisioning if no package.json's exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - fix: typeerror for users of vsDebugServer.bundle.js ([#1502](https://github.com/microsoft/vscode-js-debug/issues/1502))
+- fix: don't fail on dynamic config provisioning if no package.json's exist ([vscode#172522](https://github.com/microsoft/vscode/issues/172522))
 - fix: expansion of non-primitive getters not working ([#1525](https://github.com/microsoft/vscode-js-debug/issues/1525))
 - fix: support rich ANSI output for complex logs ([vscode#172868](https://github.com/microsoft/vscode/issues/172868))
 - fix: revert support for renamed property accessors ([#1561](https://github.com/microsoft/vscode-js-debug/issues/1561))

--- a/src/ui/debugNpmScript.ts
+++ b/src/ui/debugNpmScript.ts
@@ -116,6 +116,13 @@ export async function findScripts(
     )
   ).flat();
 
+  if (candidates.length === 0) {
+    if (!silent) {
+      vscode.window.showErrorMessage(l10n.t('No package.json files found in your workspace.'));
+    }
+    return;
+  }
+
   const scripts: IScript[] = [];
 
   // editCandidate is the file we'll edit if we don't find any npm scripts.


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/172522