### PR TITLE
fix: cannot read createScope of undefined

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1407,6 +1407,17 @@ export class Thread implements IVariableStoreLocationProvider {
       event.url = this.target.scriptUrlToUrl(event.url);
     }
 
+    // Hack: Node 16 seems to not report its 0th context where it loads some
+    // initial scripts. Pretend these are actually loaded in the 2nd (main) context.
+    // https://github.com/nodejs/node/issues/47438
+    if (
+      this.launchConfig.type === DebugType.Node &&
+      event.executionContextId === 0 &&
+      !this._executionContexts.has(0)
+    ) {
+      event.executionContextId = 1;
+    }
+
     const executionContext = this._executionContexts.get(event.executionContextId);
     if (!executionContext) {
       return;


### PR DESCRIPTION
This was a race that was exposed because we were waiting for scripts in the stacktrace to come in. Turns in Node.js doesn't emit `Runtime.executionContextCreated` for its first context.

Refs https://github.com/nodejs/node/issues/47438

Fixes #1643