### PR TITLE
Fix the race for the javascript terminal too

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1411,7 +1411,8 @@ export class Thread implements IVariableStoreLocationProvider {
     // initial scripts. Pretend these are actually loaded in the 2nd (main) context.
     // https://github.com/nodejs/node/issues/47438
     if (
-      this.launchConfig.type === DebugType.Node &&
+      (this.launchConfig.type === DebugType.Node ||
+        this.launchConfig.type === DebugType.Terminal) &&
       event.executionContextId === 0 &&
       !this._executionContexts.has(0)
     ) {


### PR DESCRIPTION
483425e50cf0fb313610d2346b51459c8db556e2 fixed a race condition, but included a hack to workaround a node bug. But the hack was too specific, and didn't apply to the javascript debug terminal.
