### PR TITLE
fix remoteHostHeader option for redirect error

### DIFF
--- a/src/cdp/webSocketTransport.ts
+++ b/src/cdp/webSocketTransport.ts
@@ -56,7 +56,7 @@ export class WebSocketTransport implements ITransport {
                 return;
               }
 
-              this.create(redirectUrl, cancellationToken).then(resolve, reject);
+              this.create(redirectUrl, cancellationToken, remoteHostHeader).then(resolve, reject);
             });
           }),
           CancellationTokenSource.withTimeout(2000, cancellationToken).token,


### PR DESCRIPTION
fix #1664 which doesn't pass the `remoteHostHeader` arg on redirect error.