### PR TITLE
fix: ECONNREFUSED when debugging from WSL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -121,7 +121,7 @@
     },
     {
       "name": "Extension and Companion",
-      "type": "pwa-extensionHost",
+      "type": "extensionHost",
       "request": "launch",
       "skipFiles": [
         "<node_internals>/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
-Nothing, yet.
+- fix: ECONNREFUSED when debugging from WSL (requires VS Code Insiders until release) ([#1603](https://github.com/microsoft/vscode-js-debug/issues/1603))
 
 ## v1.78 (April 2024)
 

--- a/src/ui/companionBrowserLaunch.ts
+++ b/src/ui/companionBrowserLaunch.ts
@@ -74,6 +74,11 @@ const launchCompanionBrowser = async (
 
     await vscode.commands.executeCommand('js-debug-companion.launchAndAttach', {
       proxyUri: tunnel ? `127.0.0.1:${tunnel.localAddress.port}` : `127.0.0.1:${args.serverPort}`,
+      wslInfo: process.env.WSL_DISTRO_NAME && {
+        execPath: process.execPath,
+        distro: process.env.WSL_DISTRO_NAME,
+        user: process.env.USER,
+      },
       ...args,
     });
   } catch (e) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-js-debug/issues/1603
Works with https://github.com/microsoft/vscode-js-debug-companion/pull/24