### PR TITLE
fix: another node 10 fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -201,19 +201,31 @@ async function compileTs({
   packages = [
     ...packages,
     { entry: `${srcDir}/common/hash/hash.ts`, library: false },
-    { entry: `${srcDir}/targets/node/bootloader.ts`, library: false },
-    { entry: `${srcDir}/targets/node/watchdog.ts`, library: false },
-    { entry: `${srcDir}/diagnosticTool/diagnosticTool.tsx`, library: false, target: 'browser' },
+    { entry: `${srcDir}/targets/node/bootloader.ts`, library: false, target: 'node10' },
+    { entry: `${srcDir}/targets/node/watchdog.ts`, library: false, target: 'node10' },
+    {
+      entry: `${srcDir}/diagnosticTool/diagnosticTool.tsx`,
+      library: false,
+      target: 'chrome102',
+      platform: 'browser',
+    },
   ];
 
   const define = await getConstantDefines();
 
   let todo = [];
-  for (const { entry, target = 'node', library, isInVsCode, nodePackages } of packages) {
+  for (const {
+    entry,
+    platform = 'node',
+    library,
+    isInVsCode,
+    nodePackages,
+    target = 'node16',
+  } of packages) {
     todo.push(
       incrementalEsbuild({
         entryPoints: [entry],
-        platform: target,
+        platform,
         bundle: true,
         outdir: buildSrcDir,
         resolveExtensions: isInVsCode
@@ -225,7 +237,8 @@ async function compileTs({
         packages: nodePackages,
         minify,
         define,
-        alias: target === 'node' ? {} : { path: 'path-browserify' },
+        target,
+        alias: platform === 'node' ? {} : { path: 'path-browserify' },
         plugins: [
           esbuildPlugins.nativeNodeModulesPlugin(),
           esbuildPlugins.importGlobLazy(),

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1154,8 +1154,10 @@ declare const EXTENSION_NAME: string;
 declare const EXTENSION_VERSION: string;
 declare const EXTENSION_PUBLISHER: string;
 
-export const packageName = EXTENSION_NAME;
-export const packageVersion = EXTENSION_VERSION;
-export const packagePublisher = EXTENSION_PUBLISHER;
+export const packageName = typeof EXTENSION_NAME !== 'undefined' ? EXTENSION_NAME : 'js-debug';
+export const packageVersion =
+  typeof EXTENSION_VERSION !== 'undefined' ? EXTENSION_VERSION : '0.0.0';
+export const packagePublisher =
+  typeof EXTENSION_PUBLISHER !== 'undefined' ? EXTENSION_PUBLISHER : 'vscode-samples';
 export const isNightly = packageName.includes('nightly');
 export const extensionId = `${packagePublisher}.${packageName}`;


### PR DESCRIPTION
esbuild can minify syntax as well, and by default it targets esnext,
which caused it to emit null coaslecing. Set the target explicitly
to avoid this.

Fixes https://github.com/microsoft/vscode-js-debug/issues/1624 (again)