### PR TITLE
fix: breakpoints not binding in certain cases if localRoot is a path child of remoteRoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 - fix: debugger failing on Node <=12 ([#1624](https://github.com/microsoft/vscode-js-debug/issues/1624))
 - fix: sourcemap lookups on ipv6 localhost addresses ([vscode#167353](https://github.com/microsoft/vscode/issues/167353))
+- fix: breakpoints not binding in certain cases if localRoot is a path child of remoteRoot ([#1617](https://github.com/microsoft/vscode-js-debug/issues/1617))
 - fix: browser debugging in remotes not working ([#1628](https://github.com/microsoft/vscode-js-debug/issues/1628))
 - feat: support ETX in stdio console endings ([vscode#175763](https://github.com/microsoft/vscode/issues/175763))
 

--- a/src/targets/node/nodeSourcePathResolver.ts
+++ b/src/targets/node/nodeSourcePathResolver.ts
@@ -158,7 +158,7 @@ export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
     }
 
     if (!path.isAbsolute(url) && this.options.basePath) {
-      url = properResolve(
+      return properResolve(
         await getComputedSourceRoot(
           this.options.remoteRoot && urlUtils.isAbsolute(map.sourceRoot)
             ? this.rebaseRemoteToLocal(map.sourceRoot) || map.sourceRoot

--- a/src/test/breakpoints/breakpoints-hot-transpiled-avoids-double-pathmapping-1617.txt
+++ b/src/test/breakpoints/breakpoints-hot-transpiled-avoids-double-pathmapping-1617.txt
@@ -1,0 +1,7 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ ${fixturesDir}/src/double.js:1:27

--- a/testWorkspace/tsNode/index.js
+++ b/testWorkspace/tsNode/index.js
@@ -7,5 +7,5 @@ const { double, triple } = require('./double.ts');
 console.log(triple(3));
 console.log(double(21));
 
-require('./matching-line.ts')
+require('./matching-line.ts');
 require('./log.ts');


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-js-debug/issues/1617

If the url in a sourcemap is relative, assume we've already mapped the
compiledPath, and don't map again.