### PR TITLE
fix: breakpoints not hitting early on in nested sourcemapped programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: step into `eval` when `pauseForSourceMap` is true does not pause on next available line ([#1692](https://github.com/microsoft/vscode-js-debug/issues/1692))
 - fix: useWebview debug sessions getting stuck if program exits without attaching ([#1666](https://github.com/microsoft/vscode-js-debug/issues/1666))
 - fix: do not to translate "promise rejection" ([#1658](https://github.com/microsoft/vscode-js-debug/issues/1658))
+- fix: breakpoints not hitting early on in nested sourcemapped programs ([#1704](https://github.com/microsoft/vscode-js-debug/issues/1704))
 
 ## v1.78 (April 2024)
 

--- a/src/common/sourceMaps/turboGlobStream.test.ts
+++ b/src/common/sourceMaps/turboGlobStream.test.ts
@@ -195,4 +195,17 @@ describe('TurboGlobStream', () => {
 
     expect(fileProcessor.callCount).to.equal(2);
   });
+
+  it('applies filters currectly', async () => {
+    const fileProcessor = spy(upperCaseContents);
+    await doTests({
+      expected: ['A1'],
+      opts: {
+        filter: fpath => fpath.endsWith('1.js'),
+        pattern: 'a/*.js',
+        ignore: [],
+        fileProcessor,
+      },
+    });
+  });
 });

--- a/src/common/sourceMaps/turboGlobStream.ts
+++ b/src/common/sourceMaps/turboGlobStream.ts
@@ -214,12 +214,7 @@ export class TurboGlobStream<E> {
       return true;
     }
 
-    if (!this.filter(path)) {
-      return true;
-    }
-
     const data = child.data?.type === CachedType.File ? child.data.extracted : undefined;
-    this.alreadyProcessedFiles.add(child);
     CacheTree.touch(child);
 
     return this.filter(path, data);
@@ -243,7 +238,7 @@ export class TurboGlobStream<E> {
       return;
     }
 
-    // note: intentionally making the child before the filder check, so it
+    // note: intentionally making the child before the filter check, so it
     // exists in the tree even if this current glob filters it out
     const nextChild = CacheTree.getOrMakeChild(cache, dirent.name);
     if (dirent.type === CachedType.File && !this.applyFilterToFile(dirent.name, nextPath, cache)) {


### PR DESCRIPTION
The filter was missed in unit testing and didn't actually work correctly. In most cases this didn't lead to a visible failure, but this fixes it.

Fixes #1704