### PR TITLE
fix: browser debugging in remotes not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 - fix: debugger failing on Node <=12 ([#1624](https://github.com/microsoft/vscode-js-debug/issues/1624))
 - fix: sourcemap lookups on ipv6 localhost addresses ([vscode#167353](https://github.com/microsoft/vscode/issues/167353))
+- fix: browser debugging in remotes not working ([#1628](https://github.com/microsoft/vscode-js-debug/issues/1628))
 - feat: support ETX in stdio console endings ([vscode#175763](https://github.com/microsoft/vscode/issues/175763))
 
 ## v1.77 (March 2023)

--- a/src/common/findOpenPort.ts
+++ b/src/common/findOpenPort.ts
@@ -111,7 +111,10 @@ export const makeAcquireTcpServer =
 export const makeAcquireWebSocketServer =
   (options?: WebSocket.ServerOptions): PortTesterFn<WebSocket.Server> =>
   (port, ct) =>
-    waitForServerToListen(new WebSocket.Server({ host: '127.0.0.1', ...options, port }), ct);
+    waitForServerToListen(
+      new WebSocket.WebSocketServer({ host: '127.0.0.1', ...options, port }),
+      ct,
+    );
 
 interface IServerLike {
   on(event: 'error', handler: (err: Error) => void): void;

--- a/src/test/browser/browser-launch.test.ts
+++ b/src/test/browser/browser-launch.test.ts
@@ -47,7 +47,10 @@ describe('browser launch', () => {
 
   itIntegrates('connects to rewritten websocket when using inspectUri parameter', async ({ r }) => {
     const pagePort = 5935;
-    const wsServer = new WebSocket.Server({ port: pagePort, path: '/_framework/debug/ws-proxy' });
+    const wsServer = new WebSocket.WebSocketServer({
+      port: pagePort,
+      path: '/_framework/debug/ws-proxy',
+    });
 
     try {
       const receivedMessage = new Promise(resolve => {


### PR DESCRIPTION
Fixes #1628

Moving to esbuild caused it to pull in the "wrapper.mjs" which doesn't
expose the same API that `ws` normally does.

See https://github.com/websockets/ws/issues/2032#issuecomment-1096945114