### PR TITLE
fix: source map resolution in parent workspace folder paths not working

### DIFF
--- a/.ci/common-validation.yml
+++ b/.ci/common-validation.yml
@@ -17,6 +17,8 @@ steps:
 - task: Npm@1
   displayName: npm install
   inputs:
+    command: custom
+    customCommand: install --legacy-peer-deps
     verbose: false
 
 - task: NodeTool@0

--- a/.ci/publish-nightly.yml
+++ b/.ci/publish-nightly.yml
@@ -23,7 +23,7 @@ extends:
     cgIgnoreDirectories: 'testdata,demos,.vscode-test'
     l10nShouldProcess: false
     buildSteps:
-      - script: npm install
+      - script: npm install --legacy-peer-deps
         displayName: Install dependencies
 
       - script: npm run compile -- package:prepare --nightly

--- a/.ci/publish.yml
+++ b/.ci/publish.yml
@@ -33,7 +33,7 @@ extends:
       ghReleaseAddChangeLog: true
     l10nShouldProcess: false
     buildSteps:
-      - script: npm install
+      - script: npm install --legacy-peer-deps
         displayName: Install dependencies
 
       - script: npm run compile -- package:prepare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: don't fail on dynamic config provisioning if no package.json's exist ([vscode#172522](https://github.com/microsoft/vscode/issues/172522))
 - fix: expansion of non-primitive getters not working ([#1525](https://github.com/microsoft/vscode-js-debug/issues/1525))
 - fix: support rich ANSI output for complex logs ([vscode#172868](https://github.com/microsoft/vscode/issues/172868))
+- fix: source map resolution in parent workspace folder paths not working ([#1554 comment](https://github.com/microsoft/vscode-js-debug/issues/1554#issuecomment-1420520834))
 - fix: revert support for renamed property accessors ([#1561](https://github.com/microsoft/vscode-js-debug/issues/1561))
 - fix: resolveSourceMapLocations not being auto-filled for ext host debug ([#1554 comment](https://github.com/microsoft/vscode-js-debug/issues/1554#issuecomment-1420520834))
 

--- a/src/common/pathUtils.ts
+++ b/src/common/pathUtils.ts
@@ -149,6 +149,10 @@ export function properRelative(fromPath: string, toPath: string): string {
   }
 }
 
+const splitRe = /\/|\\/;
+
+export const properSplit = (path: string) => path.split(splitRe);
+
 export function fixDriveLetter(aPath: string, uppercaseDriveLetter = false): string {
   if (!aPath) return aPath;
 

--- a/src/test/node/node-source-path-resolver.test.ts
+++ b/src/test/node/node-source-path-resolver.test.ts
@@ -31,53 +31,57 @@ describe('node source path resolver', () => {
     });
 
     it('escapes regex parts segments', async () => {
-      const r = new NodeSourcePathResolver(
-        fsUtils,
-        undefined,
-        {
-          ...defaultOptions,
-          workspaceFolder: 'C:\\some\\workspa*ce\\folder',
-          basePath: 'C:\\some\\workspa*ce\\folder',
-          resolveSourceMapLocations: [
-            'C:\\some\\workspa*ce\\folder/**',
-            'C:\\some\\workspa*ce\\folder/../**',
-            'C:\\some\\workspa*ce\\folder/../foo/**',
-          ],
-        },
-        await Logger.test(),
-      );
-      expect((r as unknown as Record<string, string[]>).resolvePatterns).to.deep.equal([
-        'C:/some/workspa\\*ce/folder/**',
-        'C:/some/workspa\\*ce/**',
-        'C:/some/workspa\\*ce/foo/**',
-      ]);
+      if (process.platform === 'win32') {
+        const r = new NodeSourcePathResolver(
+          fsUtils,
+          undefined,
+          {
+            ...defaultOptions,
+            workspaceFolder: 'C:\\some\\workspa*ce\\folder',
+            basePath: 'C:\\some\\workspa*ce\\folder',
+            resolveSourceMapLocations: [
+              'C:\\some\\workspa*ce\\folder/**',
+              'C:\\some\\workspa*ce\\folder/../**',
+              'C:\\some\\workspa*ce\\folder/../foo/**',
+            ],
+          },
+          await Logger.test(),
+        );
+        expect((r as unknown as Record<string, string[]>).resolvePatterns).to.deep.equal([
+          'C:/some/workspa\\*ce/folder/**',
+          'C:/some/workspa\\*ce/**',
+          'C:/some/workspa\\*ce/foo/**',
+        ]);
+      }
     });
 
     it('fixes regex escape issue #1554', async () => {
-      const r = new NodeSourcePathResolver(
-        fsUtils,
-        undefined,
-        {
-          ...defaultOptions,
-          workspaceFolder: 'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode',
-          basePath: 'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode',
-          resolveSourceMapLocations: [
-            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/**',
-            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/shared/dist/**',
-            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/swimmagic/dist/**',
-            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/editor/dist/**',
-            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../server/dist/**',
-            '!**/node_modules/**',
-          ],
-        },
-        await Logger.test(),
-      );
-      expect(
-        r.shouldResolveSourceMap({
-          compiledPath: 'c:\\Users\\Segev\\prj\\swimm\\ide\\server\\dist\\app.js',
-          sourceMapUrl: 'file:///c:/Users/Segev/prj/swimm/ide/server/dist/app.js.map',
-        }),
-      ).to.be.true;
+      if (process.platform === 'win32') {
+        const r = new NodeSourcePathResolver(
+          fsUtils,
+          undefined,
+          {
+            ...defaultOptions,
+            workspaceFolder: 'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode',
+            basePath: 'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode',
+            resolveSourceMapLocations: [
+              'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/**',
+              'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/shared/dist/**',
+              'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/swimmagic/dist/**',
+              'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/editor/dist/**',
+              'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../server/dist/**',
+              '!**/node_modules/**',
+            ],
+          },
+          await Logger.test(),
+        );
+        expect(
+          r.shouldResolveSourceMap({
+            compiledPath: 'c:\\Users\\Segev\\prj\\swimm\\ide\\server\\dist\\app.js',
+            sourceMapUrl: 'file:///c:/Users/Segev/prj/swimm/ide/server/dist/app.js.map',
+          }),
+        ).to.be.true;
+      }
     });
 
     it('resolves unc paths', async () => {

--- a/src/test/node/node-source-path-resolver.test.ts
+++ b/src/test/node/node-source-path-resolver.test.ts
@@ -30,6 +30,56 @@ describe('node source path resolver', () => {
       );
     });
 
+    it('escapes regex parts segments', async () => {
+      const r = new NodeSourcePathResolver(
+        fsUtils,
+        undefined,
+        {
+          ...defaultOptions,
+          workspaceFolder: 'C:\\some\\workspa*ce\\folder',
+          basePath: 'C:\\some\\workspa*ce\\folder',
+          resolveSourceMapLocations: [
+            'C:\\some\\workspa*ce\\folder/**',
+            'C:\\some\\workspa*ce\\folder/../**',
+            'C:\\some\\workspa*ce\\folder/../foo/**',
+          ],
+        },
+        await Logger.test(),
+      );
+      expect((r as unknown as Record<string, string[]>).resolvePatterns).to.deep.equal([
+        'C:/some/workspa\\*ce/folder/**',
+        'C:/some/workspa\\*ce/**',
+        'C:/some/workspa\\*ce/foo/**',
+      ]);
+    });
+
+    it('fixes regex escape issue #1554', async () => {
+      const r = new NodeSourcePathResolver(
+        fsUtils,
+        undefined,
+        {
+          ...defaultOptions,
+          workspaceFolder: 'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode',
+          basePath: 'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode',
+          resolveSourceMapLocations: [
+            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/**',
+            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/shared/dist/**',
+            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/swimmagic/dist/**',
+            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../../packages/editor/dist/**',
+            'C:\\Users\\Segev\\prj\\swimm\\ide\\extensions\\vscode/../../server/dist/**',
+            '!**/node_modules/**',
+          ],
+        },
+        await Logger.test(),
+      );
+      expect(
+        r.shouldResolveSourceMap({
+          compiledPath: 'c:\\Users\\Segev\\prj\\swimm\\ide\\server\\dist\\app.js',
+          sourceMapUrl: 'file:///c:/Users/Segev/prj/swimm/ide/server/dist/app.js.map',
+        }),
+      ).to.be.true;
+    });
+
     it('resolves unc paths', async () => {
       if (process.platform !== 'win32') {
         return;


### PR DESCRIPTION
See https://github.com/microsoft/vscode-js-debug/issues/1554#issuecomment-1420520834

Due to some bad logic, we ended up escaping the glob pattern that was meant to find sourcemaps.