### PR TITLE
fix: Reflect.hasOwnMetadata is not a function in debugServer

### DIFF
--- a/src/debugServerMain.ts
+++ b/src/debugServerMain.ts
@@ -2,6 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import 'reflect-metadata';
 import { startDebugServer } from './debugServer';
 
 let port = 0;


### PR DESCRIPTION
Fixes #1577