### PR TITLE
fix: vite sources on posix not setting breakpoints correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
+- fix: vite sources on posix not setting breakpoints correctly ([#1661](https://github.com/microsoft/vscode-js-debug/issues/1661))
 - fix: debugger failing on Node <=12 ([#1624](https://github.com/microsoft/vscode-js-debug/issues/1624))
 - fix: sourcemap lookups on ipv6 localhost addresses ([vscode#167353](https://github.com/microsoft/vscode/issues/167353))
 - fix: breakpoints not binding in certain cases if localRoot is a path child of remoteRoot ([#1617](https://github.com/microsoft/vscode-js-debug/issues/1617))
 - fix: browser debugging in remotes not working ([#1628](https://github.com/microsoft/vscode-js-debug/issues/1628))
+- fix: allow userDataDir in windows directory junctions ([#1656](https://github.com/microsoft/vscode-js-debug/issues/1656))
 - feat: support ETX in stdio console endings ([vscode#175763](https://github.com/microsoft/vscode/issues/175763))
+- feat: add 'remoteHostHeader' option for node attach ([#1664](https://github.com/microsoft/vscode-js-debug/issues/1664))
 
 ## v1.77 (March 2023)
 

--- a/src/adapter/breakpoints/breakpointBase.ts
+++ b/src/adapter/breakpoints/breakpointBase.ts
@@ -294,13 +294,14 @@ export abstract class Breakpoint {
     }
 
     // Find all locations for this breakpoint in the new script.
+    const scriptSource = await script.source;
     const uiLocations = this._manager._sourceContainer.currentSiblingUiLocations(
       {
         lineNumber: this.originalPosition.lineNumber,
         columnNumber: this.originalPosition.columnNumber,
         source,
       },
-      await script.source,
+      scriptSource,
     );
 
     if (!uiLocations.length) {
@@ -322,7 +323,7 @@ export abstract class Breakpoint {
         continue;
       }
 
-      if (!this.breakpointIsForSource(bp.args, source)) {
+      if (!this.breakpointIsForSource(bp.args, scriptSource)) {
         continue;
       }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-js-debug/issues/1661