### PR TITLE
fix: improve previews of maps and sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: terminal launches sometimes sending commands too soon ([#1642](https://github.com/microsoft/vscode-js-debug/issues/1642))
 - fix: step into `eval` when `pauseForSourceMap` is true does not pause on next available line ([#1692](https://github.com/microsoft/vscode-js-debug/issues/1692))
 - fix: useWebview debug sessions getting stuck if program exits without attaching ([#1666](https://github.com/microsoft/vscode-js-debug/issues/1666))
+- fix: improve the display of map and set entries
 - fix: do not to translate "promise rejection" ([#1658](https://github.com/microsoft/vscode-js-debug/issues/1658))
 - fix: breakpoints not hitting early on in nested sourcemapped programs ([#1704](https://github.com/microsoft/vscode-js-debug/issues/1704))
 - fix: sourcemap predictor not filtering nested session on windows ([#1719](https://github.com/microsoft/vscode-js-debug/issues/1719))

--- a/src/adapter/objectPreview/betterTypes.ts
+++ b/src/adapter/objectPreview/betterTypes.ts
@@ -27,7 +27,14 @@ export type TFunction = {
   // defined in V8, undefined in Hermes
   description?: string;
 };
-export type FunctionPreview = { type: 'function'; subtype: undefined; description: string };
+export type FunctionPreview = {
+  type: 'function';
+  subtype: undefined;
+  description: string;
+  entries?: undefined;
+  properties?: undefined;
+  overflow?: undefined;
+};
 export type FunctionObj = TFunction;
 
 export type TNode = {
@@ -37,6 +44,32 @@ export type TNode = {
 };
 export type NodePreview = TNode & ObjectPreview;
 export type NodeObj = TNode & { preview: NodePreview };
+
+export type TSet = {
+  type: 'object';
+  subtype: 'set';
+  className: string;
+  description: string;
+};
+export type SetPreview = TSet & {
+  entries: { key?: undefined; value: AnyPreview }[];
+  properties: PropertyPreview[];
+  overflow: boolean;
+};
+export type SetObj = TSet & { preview: SetPreview };
+
+export type TMap = {
+  type: 'object';
+  subtype: 'map';
+  className: string;
+  description: string;
+};
+export type MapPreview = TMap & {
+  entries: { key: AnyPreview; value: AnyPreview }[];
+  properties: PropertyPreview[];
+  overflow: boolean;
+};
+export type MapObj = TMap & { preview: MapPreview };
 
 export type TString = {
   type: 'string';
@@ -110,6 +143,8 @@ export type AnyObject =
   | ObjectObj
   | NodeObj
   | ArrayObj
+  | SetObj
+  | MapObj
   | ErrorObj
   | RegExpObj
   | FunctionObj
@@ -120,6 +155,8 @@ export type AnyObject =
   | NullObj;
 export type AnyPreview =
   | ObjectPreview
+  | SetPreview
+  | MapPreview
   | NodePreview
   | ArrayPreview
   | ErrorPreview
@@ -130,7 +167,12 @@ export type AnyPreview =
   | UndefinedPreview
   | NullPreview;
 
-export type PreviewAsObjectType = NodePreview | FunctionPreview | ObjectPreview;
+export type PreviewAsObjectType =
+  | NodePreview
+  | FunctionPreview
+  | ObjectPreview
+  | MapPreview
+  | SetPreview;
 export type Numeric = NumberPreview | BigintPreview | TSpecialNumber;
 export type Primitive =
   | NullPreview

--- a/src/adapter/objectPreview/index.ts
+++ b/src/adapter/objectPreview/index.ts
@@ -169,7 +169,7 @@ function renderArrayPreview(preview: ObjectPreview.ArrayPreview, characterBudget
 }
 
 function renderObjectPreview(
-  preview: ObjectPreview.ObjectPreview | ObjectPreview.NodePreview,
+  preview: ObjectPreview.PreviewAsObjectType,
   characterBudget: number,
   format: Dap.ValueFormat | undefined,
 ): string {

--- a/src/test/evaluate/evaluate-repl.txt
+++ b/src/test/evaluate/evaluate-repl.txt
@@ -25,8 +25,8 @@ result: 1234567890n
 
 
 > result: Map(1) {size: 1, hello => ƒ ()}
+    > 0: {"hello" => function() { return 'world' }}
     size: 1
-    > [[Entries]]: Array(1)
     > [[Prototype]]: Map
 
 result: 42

--- a/src/test/evaluate/evaluate-supports-bigint-map-keys-1277.txt
+++ b/src/test/evaluate/evaluate-supports-bigint-map-keys-1277.txt
@@ -1,4 +1,5 @@
 > result: Map(2) {size: 2, 1n => one, 2n => two}
+    > 0: {1n => "one"}
+    > 1: {2n => "two"}
     size: 2
-    > [[Entries]]: Array(2)
     > [[Prototype]]: Map


### PR DESCRIPTION
Objects and sets now show their values under the first expansion instead
of requiring the user to expand an additional level. Also, their
accessors are fixed which allows "copy value" and "copy as expression"/

![](https://memes.peet.io/img/23-06-2bb71702-f805-46d8-aff2-6cf3b8dd40c1.png)