### PR TITLE
Remove extra bracket from command line copy utility

### DIFF
--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -626,7 +626,7 @@ export class Thread implements IVariableStoreLocationProvider {
             output: l10n.t(
               'Output has been truncated to the first {0} characters. Run `{1}` to copy the full output.',
               budget,
-              `copy(${originalCall.expression.trim()}))`,
+              `copy(${originalCall.expression.trim()})`,
             ),
             category: 'stdout',
           }),


### PR DESCRIPTION
Excellent project, I love that it just always works out of the box! Thanks! This is just a minor fix where one of the utility outputs were off by a character.

The output was:
```bash
Output has been truncated to the first 100000 characters. Run `copy(object))` to copy the full output.
```

Which just results in a syntax error:
```bash
Uncaught SyntaxError SyntaxError: Unexpected token ')'
```