### PR TITLE
chore: 'hoist' package to reduce pipeline variance

### DIFF
--- a/.ci/publish-nightly.yml
+++ b/.ci/publish-nightly.yml
@@ -17,7 +17,6 @@ parameters:
 extends:
   template: azure-pipelines/extension/pre-release.yml@templates
   parameters:
-    workingDirectory: dist
     usePreReleaseChannel: false
     vscePackageArgs: --no-dependencies
     cgIgnoreDirectories: 'testdata,demos,.vscode-test'
@@ -26,8 +25,8 @@ extends:
       - script: npm install --legacy-peer-deps
         displayName: Install dependencies
 
-      - script: npm run compile -- package:prepare --nightly
-        displayName: Package
-
-      - script: npx -y @vscode/l10n-dev export --outDir ./dist/l10n-extract ./src
+      - script: npx -y @vscode/l10n-dev export --outDir ./l10n-extract ./src
         displayName: Extract localization
+
+      - script: npm run compile -- package:hoist --nightly
+        displayName: Package

--- a/.ci/publish.yml
+++ b/.ci/publish.yml
@@ -24,7 +24,6 @@ parameters:
 extends:
   template: azure-pipelines/extension/stable.yml@templates
   parameters:
-    workingDirectory: dist
     publishExtension: ${{ parameters.publishExtension }}
     vscePackageArgs: --no-dependencies
     cgIgnoreDirectories: 'testdata,demos,.vscode-test'
@@ -32,8 +31,8 @@ extends:
       ghCreateRelease: true
       ghReleaseAddChangeLog: true
     l10nShouldOnlyPush: true
-    l10nPackageNlsPath: ../package.nls.json
-    l10nSourcePaths: ../src
+    l10nPackageNlsPath: package.nls.json
+    l10nSourcePaths: src
     buildSteps:
       - script: npm install --legacy-peer-deps
         displayName: Install dependencies
@@ -47,5 +46,5 @@ extends:
       - publish: $(Build.ArtifactStagingDirectory)/dap-server
         artifact: Publish DAP Debug Server Bundle
 
-      - script: npm run compile -- package:prepare
+      - script: npm run compile -- package:hoist
         displayName: Package Stable

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,6 @@
         "chai-as-promised": "^7.1.1",
         "chai-string": "^1.5.0",
         "chai-subset": "^1.6.0",
-        "deepmerge": "^4.2.2",
         "del": "^6.0.0",
         "diff": "^5.0.0",
         "esbuild": "^0.17.10",
@@ -4539,15 +4538,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/default-browser": {
       "version": "2.0.1",
@@ -18400,12 +18390,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
     "default-browser": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
     "chai-subset": "^1.6.0",
-    "deepmerge": "^4.2.2",
     "del": "^6.0.0",
     "diff": "^5.0.0",
     "esbuild": "^0.17.10",
@@ -174,16 +173,5 @@
   ],
   "extensionKind": [
     "workspace"
-  ],
-  "contributes": {
-    "terminal": {
-      "profiles": [
-        {
-          "id": "extension.js-debug.debugTerminal",
-          "title": "%debug.terminal.label%",
-          "icon": "$(debug)"
-        }
-      ]
-    }
-  }
+  ]
 }

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -1591,6 +1591,15 @@ if (require.main === module) {
           title: 'JavaScript Debugger',
           properties: configurationSchema,
         },
+        terminal: {
+          profiles: [
+            {
+              id: 'extension.js-debug.debugTerminal',
+              title: refString('debug.terminal.label'),
+              icon: '$(debug)',
+            },
+          ],
+        },
         views,
         viewsWelcome,
       },


### PR DESCRIPTION
This adds a new build mode where the built assets will replace those in the repo. This can be used in pipelines to avoid having the "workingDir" that doesn't exist until later.

I also looked at modifying the checked-in package.json, but this was difficult because:

(a) we modify the _name_ for nightly builds, which includes local
    development, and having this change based on the build is noisy.
(b) there's just a lot of package.json (about 13k lines) which
    uncompressed is sizable