### PR TITLE
fix: assorted bad source behaviors when reloading a page

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run test:lint && npm run test:types
+npm run -S precommit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: repl stacktrace with renames showing too much info ([#1259](https://github.com/microsoft/vscode-js-debug/issues/1259#issuecomment-1409443564))
 - fix: recursive source map resolution parsing ignored locations ([vscode#169733](https://github.com/microsoft/vscode/issues/169733))
 - fix: unbound breakpoints in sourcemaps on Chrome 112 ([#1567](https://github.com/microsoft/vscode-js-debug/issues/1567))
+- fix: assorted bad source behaviors when reloading a page ([#1582](https://github.com/microsoft/vscode-js-debug/issues/1582))
 - chore: remove webpack, adopt esbuild
 
 ## v1.76 (February 2023)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prepare": "husky install",
     "package": "gulp package",
     "publish": "gulp publish",
+    "precommit": "npm-run-all --parallel test:lint test:types",
     "updatetypes": "cd src/typings && npx vscode-dts dev && npx vscode-dts master",
     "updatenodeapi": "python src/build/getNodePdl.py && prettier --write src/build/nodeCustom.ts",
     "generateapis": "node dist/src/build/generateDap.js && node dist/src/build/generateCdp.js",

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -26,17 +26,17 @@ import { PatternEntryBreakpoint } from './breakpoints/patternEntrypointBreakpoin
 import { UserDefinedBreakpoint } from './breakpoints/userDefinedBreakpoint';
 import { DiagnosticToolSuggester } from './diagnosticToolSuggester';
 import {
-  base0To1,
-  base1To0,
   ISourceWithMap,
-  isSourceWithMap,
   IUiLocation,
-  rawToUiOffset,
   Source,
   SourceContainer,
+  base0To1,
+  base1To0,
+  isSourceWithMap,
+  rawToUiOffset,
   uiToRawOffset,
 } from './sources';
-import { Script, ScriptWithSourceMapHandler, Thread } from './threads';
+import { ScriptWithSourceMapHandler, Thread } from './threads';
 
 /**
  * Differential result used internally in setBreakpoints.
@@ -348,16 +348,15 @@ export class BreakpointManager {
         continue;
       }
 
-      // Only take the first script that matches this source. The breakpoints
+      // Only take the last script that matches this source. The breakpoints
       // are all coming from the same source code, so possible breakpoints
       // at one location where this source is present should match every other.
       const lsrc = start.source;
-      const scripts = thread.scriptsFromSource(lsrc);
-      if (scripts.size === 0) {
+      if (!lsrc.scripts.length) {
         continue;
       }
 
-      const { scriptId } = scripts.values().next().value as Script;
+      const { scriptId } = lsrc.scripts[lsrc.scripts.length - 1];
       todo.push(
         thread
           .cdp()
@@ -610,7 +609,7 @@ export class BreakpointManager {
     await Promise.all(
       result.unbound.map(b => {
         this._byDapId.delete(b.dapId);
-        b.disable();
+        return b.disable();
       }),
     );
 

--- a/src/adapter/diagnosics.ts
+++ b/src/adapter/diagnosics.ts
@@ -140,7 +140,7 @@ export class Diagnostics {
           sourceReference: source.sourceReference,
           absolutePath: source.absolutePath,
           actualAbsolutePath: await source.existingAbsolutePath(),
-          scriptIds: source.scriptIds(),
+          scriptIds: source.scripts.map(s => s.scriptId),
           prettyName: await source.prettyName(),
           compiledSourceRefToUrl:
             source instanceof SourceFromMap

--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { IBrowserFinder, isQuality, Quality } from '@vscode/js-debug-browsers';
+import { IBrowserFinder, isQuality } from '@vscode/js-debug-browsers';
 import * as fs from 'fs';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
@@ -92,7 +92,7 @@ export abstract class BrowserLauncher<T extends AnyChromiumLaunchConfiguration>
     telemetryReporter: ITelemetryReporter,
     promisedPort?: Promise<number>,
   ): Promise<launcher.ILaunchResult> {
-    const executablePath = await this.findBrowserPath(executable || Quality.Stable);
+    const executablePath = await this.findBrowserPath(executable || 'stable');
 
     // If we had a custom executable, don't resolve a data
     // dir unless it's  explicitly requested.
@@ -298,7 +298,7 @@ export abstract class BrowserLauncher<T extends AnyChromiumLaunchConfiguration>
       // try to find the stable browser, but if that fails just get any browser
       // that's available on the system
       const found =
-        (await finder.findWhere(r => r.quality === Quality.Stable)) || (await finder.findAll())[0];
+        (await finder.findWhere(r => r.quality === 'stable')) || (await finder.findAll())[0];
       return found?.path;
     } else if (isQuality(executablePath)) {
       return (await finder.findWhere(r => r.quality === executablePath))?.path;

--- a/src/test/breakpoints/breakpoints-deals-with-removed-execution-contexts-1582.txt
+++ b/src/test/breakpoints/breakpoints-deals-with-removed-execution-contexts-1582.txt
@@ -1,0 +1,27 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${workspaceFolder}/web/iframe-1582/inner.js:3:3
+----setInterval----
+<anonymous> @ ${workspaceFolder}/web/iframe-1582/inner.js:2:1
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${workspaceFolder}/web/iframe-1582/inner.js:3:3
+----setInterval----
+<anonymous> @ ${workspaceFolder}/web/iframe-1582/inner.js:2:1
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${workspaceFolder}/web/iframe-1582/inner.js:3:3
+----setInterval----
+<anonymous> @ ${workspaceFolder}/web/iframe-1582/inner.js:2:1

--- a/testWorkspace/web/iframe-1582/index.html
+++ b/testWorkspace/web/iframe-1582/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <iframe src="inner.html"></iframe>
+</body>
+</html>

--- a/testWorkspace/web/iframe-1582/inner.html
+++ b/testWorkspace/web/iframe-1582/inner.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <script src="inner.js"></script>
+</body>
+</html>

--- a/testWorkspace/web/iframe-1582/inner.js
+++ b/testWorkspace/web/iframe-1582/inner.js
@@ -1,0 +1,4 @@
+let i = 0;
+setInterval(() => {
+  i++;
+}, 50);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-js-debug/issues/1582

We weren't dealing with removed execution contexts at all (e.g. removing an iframe or worker), only cleared ones (e.g. refreshing the entire page). Now, removing an execution context properly removes its sources, and scripts from multiple contexts are handled.

I think this is also an underlying fix for several other bugs I have open; will investigate tomorrow.