### PR TITLE
fix: step into `eval` when `pauseForSourceMap` is true does not pause on next available line

### DIFF
--- a/src/test/breakpoints/breakpoints-does-not-interrupt-stepin-with-instrumentation-breakpoint-1665.txt
+++ b/src/test/breakpoints/breakpoints-does-not-interrupt-stepin-with-instrumentation-breakpoint-1665.txt
@@ -1,0 +1,26 @@
+Evaluating#1: test()
+{
+    allThreadsStopped : false
+    description : Paused on debugger statement
+    reason : pause
+    threadId : <number>
+}
+test @ <eval>/VM<xx>:4:13
+<anonymous> @ eval1.js:1:1
+{
+    allThreadsStopped : false
+    description : Paused
+    reason : step
+    threadId : <number>
+}
+test @ <eval>/VM<xx>:5:13
+<anonymous> @ eval1.js:1:1
+{
+    allThreadsStopped : false
+    description : Paused
+    reason : step
+    threadId : <number>
+}
+<anonymous> @ foo.js:2:15
+test @ <eval>/VM<xx>:5:15
+<anonymous> @ eval1.js:1:1


### PR DESCRIPTION
Fixes #1665

Test failure is a different issue in main, fixing that in another PR