### PR TITLE
Speed up sourcemap lookups by checking existance of .map files

### DIFF
--- a/src/common/sourceMaps/cacheTree.ts
+++ b/src/common/sourceMaps/cacheTree.ts
@@ -20,6 +20,7 @@ export namespace CacheTree {
    * separated with forward slashes.
    */
   export function getPath<T>(node: CacheTree<T>, directory: string) {
+    node[touched] = 1;
     return _getDir(node, splitDir(directory), 0);
   }
 

--- a/src/common/sourceMaps/sourceMapRepository.ts
+++ b/src/common/sourceMaps/sourceMapRepository.ts
@@ -2,7 +2,6 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { Dirent } from 'fs';
 import { xxHash32 } from 'js-xxhash';
 import { basename } from 'path';
 import { FileGlobList } from '../fileGlobList';
@@ -69,16 +68,14 @@ export interface ISearchStrategy {
  */
 export const createMetadataForFile = async (
   compiledPath: string,
-  siblings: Dirent[],
+  siblings: readonly string[],
   fileContents?: string,
 ): Promise<Required<ISourceMapMetadata> | undefined> => {
   let sourceMapUrl;
   const compiledFileName = basename(compiledPath);
-  for (const sibling of siblings) {
-    if (sibling.isFile() && sibling.name === `${compiledFileName}.map`) {
-      sourceMapUrl = sibling.name;
-      break;
-    }
+  const maybeSibling = `${compiledFileName}.map`;
+  if (siblings.includes(maybeSibling)) {
+    sourceMapUrl = maybeSibling;
   }
   if (!sourceMapUrl) {
     if (typeof fileContents === 'undefined') {

--- a/src/common/sourceMaps/sourceMapRepository.ts
+++ b/src/common/sourceMaps/sourceMapRepository.ts
@@ -8,6 +8,7 @@ import { IFsUtils, readfile, stat } from '../fsUtils';
 import { parseSourceMappingUrl } from '../sourceUtils';
 import { absolutePathToFileUrl, completeUrl, fileUrlToAbsolutePath, isDataUri } from '../urlUtils';
 import { ISourceMapMetadata } from './sourceMap';
+
 /**
  * A copy of vscode.RelativePattern, but we can't to import 'vscode' here.
  */

--- a/src/common/sourceMaps/turboGlobStream.test.ts
+++ b/src/common/sourceMaps/turboGlobStream.test.ts
@@ -80,7 +80,7 @@ describe('TurboGlobStream', () => {
       },
     });
 
-    expect(fileProcessor.callCount).to.equal(1);
+    expect(fileProcessor.args).to.deep.equal([[join(dir, 'a', 'a1.js'), ['a1.js', 'a2.js']]]);
   });
 
   it('uses platform preferred path', async () => {
@@ -109,7 +109,10 @@ describe('TurboGlobStream', () => {
       },
     });
 
-    expect(fileProcessor.callCount).to.equal(2);
+    expect(fileProcessor.args.slice().sort((a, b) => a[0].localeCompare(b[0]))).to.deep.equal([
+      [join(dir, 'a', 'a1.js'), ['a1.js', 'a2.js']],
+      [join(dir, 'a', 'a2.js'), ['a1.js', 'a2.js']],
+    ]);
   });
 
   it('globs for files recursively', async () => {
@@ -123,7 +126,13 @@ describe('TurboGlobStream', () => {
       },
     });
 
-    expect(fileProcessor.callCount).to.equal(5);
+    expect(fileProcessor.args.slice().sort((a, b) => a[0].localeCompare(b[0]))).to.deep.equal([
+      [join(dir, 'a', 'a1.js'), ['a1.js', 'a2.js']],
+      [join(dir, 'a', 'a2.js'), ['a1.js', 'a2.js']],
+      [join(dir, 'b', 'b1.js'), ['b1.js', 'b2.js']],
+      [join(dir, 'b', 'b2.js'), ['b1.js', 'b2.js']],
+      [join(dir, 'c', 'nested', 'a', 'c1.js'), ['c1.js']],
+    ]);
   });
 
   it('globs star dirname', async () => {

--- a/src/common/sourceMaps/turboGlobStream.test.ts
+++ b/src/common/sourceMaps/turboGlobStream.test.ts
@@ -31,7 +31,15 @@ describe('TurboGlobStream', () => {
     for (let i = 0; i < 2; i++) {
       await new Promise((resolve, reject) => {
         const matches: T[] = [];
-        const tgs = new TurboGlobStream({ cwd: dir, ...opts, cache });
+        const tgs = new TurboGlobStream({
+          cwd: dir,
+          ...opts,
+          cache,
+          fileProcessor: (fname, meta) => {
+            delete (meta as Record<string, unknown>).mtime; // delete this since it'll change for every test
+            return opts.fileProcessor(fname, meta);
+          },
+        });
         tgs.onError(reject);
         tgs.onFile(result => matches.push(result));
         tgs.done
@@ -80,7 +88,9 @@ describe('TurboGlobStream', () => {
       },
     });
 
-    expect(fileProcessor.args).to.deep.equal([[join(dir, 'a', 'a1.js'), ['a1.js', 'a2.js']]]);
+    expect(fileProcessor.args).to.deep.equal([
+      [join(dir, 'a', 'a1.js'), { siblings: ['a1.js', 'a2.js'] }],
+    ]);
   });
 
   it('uses platform preferred path', async () => {
@@ -110,8 +120,8 @@ describe('TurboGlobStream', () => {
     });
 
     expect(fileProcessor.args.slice().sort((a, b) => a[0].localeCompare(b[0]))).to.deep.equal([
-      [join(dir, 'a', 'a1.js'), ['a1.js', 'a2.js']],
-      [join(dir, 'a', 'a2.js'), ['a1.js', 'a2.js']],
+      [join(dir, 'a', 'a1.js'), { siblings: ['a1.js', 'a2.js'] }],
+      [join(dir, 'a', 'a2.js'), { siblings: ['a1.js', 'a2.js'] }],
     ]);
   });
 
@@ -127,11 +137,11 @@ describe('TurboGlobStream', () => {
     });
 
     expect(fileProcessor.args.slice().sort((a, b) => a[0].localeCompare(b[0]))).to.deep.equal([
-      [join(dir, 'a', 'a1.js'), ['a1.js', 'a2.js']],
-      [join(dir, 'a', 'a2.js'), ['a1.js', 'a2.js']],
-      [join(dir, 'b', 'b1.js'), ['b1.js', 'b2.js']],
-      [join(dir, 'b', 'b2.js'), ['b1.js', 'b2.js']],
-      [join(dir, 'c', 'nested', 'a', 'c1.js'), ['c1.js']],
+      [join(dir, 'a', 'a1.js'), { siblings: ['a1.js', 'a2.js'] }],
+      [join(dir, 'a', 'a2.js'), { siblings: ['a1.js', 'a2.js'] }],
+      [join(dir, 'b', 'b1.js'), { siblings: ['b1.js', 'b2.js'] }],
+      [join(dir, 'b', 'b2.js'), { siblings: ['b1.js', 'b2.js'] }],
+      [join(dir, 'c', 'nested', 'a', 'c1.js'), { siblings: ['c1.js'] }],
     ]);
   });
 

--- a/src/common/sourceMaps/turboSearchStrategy.ts
+++ b/src/common/sourceMaps/turboSearchStrategy.ts
@@ -82,8 +82,8 @@ export class TurboSearchStrategy implements ISearchStrategy {
       cwd: glob.cwd,
       cache,
       filter: opts.filter,
-      fileProcessor: (file, siblings) =>
-        createMetadataForFile(file, siblings).then(m => m && opts.processMap(m)),
+      fileProcessor: (file, metadata) =>
+        createMetadataForFile(file, metadata).then(m => m && opts.processMap(m)),
     });
 
     tgs.onError(({ path, error }) => {

--- a/src/common/sourceMaps/turboSearchStrategy.ts
+++ b/src/common/sourceMaps/turboSearchStrategy.ts
@@ -2,11 +2,9 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { promises as fsPromises } from 'fs';
 import globStream from 'glob-stream';
 import { inject, injectable } from 'inversify';
 import { FileGlobList, IExplodedGlob } from '../fileGlobList';
-import { LocalFsUtils } from '../fsUtils';
 import { ILogger, LogTag } from '../logging';
 import { truthy } from '../objUtils';
 import { fixDriveLetterAndSlashes } from '../pathUtils';
@@ -26,8 +24,6 @@ type CachedType<T> = CacheTree<IGlobCached<T>>;
 @injectable()
 export class TurboSearchStrategy implements ISearchStrategy {
   constructor(@inject(ILogger) protected readonly logger: ILogger) {}
-
-  fsUtils: LocalFsUtils = new LocalFsUtils(fsPromises);
 
   /**
    * @inheritdoc
@@ -86,8 +82,8 @@ export class TurboSearchStrategy implements ISearchStrategy {
       cwd: glob.cwd,
       cache,
       filter: opts.filter,
-      fileProcessor: file =>
-        createMetadataForFile(this.fsUtils, file).then(m => m && opts.processMap(m)),
+      fileProcessor: (file, siblings) =>
+        createMetadataForFile(file, siblings).then(m => m && opts.processMap(m)),
     });
 
     tgs.onError(({ path, error }) => {


### PR DESCRIPTION
**Problem**
Debugging experience is slow in large monorepos, since all the files are read to check location of sourcemap file

**PR fix**
Check if .map file exists for compiled file we don't need to read file to find location of sourcemap location. 

**Possible issue**
If there is a js file and it has .map file which is not a sourcemap file with same js file name, it can lead to issue.
This however should be rare edge case.
