### PR TITLE
fix: sourcemap lookups on ipv6 localhost addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
+- fix: sourcemap lookups on ipv6 localhost addresses ([vscode#167353](https://github.com/microsoft/vscode/issues/167353))
 - feat: support ETX in stdio console endings ([vscode#175763](https://github.com/microsoft/vscode/issues/175763))
 
 ## v1.77 (March 2023)

--- a/src/adapter/resourceProvider/basicResourceProvider.ts
+++ b/src/adapter/resourceProvider/basicResourceProvider.ts
@@ -103,7 +103,7 @@ export class BasicResourceProvider implements IResourceProvider {
         return response;
       }
 
-      parsed.hostname = resolved.family === 6 ? '127.0.0.1' : '::1';
+      parsed.hostname = resolved.family === 6 ? '127.0.0.1' : '[::1]';
       return this.requestHttp(parsed.toString(), options, cancellationToken);
     }
 


### PR DESCRIPTION
TIL that assigning an invalid value to `url.hostname` silently fails
if invalid.

Fixes https://github.com/microsoft/vscode/issues/167353