### PR TITLE
fix: increase smart step backout threshold for better stepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: step into `eval` when `pauseForSourceMap` is true does not pause on next available line ([#1692](https://github.com/microsoft/vscode-js-debug/issues/1692))
 - fix: useWebview debug sessions getting stuck if program exits without attaching ([#1666](https://github.com/microsoft/vscode-js-debug/issues/1666))
 - fix: do not to translate "promise rejection" ([#1658](https://github.com/microsoft/vscode-js-debug/issues/1658))
+- fix: increase smart step backout threshold for better stepping ([#1700](https://github.com/microsoft/vscode-js-debug/issues/1700))
 
 ## v1.78 (April 2024)
 

--- a/src/adapter/smartStepping.ts
+++ b/src/adapter/smartStepping.ts
@@ -41,7 +41,7 @@ export async function shouldStepOverStackFrame(
 
 const neverStepReasons: ReadonlySet<PausedReason> = new Set(['breakpoint', 'exception', 'entry']);
 
-const smartStepBackoutThreshold = 16;
+const smartStepBackoutThreshold = 256;
 
 /**
  * The SmartStepper is a device that controls stepping through code that lacks


### PR DESCRIPTION
Fixes #1700

A step/pause pair usually takes <3ms, so I think we can be much more generous with our threshold