### PR TITLE
Add 'remoteHostHeader' option for node attach

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -24,6 +24,7 @@
 <h5>Default value:</h4><pre><code>"console"</pre></code><h4>pauseForSourceMap</h4><p>Whether to wait for source maps to load for each incoming script. This has a performance overhead, and might be safely disabled when running off of disk, so long as <code>rootPath</code> is not disabled.</p>
 <h5>Default value:</h4><pre><code>false</pre></code><h4>port</h4><p>Debug port to attach to. Default is 9229.</p>
 <h5>Default value:</h4><pre><code>9229</pre></code><h4>processId</h4><p>ID of process to attach to.</p>
+<h5>Default value:</h4><pre><code>undefined</pre></code><h4>remoteHostHeader</h4><p>Explicit Host header to use when connecting to the websocket of inspector. If unspecified, the host header will be set to &#39;localhost&#39;. This is useful when the inspector is running behind a proxy that only accept particular Host header.</p>
 <h5>Default value:</h4><pre><code>undefined</pre></code><h4>remoteRoot</h4><p>Absolute path to the remote directory containing the program.</p>
 <h5>Default value:</h4><pre><code>null</pre></code><h4>resolveSourceMapLocations</h4><p>A list of minimatch patterns for locations (folders and URLs) in which source maps can be used to resolve local files. This can be used to avoid incorrectly breaking in external source mapped code. Patterns can be prefixed with &quot;!&quot; to exclude them. May be set to an empty array or null to avoid restriction.</p>
 <h5>Default value:</h4><pre><code>[

--- a/package.nls.json
+++ b/package.nls.json
@@ -178,6 +178,7 @@
   "node.timeout.description": "Retry for this number of milliseconds to connect to Node.js. Default is 10000 ms.",
   "node.versionHint.description": "Allows you to explicitly specify the Node version that's running, which can be used to disable or enable certain behaviors in cases where the automatic version detection does not work.",
   "node.websocket.address.description": "Exact websocket address to attach to. If unspecified, it will be discovered from the address and port.",
+  "node.remote.host.header.description": "Explicit Host header to use when connecting to the websocket of inspector. If unspecified, the host header will be set to 'localhost'. This is useful when the inspector is running behind a proxy that only accept particular Host header.",
   "openEdgeDevTools.label": "Open Browser Devtools",
   "outFiles.description": "If source maps are enabled, these glob patterns specify the generated JavaScript files. If a pattern starts with `!` the files are excluded. If not specified, the generated code is expected in the same directory as its source.",
   "pretty.print.script": "Pretty print for debugging",

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -427,6 +427,11 @@ const nodeAttachConfig: IDebugger<INodeAttachConfiguration> = {
       description: refString('node.websocket.address.description'),
       default: undefined,
     },
+    remoteHostHeader: {
+      type: 'string',
+      description: refString('node.remote.host.header.description'),
+      default: undefined,
+    },
     restart: {
       description: refString('node.attach.restart.description'),
       default: true,

--- a/src/cdp/webSocketTransport.ts
+++ b/src/cdp/webSocketTransport.ts
@@ -27,6 +27,7 @@ export class WebSocketTransport implements ITransport {
   static async create(
     url: string,
     cancellationToken: CancellationToken,
+    remoteHostHeader?: string,
   ): Promise<WebSocketTransport> {
     const isSecure = !url.startsWith('ws://');
     const targetAddressIsLoopback = await isLoopback(url);
@@ -35,7 +36,7 @@ export class WebSocketTransport implements ITransport {
       const dontRetryBefore = Date.now() + maxRetryInterval;
       try {
         const options = {
-          headers: { host: 'localhost' },
+          headers: { host: remoteHostHeader ?? 'localhost' },
           perMessageDeflate: false,
           maxPayload: 256 * 1024 * 1024, // 256Mb
           rejectUnauthorized: !(isSecure && targetAddressIsLoopback),

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -524,6 +524,13 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
   websocketAddress?: string;
 
   /**
+   * Explicit Host header to use when connecting to the websocket of inspector.
+   * If not set, the host header will be set to 'localhost'.
+   * This is useful when the inspector is running behind a proxy that only accept particular Host header.
+   */
+  remoteHostHeader?: string;
+
+  /**
    * TCP/IP address of process to be debugged. Default is 'localhost'.
    */
   address: string;

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -86,6 +86,7 @@ export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
         ipcAddress: runData.serverAddress,
         scriptName: 'Remote Process',
         inspectorURL,
+        remoteHostHeader: runData.params.remoteHostHeader,
         waitForDebugger: true,
         dynamicAttach: true,
       });

--- a/src/targets/node/watchdogSpawn.ts
+++ b/src/targets/node/watchdogSpawn.ts
@@ -43,6 +43,13 @@ export interface IWatchdogInfo {
   inspectorURL: string;
 
   /**
+   * Explicit Host header to use when connecting to the websocket of inspector.
+   * If not set, the host header will be set to 'localhost'.
+   * This is useful when the inspector is running behind a proxy that only accept particular Host header.
+   */
+  remoteHostHeader?: string;
+
+  /**
    * Address on the debugging server to attach to.
    */
   ipcAddress: string;
@@ -190,7 +197,11 @@ export class WatchDog implements IDisposable {
 
   private async createTarget() {
     this.gracefulExit = false; // reset
-    const target = await WebSocketTransport.create(this.info.inspectorURL, this.cts.token);
+    const target = await WebSocketTransport.create(
+      this.info.inspectorURL,
+      this.cts.token,
+      this.info.remoteHostHeader,
+    );
     target.onMessage(([data]) => this.server.send(data));
     target.onEnd(() => {
       if (target) {


### PR DESCRIPTION
Fixes #778
Related: https://github.com/microsoft/vscode-js-debug/pull/667/files#r468093566

The use case is very clear here:
https://github.com/microsoft/vscode-js-debug/issues/778#issuecomment-1042536875

I notice that there is already a PR for this but with too old code base to merge.
I think the reason to take this feature is good enough since it is requested more than three times.

Clear use case again:
The remote gateway rule that reject host:localhost header is under control of my serverless cloud provider and I have no way to modify it. I already know that nodejs will only [accept ip address or localhost](https://nodejs.org/en/docs/guides/debugging-getting-started#browsers-websockets-and-same-origin-policy), but I can change the Host header back to `localhost` behind the cloud gateway with one more websocket proxy that in my control.
I think this is the only way to remote debug on such strict server.

