### PR TITLE
fix: immediately log stdout/err unless EXT is encountered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "signale": "^1.4.0",
         "source-map": "0.8.0-beta.0",
         "source-map-support": "^0.5.21",
-        "split2": "^4.1.0",
+        "split2": "^4.2.0",
         "to-absolute-glob": "^2.0.2",
         "vscode-tas-client": "^0.1.42",
         "ws": "^8.5.0"
@@ -71,7 +71,7 @@
         "@types/prettier": "^2.4.4",
         "@types/signale": "^1.4.4",
         "@types/sinon": "^10.0.11",
-        "@types/split2": "^3.2.1",
+        "@types/split2": "^4.2.0",
         "@types/stream-buffers": "^3.0.4",
         "@types/tmp": "^0.2.3",
         "@types/to-absolute-glob": "^2.0.1",
@@ -1909,9 +1909,9 @@
       "dev": true
     },
     "node_modules/@types/split2": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/split2/-/split2-3.2.1.tgz",
-      "integrity": "sha512-7uz3yU+LooBq4yNOzlZD9PU9/1Eu0rTD1MjQ6apOVEoHsPrMUrFw7W8XrvWtesm2vK67SBK9AyJcOXtMpl9bgQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-rwV0tC3XGQvQ8zdeYDZ+dLn4CJLKnYPBrSU8dRXvzMVLUPMsYTsy3/ZbE4OlejsT2D7MTGP8ePk05C98xl2seQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -13284,9 +13284,9 @@
       }
     },
     "node_modules/split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "engines": {
         "node": ">= 10.x"
       }
@@ -16392,9 +16392,9 @@
       "dev": true
     },
     "@types/split2": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/split2/-/split2-3.2.1.tgz",
-      "integrity": "sha512-7uz3yU+LooBq4yNOzlZD9PU9/1Eu0rTD1MjQ6apOVEoHsPrMUrFw7W8XrvWtesm2vK67SBK9AyJcOXtMpl9bgQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-rwV0tC3XGQvQ8zdeYDZ+dLn4CJLKnYPBrSU8dRXvzMVLUPMsYTsy3/ZbE4OlejsT2D7MTGP8ePk05C98xl2seQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -25167,9 +25167,9 @@
       }
     },
     "split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "signale": "^1.4.0",
     "source-map": "0.8.0-beta.0",
     "source-map-support": "^0.5.21",
-    "split2": "^4.1.0",
+    "split2": "^4.2.0",
     "to-absolute-glob": "^2.0.2",
     "vscode-tas-client": "^0.1.42",
     "ws": "^8.5.0"
@@ -118,7 +118,7 @@
     "@types/prettier": "^2.4.4",
     "@types/signale": "^1.4.4",
     "@types/sinon": "^10.0.11",
-    "@types/split2": "^3.2.1",
+    "@types/split2": "^4.2.0",
     "@types/stream-buffers": "^3.0.4",
     "@types/tmp": "^0.2.3",
     "@types/to-absolute-glob": "^2.0.1",

--- a/src/test/console/console-format-ext-handling.txt
+++ b/src/test/console/console-format-ext-handling.txt
@@ -1,0 +1,7 @@
+{"category":"stdout","output":"hello"}
+{"category":"stdout","output":"world"}
+{"category":"stdout","output":"new line\nasdf"}
+{"category":"stdout","output":"now ext\n"}
+{"category":"stdout","output":"this should be bulkedwith this!\n"}
+{"category":"stderr","output":"Waiting for the debugger to disconnect...\n"}
+{"category":"stdout","output":"trailing"}


### PR DESCRIPTION
Previously when supporting EXT we added per-line splitting and emitting,
but we actually should just reemit things immediately unless we see
an EXT.

Fixes https://github.com/microsoft/vscode/issues/181785