### PR TITLE
Write port to fd3

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -294,6 +294,11 @@ gulp.task('vsDebugServerBundle:webpack-bundle', async () => {
   return compileTs({ packages, sourcemap: isWatch });
 });
 
+gulp.task('debugServerMain:webpack-bundle', async () => {
+  const packages = [{ entry: `${srcDir}/debugServerMain.ts`, library: true }];
+  return compileTs({ packages, sourcemap: isWatch });
+});
+
 const vsceUrls = {
   baseContentUrl: 'https://github.com/microsoft/vscode-js-debug/blob/main',
   baseImagesUrl: 'https://github.com/microsoft/vscode-js-debug/raw/main',

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -431,7 +431,7 @@ export class DebugAdapter implements IDisposable {
     if (details) await this._thread.refreshStackTrace();
   }
 
-  createThread(cdp: Cdp.Api, target: ITarget): Thread {
+  createThread(cdp: Cdp.Api, target: ITarget, initializeParams?: Dap.InitializeParams): Thread {
     this._thread = new Thread(
       this.sourceContainer,
       cdp,
@@ -448,6 +448,14 @@ export class DebugAdapter implements IDisposable {
       this._services.get(SmartStepper),
       this._services.get(IShutdownParticipants),
     );
+
+    if (initializeParams) {
+      // We won't get notified of an initialize message:
+      // that was already caught by the caller.
+      setTimeout(() => {
+        this.onInitialize(initializeParams);
+      }, 0);
+    }
 
     const profile = this._services.get<IProfileController>(IProfileController);
     profile.connect(this.dap, this._thread);

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -84,6 +84,7 @@ export class Binder implements IDisposable {
   private _dap: Dap.Api;
   private _targetOrigin: ITargetOrigin;
   private _launchParams?: AnyLaunchConfiguration;
+  private _dapInitializeParams?: Dap.InitializeParams;
   private _asyncStackPolicy?: IAsyncStackPolicy;
   private _serviceTree = new WeakMap<ITarget, Container>();
 
@@ -120,6 +121,7 @@ export class Binder implements IDisposable {
         filterErrorsReportedToTelemetry();
       }
 
+      this._dapInitializeParams = clientCapabilities;
       setTimeout(() => dap.initialized({}), 0);
       return capabilities;
     });
@@ -408,7 +410,7 @@ export class Binder implements IDisposable {
     this._serviceTree.set(target, parentContainer);
 
     const debugAdapter = new DebugAdapter(dap, this._asyncStackPolicy, launchParams, container);
-    const thread = debugAdapter.createThread(cdp, target);
+    const thread = debugAdapter.createThread(cdp, target, this._dapInitializeParams);
 
     const startThread = async () => {
       await debugAdapter.launchBlocker();

--- a/src/debugServer.ts
+++ b/src/debugServer.ts
@@ -113,7 +113,12 @@ export function startDebugServer(port: number, host?: string): Promise<IDisposab
       })
       .on('error', reject)
       .listen({ port, host }, () => {
-        console.log(`Debug server listening at ${(server.address() as net.AddressInfo).port}`);
+        // Instead of printing the port used to stdout,
+        // send it over FD 3.
+        const address = server.address() as net.AddressInfo;
+        const fd3 = fs.createWriteStream('', { fd: 3 });
+        fd3.write(`${address.port}`, () => fd3.close());
+
         resolve({
           dispose: () => {
             server.close();


### PR DESCRIPTION
## Why?

This is another modification made to the [vendored version of js-debug](https://github.com/replit/goval/tree/main/nix/dapNode). This writes the port number listened to by the DAP server, and writes it to file descriptor 3, which will be captured by debugproxy and utilized.

## Change

Added the change.

## Testing

Follow the testing procedure for https://github.com/replit/vscode-js-debug/pull/1 in a repl. Wire it up to the debugger in `.replit` and try a debugging session.