### PR TITLE
fix: solving the problem of escaped backslashes in regular expressions.

### DIFF
--- a/src/adapter/objectPreview/index.ts
+++ b/src/adapter/objectPreview/index.ts
@@ -61,6 +61,9 @@ export function previewRemoteObject(
     context,
     valueFormat,
   );
+
+  if (object.preview?.subtype === 'regexp') return result;
+
   return context.postProcess?.(result) ?? result;
 }
 


### PR DESCRIPTION
## Fix
backslash which in regexp SHOULD NOT be escaped as a string.

## Reproduce Sample Code
```js
const regArr = [/hello\w+/];
const reg0 = regArr[0];
debugger;
```

## Incorrect:
![image](https://user-images.githubusercontent.com/24789328/236610844-87fe5f47-d200-43fe-b69e-cf0935416058.png)

## Correct
![image](https://user-images.githubusercontent.com/24789328/236626490-29f8c4f7-6cbd-42f9-bc9d-99b3e8726387.png)

## After fixed
<img width="890" alt="image" src="https://user-images.githubusercontent.com/24789328/236627201-1487cf9c-ba60-41a8-8807-71541be6e24f.png">





