### PR TITLE
fix: workspace detection of nightly extension not working

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,7 +2,6 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import pkg from '../package.json';
 import { SourceMapTimeouts } from './adapter/sources';
 import { DebugType } from './common/contributionUtils';
 import { assertNever, filterValues } from './common/objUtils';
@@ -1151,8 +1150,12 @@ export const breakpointLanguages: ReadonlyArray<string> = [
   'html',
 ];
 
-export const packageName: string = pkg.name;
-export const packageVersion: string = pkg.version;
-export const packagePublisher: string = pkg.publisher;
+declare const EXTENSION_NAME: string;
+declare const EXTENSION_VERSION: string;
+declare const EXTENSION_PUBLISHER: string;
+
+export const packageName = EXTENSION_NAME;
+export const packageVersion = EXTENSION_VERSION;
+export const packagePublisher = EXTENSION_PUBLISHER;
 export const isNightly = packageName.includes('nightly');
 export const extensionId = `${packagePublisher}.${packageName}`;


### PR DESCRIPTION
Previously, the package.json pulled in at the bundle step was the "nightly"-treated version, but this is no longer the case. This causes nightly to not be able to automatically determine it's running in a remote workspace, since the extensionId is wrong.

Instead, define the version, package name, and publisher as compile-time constants.

Refs https://github.com/microsoft/vscode-js-debug/issues/1628#issuecomment-1492769589