### PR TITLE
fix: unbound breakpoints in sourcemaps on Chrome 112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 - fix: repl stacktrace with renames showing too much info ([#1259](https://github.com/microsoft/vscode-js-debug/issues/1259#issuecomment-1409443564))
 - fix: recursive source map resolution parsing ignored locations ([vscode#169733](https://github.com/microsoft/vscode/issues/169733))
+- fix: unbound breakpoints in sourcemaps on Chrome 112 ([#1567](https://github.com/microsoft/vscode-js-debug/issues/1567))
 
 ## v1.76 (February 2023)
 

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -5,7 +5,7 @@
 import { inject, injectable } from 'inversify';
 import Cdp from '../cdp/api';
 import { ILogger, LogTag } from '../common/logging';
-import { bisectArray } from '../common/objUtils';
+import { bisectArray, flatten } from '../common/objUtils';
 import { IPosition } from '../common/positions';
 import { delay } from '../common/promiseUtil';
 import { SourceMap } from '../common/sourceMaps/sourceMap';
@@ -193,7 +193,7 @@ export class BreakpointManager {
         }
       }
 
-      return (await Promise.all(todo)).reduce((a, b) => [...a, ...b], []);
+      return flatten(await Promise.all(todo));
     };
   }
 


### PR DESCRIPTION
Chrome Dev (112) no longer has any stackframes for instrumentation
breakpoints, which was resulting in a thrown error.

Fixes #1567