### PR TITLE
fix: runtime error when loading electron preloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - fix: set breakpoints predictably when launching with files ([#1748](https://github.com/microsoft/vscode-js-debug/issues/1748))
+- fix: don't overwrite custom NODE_OPTIONS ([#1746](https://github.com/microsoft/vscode-js-debug/issues/1746))
 
 ## v1.80 (June 2023)
 

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -107,6 +107,11 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
       return false;
     }
 
+    // Empty URL modules present in Electron (found looking at #1741)
+    if (compiledPath === '') {
+      return false;
+    }
+
     if (!this.resolvePatterns || this.resolvePatterns.length === 0) {
       return true;
     }


### PR DESCRIPTION
Didn't seem to actually cause any issues, just noticed and error in the logs.