### PR TITLE
feat: make wasm variable store work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^5.17.0",
         "@typescript-eslint/parser": "^5.17.0",
+        "@vscode/dwarf-debugging": "^0.0.2",
         "@vscode/test-electron": "^2.2.3",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
@@ -2278,6 +2279,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vscode/dwarf-debugging": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/dwarf-debugging/-/dwarf-debugging-0.0.2.tgz",
+      "integrity": "sha512-u/sQV5SBYOzAFE9Wy0N9oH+FbpZ/KJCl9ESv+3I6G7IAQXvmzFOdkA+BCTFLgZl89viT28SoHmZk4ZPwjQhIkA==",
+      "dev": true,
+      "dependencies": {
+        "ws": "^8.14.1"
       }
     },
     "node_modules/@vscode/js-debug-browsers": {
@@ -14816,15 +14826,15 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -16642,6 +16652,15 @@
       "requires": {
         "@typescript-eslint/types": "5.17.0",
         "eslint-visitor-keys": "^3.0.0"
+      }
+    },
+    "@vscode/dwarf-debugging": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/dwarf-debugging/-/dwarf-debugging-0.0.2.tgz",
+      "integrity": "sha512-u/sQV5SBYOzAFE9Wy0N9oH+FbpZ/KJCl9ESv+3I6G7IAQXvmzFOdkA+BCTFLgZl89viT28SoHmZk4ZPwjQhIkA==",
+      "dev": true,
+      "requires": {
+        "ws": "^8.14.1"
       }
     },
     "@vscode/js-debug-browsers": {
@@ -26393,9 +26412,9 @@
       }
     },
     "ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "requires": {}
     },
     "xdg-default-browser": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
+    "@vscode/dwarf-debugging": "^0.0.2",
     "@vscode/test-electron": "^2.2.3",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/src/adapter/dwarf/dwarfModuleProvider.ts
+++ b/src/adapter/dwarf/dwarfModuleProvider.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export const IDwarfModuleProvider = Symbol('IDwarfModuleProvider');
+
+export interface IDwarfModuleProvider {
+  /**
+   * Loads the dwarf module if it exists.
+   */
+  load(): Promise<typeof import('@vscode/dwarf-debugging') | undefined>;
+
+  /**
+   * Prompts the user to install the dwarf module (called if the module is
+   * not installed.)
+   */
+  prompt(): void;
+}

--- a/src/adapter/dwarf/dwarfModuleProviderImpl.ts
+++ b/src/adapter/dwarf/dwarfModuleProviderImpl.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import type * as dwf from '@vscode/dwarf-debugging';
+import * as l10n from '@vscode/l10n';
+import { inject, injectable } from 'inversify';
+import Dap from '../../dap/api';
+import { IDapApi } from '../../dap/connection';
+import { IDwarfModuleProvider } from './dwarfModuleProvider';
+
+const name = '@vscode/dwarf-debugging';
+
+@injectable()
+export class DwarfModuleProvider implements IDwarfModuleProvider {
+  private didPrompt = false;
+
+  constructor(@inject(IDapApi) private readonly dap: Dap.Api) {}
+
+  public async load(): Promise<typeof dwf | undefined> {
+    try {
+      return await import(name);
+    } catch {
+      return undefined;
+    }
+  }
+
+  public prompt() {
+    if (!this.didPrompt) {
+      this.didPrompt = true;
+      this.dap.output({
+        output: l10n.t(
+          'You may install the `{}` module via npm for enhanced WebAssembly debugging',
+          name,
+        ),
+        category: 'console',
+      });
+    }
+  }
+}

--- a/src/adapter/pause.ts
+++ b/src/adapter/pause.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import Cdp from '../cdp/api';
+import { IPossibleBreakLocation } from './breakpoints';
+import { StackTrace } from './stackTrace';
+import { Thread } from './threads';
+
+export type PausedReason =
+  | 'step'
+  | 'breakpoint'
+  | 'exception'
+  | 'pause'
+  | 'entry'
+  | 'goto'
+  | 'function breakpoint'
+  | 'data breakpoint'
+  | 'frame_entry';
+
+export const enum StepDirection {
+  In,
+  Over,
+  Out,
+}
+
+export type ExpectedPauseReason =
+  | { reason: Exclude<PausedReason, 'step'>; description?: string }
+  | { reason: 'step'; description?: string; direction: StepDirection };
+
+export interface IPausedDetails {
+  thread: Thread;
+  reason: PausedReason;
+  event: Cdp.Debugger.PausedEvent;
+  description: string;
+  stackTrace: StackTrace;
+  stepInTargets?: IPossibleBreakLocation[];
+  hitBreakpoints?: string[];
+  text?: string;
+  exception?: Cdp.Runtime.RemoteObject;
+}

--- a/src/adapter/smartStepping.ts
+++ b/src/adapter/smartStepping.ts
@@ -6,10 +6,10 @@ import { inject, injectable } from 'inversify';
 import { ILogger, LogTag } from '../common/logging';
 import { isInstanceOf } from '../common/objUtils';
 import { AnyLaunchConfiguration } from '../configuration';
+import { ExpectedPauseReason, IPausedDetails, PausedReason, StepDirection } from './pause';
 import { isSourceWithMap } from './source';
 import { UnmappedReason } from './sourceContainer';
 import { StackFrame } from './stackTrace';
-import { ExpectedPauseReason, IPausedDetails, PausedReason, StepDirection } from './threads';
 
 export const enum StackFrameStepOverReason {
   NotStepped,

--- a/src/adapter/source.ts
+++ b/src/adapter/source.ts
@@ -509,6 +509,7 @@ export const isSourceWithWasm = (
   source: unknown,
 ): source is ISourceWithMap<IWasmLocationProvider> =>
   isSourceWithMap(source) && source.sourceMap.type === SourceLocationType.WasmSymbols;
+
 export type ContentGetter = () => Promise<string | undefined>;
 export type LineColumn = { lineNumber: number; columnNumber: number }; // 1-based
 

--- a/src/adapter/source.ts
+++ b/src/adapter/source.ts
@@ -16,8 +16,8 @@ import * as sourceUtils from '../common/sourceUtils';
 import { prettyPrintAsSourceMap } from '../common/sourceUtils';
 import * as utils from '../common/urlUtils';
 import Dap from '../dap/api';
+import { IWasmSymbols } from './dwarf/wasmSymbolProvider';
 import type { SourceContainer } from './sourceContainer';
-import { IWasmSymbols } from './wasmSymbolProvider';
 
 // Represents a text source visible to the user.
 //

--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -4,13 +4,18 @@
 
 import * as l10n from '@vscode/l10n';
 import Cdp from '../cdp/api';
+import { groupBy } from '../common/arrayUtils';
 import { once, posInt32Counter, truthy } from '../common/objUtils';
-import { Base0Position } from '../common/positions';
+import { Base0Position, Base1Position, IPosition, Range } from '../common/positions';
 import { SourceConstants } from '../common/sourceUtils';
 import Dap from '../dap/api';
 import { asyncScopesNotAvailable } from '../dap/errors';
 import { ProtocolError } from '../dap/protocolError';
+import { WasmScope } from './dwarf/wasmSymbolProvider';
+import { PreviewContextType } from './objectPreview/contexts';
+import { StepDirection } from './pause';
 import { StackFrameStepOverReason, shouldStepOverStackFrame } from './smartStepping';
+import { ISourceWithMap, IWasmLocationProvider, SourceFromMap, isSourceWithWasm } from './source';
 import { IPreferredUiLocation } from './sourceContainer';
 import { getToStringIfCustom } from './templates/getStringyProps';
 import { RawLocation, Thread } from './threads';
@@ -18,7 +23,7 @@ import { IExtraProperty, IScopeRef, IVariableContainer } from './variableStore';
 
 export interface IFrameElement {
   /** DAP stack frame ID */
-  frameId: number;
+  readonly frameId: number;
   /** Formats the stack element as V8 would format it */
   formatAsNative(): Promise<string>;
   /** Pretty formats the stack element as text */
@@ -27,11 +32,38 @@ export interface IFrameElement {
   toDap(format?: Dap.StackFrameFormat): Promise<Dap.StackFrame>;
 }
 
-type FrameElement = StackFrame | AsyncSeparator;
+export interface IStackFrameElement extends IFrameElement {
+  /** Stack frame that contains this one. Usually == this, except for inline stack frames */
+  readonly root: StackFrame;
+
+  /** UI location for the frame. */
+  uiLocation(): Promise<IPreferredUiLocation | undefined> | IPreferredUiLocation | undefined;
+
+  /**
+   * Gets variable scopes on this frame. All scope variables should be added
+   * to the paused {@link VariablesStore} when this resolves.
+   */
+  scopes(): Promise<Dap.ScopesResult>;
+
+  /**
+   * Gets ranges that should be stepped for the given step kind and location.
+   */
+  getStepSkipList(direction: StepDirection, position: IPosition): Promise<Range[] | undefined>;
+}
+
+type FrameElement = StackFrame | InlinedFrame | AsyncSeparator;
+
+export const isStackFrameElement = (element: IFrameElement): element is IStackFrameElement =>
+  typeof (element as IStackFrameElement).uiLocation === 'function';
 
 export class StackTrace {
   public readonly frames: FrameElement[] = [];
-  private _frameById: Map<number, StackFrame> = new Map();
+  private _frameById: Map<number, StackFrame | InlinedFrame> = new Map();
+  /**
+   * Frame index that was last checked for inline expansion.
+   * @see https://github.com/ChromeDevTools/devtools-frontend/blob/c9f204731633fd2e2b6999a2543e99b7cc489b4b/docs/language_extension_api.md#dealing-with-inlined-functions
+   */
+  private _lastInlineWasmExpanded = Promise.resolve(0);
   private _asyncStackTraceId?: Cdp.Runtime.StackTraceId;
   private _lastFrameThread?: Thread;
 
@@ -40,33 +72,6 @@ export class StackTrace {
     for (const frame of stack.callFrames) {
       if (!frame.url.endsWith(SourceConstants.InternalExtension)) {
         result.frames.push(StackFrame.fromRuntime(thread, frame, false));
-      }
-    }
-
-    if (stack.parentId) {
-      result._asyncStackTraceId = stack.parentId;
-      console.assert(!stack.parent);
-    } else {
-      result._appendStackTrace(thread, stack.parent);
-    }
-
-    return result;
-  }
-
-  public static async fromRuntimeWithPredicate(
-    thread: Thread,
-    stack: Cdp.Runtime.StackTrace,
-    predicate: (frame: StackFrame) => Promise<boolean>,
-    frameLimit = Infinity,
-  ): Promise<StackTrace> {
-    const result = new StackTrace(thread);
-    for (let frameNo = 0; frameNo < stack.callFrames.length && frameLimit > 0; frameNo++) {
-      if (!stack.callFrames[frameNo].url.endsWith(SourceConstants.InternalExtension)) {
-        const frame = StackFrame.fromRuntime(thread, stack.callFrames[frameNo], false);
-        if (await predicate(frame)) {
-          result.frames.push();
-          frameLimit--;
-        }
       }
     }
 
@@ -97,37 +102,88 @@ export class StackTrace {
     return result;
   }
 
-  constructor(thread: Thread) {
+  constructor(private readonly thread: Thread) {
     this._lastFrameThread = thread;
   }
 
-  async loadFrames(limit: number, noFuncEval?: boolean): Promise<FrameElement[]> {
+  public async loadFrames(limit: number, noFuncEval?: boolean): Promise<FrameElement[]> {
+    await this.expandAsyncStack(limit, noFuncEval);
+    await this.expandWasmFrames();
+    return this.frames;
+  }
+
+  private async expandAsyncStack(limit: number, noFuncEval?: boolean) {
     while (this.frames.length < limit && this._asyncStackTraceId) {
-      if (this._asyncStackTraceId.debuggerId)
+      if (this._asyncStackTraceId.debuggerId) {
         this._lastFrameThread = Thread.threadForDebuggerId(this._asyncStackTraceId.debuggerId);
+      }
+
       if (!this._lastFrameThread) {
         this._asyncStackTraceId = undefined;
         break;
       }
-      if (noFuncEval)
+
+      if (noFuncEval) {
         this._lastFrameThread
           .cdp()
           .DotnetDebugger.setEvaluationOptions({ options: { noFuncEval }, type: 'stackFrame' });
+      }
 
       const response = await this._lastFrameThread
         .cdp()
         .Debugger.getStackTrace({ stackTraceId: this._asyncStackTraceId });
       this._asyncStackTraceId = undefined;
-      if (response) this._appendStackTrace(this._lastFrameThread, response.stackTrace);
+      if (response) {
+        this._appendStackTrace(this._lastFrameThread, response.stackTrace);
+      }
     }
-    return this.frames;
   }
 
-  frame(frameId: number): StackFrame | undefined {
+  private expandWasmFrames() {
+    return (this._lastInlineWasmExpanded = this._lastInlineWasmExpanded.then(async last => {
+      for (; last < this.frames.length; last++) {
+        const frame = this.frames[last];
+        if (!(frame instanceof StackFrame)) {
+          continue;
+        }
+
+        const source = frame.scriptSource?.resolvedSource;
+        if (!isSourceWithWasm(source)) {
+          continue;
+        }
+
+        const symbols = await source.sourceMap.value.promise;
+        if (!symbols.getFunctionStack) {
+          continue;
+        }
+
+        const stack = await symbols.getFunctionStack(frame.rawPosition);
+        if (stack.length === 0) {
+          continue;
+        }
+
+        for (let i = 0; i < stack.length; i++) {
+          const inlinedFrame = new InlinedFrame({
+            source,
+            thread: this.thread,
+            inlineFrameIndex: i,
+            name: stack[i].name,
+            root: frame,
+          });
+
+          this._appendFrame(inlinedFrame, last++);
+        }
+      }
+
+      return last;
+    }));
+  }
+
+  public frame(frameId: number): StackFrame | InlinedFrame | undefined {
     return this._frameById.get(frameId);
   }
 
-  _appendStackTrace(thread: Thread, stackTrace: Cdp.Runtime.StackTrace | undefined) {
+  private _appendStackTrace(thread: Thread, stackTrace: Cdp.Runtime.StackTrace | undefined) {
     console.assert(!stackTrace || !this._asyncStackTraceId);
 
     while (stackTrace) {
@@ -150,18 +206,22 @@ export class StackTrace {
     }
   }
 
-  _appendFrame(frame: FrameElement) {
-    this.frames.push(frame);
-    if (frame instanceof StackFrame) {
+  private _appendFrame(frame: FrameElement, index?: number) {
+    if (index !== undefined) {
+      this.frames.splice(index, 0, frame);
+    } else {
+      this.frames.push(frame);
+    }
+    if (!(frame instanceof AsyncSeparator)) {
       this._frameById.set(frame.frameId, frame);
     }
   }
 
-  async formatAsNative(): Promise<string> {
+  public async formatAsNative(): Promise<string> {
     return await this.formatWithMapper(frame => frame.formatAsNative());
   }
 
-  async format(): Promise<string> {
+  public async format(): Promise<string> {
     return await this.formatWithMapper(frame => frame.format());
   }
 
@@ -181,7 +241,7 @@ export class StackTrace {
     return (await Promise.all(promises)).join('\n') + '\n';
   }
 
-  async toDap(params: Dap.StackTraceParamsExtended): Promise<Dap.StackTraceResult> {
+  public async toDap(params: Dap.StackTraceParamsExtended): Promise<Dap.StackTraceResult> {
     const from = params.startFrame || 0;
     let to = (params.levels || 50) + from;
     const frames = await this.loadFrames(to, params.noFuncEval);
@@ -288,10 +348,16 @@ function getDefaultName(callFrame: Cdp.Debugger.CallFrame | Cdp.Runtime.CallFram
   return callFrame.functionName || fallbackName;
 }
 
-export class StackFrame implements IFrameElement {
+export class StackFrame implements IStackFrameElement {
   public readonly frameId = frameIdCounter();
+  /** Override for the `name` in the DAP representation. */
+  public overrideName?: string;
+  /** @inheritdoc */
+  public readonly root = this;
 
   private _rawLocation: RawLocation;
+
+  /** @inheritdoc */
   public readonly uiLocation: () =>
     | Promise<IPreferredUiLocation | undefined>
     | IPreferredUiLocation
@@ -340,6 +406,24 @@ export class StackFrame implements IFrameElement {
   }
 
   /**
+   * Gets this frame's script ID.
+   */
+  public get scriptId() {
+    return 'scriptId' in this.callFrame
+      ? this.callFrame.scriptId
+      : this.callFrame.location.scriptId;
+  }
+
+  /**
+   * Gets the source associated with the script ID of the stackframe. This may
+   * not be where the frame is eventually displayed to the user;
+   * use {@link uiLocation} for that.
+   */
+  public get scriptSource() {
+    return this._thread._sourceContainer.getScriptById(this.scriptId);
+  }
+
+  /**
    * Gets whether the runtime explicitly said this frame can be restarted.
    */
   public get canExplicitlyBeRestarted() {
@@ -362,6 +446,7 @@ export class StackFrame implements IFrameElement {
     return this._scope ? this._scope.callFrameId : undefined;
   }
 
+  /** @inheritdoc */
   async scopes(): Promise<Dap.ScopesResult> {
     const currentScope = this._scope;
     if (!currentScope) {
@@ -447,19 +532,26 @@ export class StackFrame implements IFrameElement {
     return { scopes: scopes.filter(truthy) };
   }
 
+  /** @inheritdoc */
+  public getStepSkipList(_direction: StepDirection): Promise<Range[] | undefined> {
+    // Normal JS never has any skip lists -- only web assembly does
+    return Promise.resolve(undefined);
+  }
+
   private readonly getLocationInfo = once(async () => {
     const uiLocation = this.uiLocation();
     const isSmartStepped = await shouldStepOverStackFrame(this);
     // only use the relatively expensive custom tostring lookup for frames
     // that aren't skipped, to avoid unnecessary work e.g. on node_internals
     const name =
-      'this' in this.callFrame
+      this.overrideName ||
+      ('this' in this.callFrame
         ? await getEnhancedName(
             this._thread,
             this.callFrame,
             isSmartStepped === StackFrameStepOverReason.NotStepped,
           )
-        : getDefaultName(this.callFrame);
+        : getDefaultName(this.callFrame));
 
     return { isSmartStepped, name, uiLocation: await uiLocation };
   });
@@ -582,4 +674,135 @@ export class StackFrame implements IFrameElement {
     const completions = await Promise.all(promises);
     return ([] as Dap.CompletionItem[]).concat(...completions);
   });
+}
+
+const EMPTY_SCOPES: Dap.ScopesResult = { scopes: [] };
+
+export class InlinedFrame implements IStackFrameElement {
+  /** @inheritdoc */
+  public readonly root: StackFrame;
+
+  /** @inheritdoc */
+  public readonly frameId = frameIdCounter();
+
+  /** @inheritdoc */
+  public readonly uiLocation: () => Promise<IPreferredUiLocation>;
+
+  private readonly name: string;
+  private readonly thread: Thread;
+  private readonly inlineFrameIndex: number;
+  private readonly source: ISourceWithMap<IWasmLocationProvider>;
+
+  constructor(opts: {
+    thread: Thread;
+    /** Inline frame index in the function info */
+    inlineFrameIndex: number;
+    /** Display name of the call frame */
+    name: string;
+    /** Original WASM source */
+    source: ISourceWithMap<IWasmLocationProvider>;
+    /** Original stack frame this was derived from */
+    root: StackFrame;
+  }) {
+    this.name = opts.name;
+    this.root = opts.root;
+    this.thread = opts.thread;
+    this.source = opts.source;
+    this.inlineFrameIndex = opts.inlineFrameIndex;
+    this.uiLocation = once(() =>
+      opts.thread._sourceContainer.preferredUiLocation({
+        columnNumber: opts.root.rawPosition.base1.columnNumber,
+        lineNumber: opts.inlineFrameIndex + 1,
+        source: opts.source,
+      }),
+    );
+  }
+
+  /** @inheritdoc */
+  public async formatAsNative(): Promise<string> {
+    const { columnNumber, lineNumber, source } = await this.uiLocation();
+    return `    at ${this.name} (${source.url}:${lineNumber}:${columnNumber})`;
+  }
+
+  /** @inheritdoc */
+  public async format(): Promise<string> {
+    const { columnNumber, lineNumber, source } = await this.uiLocation();
+    const prettyName = (await source.prettyName()) || '<unknown>';
+    return `${this.name} @ ${prettyName}:${lineNumber}:${columnNumber}`;
+  }
+
+  /** @inheritdoc */
+  public async toDap(): Promise<Dap.StackFrame> {
+    const { columnNumber, lineNumber, source } = await this.uiLocation();
+    return Promise.resolve({
+      id: this.frameId,
+      name: this.name,
+      column: columnNumber,
+      line: lineNumber,
+      source: await source.toDapShallow(),
+    });
+  }
+
+  /** @inheritdoc */
+  public async getStepSkipList(direction: StepDirection): Promise<Range[] | undefined> {
+    const sm = this.source.sourceMap.value.settledValue;
+    if (!sm?.getStepSkipList) {
+      return;
+    }
+
+    const uiLocation = await this.uiLocation();
+    if (uiLocation) {
+      return sm.getStepSkipList(
+        direction,
+        this.root.rawPosition,
+        (uiLocation.source as SourceFromMap).compiledToSourceUrl.get(this.source),
+        new Base1Position(uiLocation.lineNumber, uiLocation.columnNumber),
+      );
+    } else {
+      return sm.getStepSkipList(direction, this.root.rawPosition);
+    }
+  }
+
+  /** @inheritdoc */
+  public async scopes(): Promise<Dap.ScopesResult> {
+    const v = this.source.sourceMap.value.settledValue;
+    const callFrameId = this.root.callFrameId();
+    if (!v || !callFrameId) {
+      return EMPTY_SCOPES;
+    }
+
+    const variables = await v.getVariablesInScope?.(
+      callFrameId,
+      new Base0Position(this.inlineFrameIndex, this.root.rawPosition.base0.columnNumber),
+    );
+    if (!variables) {
+      return EMPTY_SCOPES;
+    }
+
+    const paused = this.thread.pausedVariables();
+    if (!paused) {
+      return EMPTY_SCOPES;
+    }
+
+    const scopeRef: IScopeRef = {
+      stackFrame: this.root,
+      callFrameId,
+      scopeNumber: 0, // this is only used for setting variables, which wasm doesn't support
+    };
+
+    return {
+      scopes: await Promise.all(
+        [...groupBy(variables, v => v.scope)].map(([key, vars]) =>
+          paused
+            .createWasmScope(key as WasmScope, vars, scopeRef)
+            .toDap(PreviewContextType.PropertyValue)
+            .then(v => ({
+              name: v.name,
+              variablesReference: v.variablesReference,
+              expensive: key !== WasmScope.Local,
+            })),
+        ),
+      ),
+    };
+  }
 }

--- a/src/common/arrayUtils.ts
+++ b/src/common/arrayUtils.ts
@@ -32,3 +32,26 @@ export function binarySearch<T>(
 
   return low;
 }
+
+/**
+ * Groups an array using an accessor function.
+ */
+export function groupBy<T, K>(array: T[], accessor: (item: T) => K): Map<K, T[]> {
+  const groups: Map<K, T[]> = new Map();
+
+  for (const item of array) {
+    const key = accessor(item);
+    const group = groups.get(key);
+    if (group) {
+      group.push(item);
+    } else {
+      groups.set(key, [item]);
+    }
+  }
+
+  return groups;
+}
+
+export function iteratorFirst<T>(it: IterableIterator<T>): T | undefined {
+  return it.next().value;
+}

--- a/src/common/positions.test.ts
+++ b/src/common/positions.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { expect } from 'chai';
+import { Base0Position, Range } from './positions';
+
+describe('Range', () => {
+  describe('simplify', () => {
+    it('should merge overlapping ranges', () => {
+      const range1 = new Range(new Base0Position(0, 0), new Base0Position(0, 5));
+      const range2 = new Range(new Base0Position(0, 3), new Base0Position(0, 8));
+      const range3 = new Range(new Base0Position(0, 10), new Base0Position(0, 15));
+      const range4 = new Range(new Base0Position(0, 12), new Base0Position(0, 20));
+      const range5 = new Range(new Base0Position(0, 25), new Base0Position(0, 30));
+      const range6 = new Range(new Base0Position(0, 28), new Base0Position(0, 35));
+      const mergedRanges = Range.simplify([range1, range2, range3, range4, range5, range6]);
+      expect(mergedRanges.join(', ')).to.equal(
+        'Range[0:0 -> 0:8], Range[0:10 -> 0:20], Range[0:25 -> 0:35]',
+      );
+    });
+
+    it('should merge adjacent ranges', () => {
+      const range1 = new Range(new Base0Position(0, 0), new Base0Position(0, 5));
+      const range2 = new Range(new Base0Position(0, 5), new Base0Position(0, 8));
+      const range3 = new Range(new Base0Position(0, 8), new Base0Position(0, 10));
+      const range4 = new Range(new Base0Position(0, 10), new Base0Position(0, 15));
+      const range5 = new Range(new Base0Position(0, 15), new Base0Position(0, 20));
+      const mergedRanges = Range.simplify([range1, range2, range3, range4, range5]);
+      expect(mergedRanges.join(', ')).to.equal('Range[0:0 -> 0:20]');
+    });
+
+    it('should not merge non-overlapping ranges', () => {
+      const range1 = new Range(new Base0Position(0, 0), new Base0Position(0, 5));
+      const range2 = new Range(new Base0Position(0, 7), new Base0Position(0, 10));
+      const range3 = new Range(new Base0Position(0, 12), new Base0Position(0, 15));
+      const mergedRanges = Range.simplify([range1, range2, range3]);
+      expect(mergedRanges.join(', ')).to.equal(
+        'Range[0:0 -> 0:5], Range[0:7 -> 0:10], Range[0:12 -> 0:15]',
+      );
+    });
+
+    it('should handle empty input', () => {
+      const mergedRanges = Range.simplify([]);
+      expect(mergedRanges).to.have.lengthOf(0);
+    });
+
+    it('should handle input with a single range', () => {
+      const range = new Range(new Base0Position(0, 0), new Base0Position(0, 5));
+      const mergedRanges = Range.simplify([range]);
+      expect(mergedRanges.join(', ')).to.equal('Range[0:0 -> 0:5]');
+    });
+
+    it('should handle duplicated range', () => {
+      const range1 = new Range(new Base0Position(0, 0), new Base0Position(0, 5));
+      const range2 = new Range(new Base0Position(0, 0), new Base0Position(0, 5));
+      const range3 = new Range(new Base0Position(0, 6), new Base0Position(0, 7));
+      const range4 = new Range(new Base0Position(0, 6), new Base0Position(0, 7));
+      const mergedRanges = Range.simplify([range1, range2, range3, range4]);
+      expect(mergedRanges.join(', ')).to.equal('Range[0:0 -> 0:5], Range[0:6 -> 0:7]');
+    });
+  });
+});

--- a/src/common/positions.ts
+++ b/src/common/positions.ts
@@ -51,7 +51,8 @@ export class Base0Position implements IPosition {
   }
 
   public compare(other: Base0Position) {
-    return this.lineNumber - other.lineNumber || this.columnNumber - other.columnNumber || 0;
+    const other0 = other.base0;
+    return this.lineNumber - other0.lineNumber || this.columnNumber - other0.columnNumber;
   }
 }
 
@@ -76,7 +77,8 @@ export class Base1Position implements IPosition {
   }
 
   public compare(other: Base1Position) {
-    return this.lineNumber - other.lineNumber || this.columnNumber - other.columnNumber || 0;
+    const other1 = other.base1;
+    return this.lineNumber - other1.lineNumber || this.columnNumber - other1.columnNumber || 0;
   }
 }
 
@@ -101,6 +103,40 @@ export class Base01Position implements IPosition {
   }
 
   public compare(other: Base01Position) {
-    return this.lineNumber - other.lineNumber || this.columnNumber - other.columnNumber || 0;
+    const other01 = other.base01;
+    return this.lineNumber - other01.lineNumber || this.columnNumber - other01.columnNumber;
+  }
+}
+
+export class Range {
+  public static simplify(rangeList: readonly Range[]): Range[] {
+    if (rangeList.length === 0) {
+      return [];
+    }
+
+    const sortedRanges = rangeList.slice().sort((a, b) => a.begin.compare(b.begin));
+    const mergedRanges: Range[] = [];
+
+    let currentRange = sortedRanges[0];
+    for (let i = 1; i < sortedRanges.length; i++) {
+      const nextRange = sortedRanges[i];
+      if (currentRange.end.compare(nextRange.begin) >= 0) {
+        currentRange = new Range(currentRange.begin, nextRange.end);
+      } else {
+        mergedRanges.push(currentRange);
+        currentRange = nextRange;
+      }
+    }
+    mergedRanges.push(currentRange);
+
+    return mergedRanges;
+  }
+
+  constructor(public readonly begin: IPosition, public readonly end: IPosition) {}
+
+  public toString() {
+    const b1 = this.begin.base0;
+    const e1 = this.end.base0;
+    return `Range[${b1.lineNumber}:${b1.columnNumber} -> ${e1.lineNumber}:${e1.columnNumber}]`;
   }
 }

--- a/src/common/sourceMaps/renameProvider.ts
+++ b/src/common/sourceMaps/renameProvider.ts
@@ -3,9 +3,10 @@
  *--------------------------------------------------------*/
 
 import { inject, injectable } from 'inversify';
-import { ISourceWithMap, Source, SourceFromMap, isSourceWithSourceMap } from '../../adapter/source';
+import { Source, SourceFromMap, isSourceWithSourceMap } from '../../adapter/source';
 import { StackFrame } from '../../adapter/stackTrace';
 import { AnyLaunchConfiguration } from '../../configuration';
+import { iteratorFirst } from '../arrayUtils';
 import { Base01Position, IPosition } from '../positions';
 import { PositionToOffset } from '../stringUtils';
 import { SourceMap } from './sourceMap';
@@ -73,7 +74,7 @@ export class RenameProvider implements IRenameProvider {
       return RenameMapping.None;
     }
 
-    const original: ISourceWithMap | undefined = source.compiledToSourceUrl.keys().next().value;
+    const original = iteratorFirst(source.compiledToSourceUrl.keys());
     if (!original) {
       throw new Error('unreachable');
     }

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -4,10 +4,11 @@
 
 import { promises as dns } from 'dns';
 import * as path from 'path';
-import { parse as urlParse, URL } from 'url';
+import { URL, parse as urlParse } from 'url';
 import Cdp from '../cdp/api';
 import { AnyChromiumConfiguration } from '../configuration';
 import { BrowserTargetType } from '../targets/browser/browserTargets';
+import { iteratorFirst } from './arrayUtils';
 import { MapUsingProjection } from './datastructure/mapUsingProjection';
 import { IFsUtils } from './fsUtils';
 import { memoize } from './objUtils';
@@ -362,7 +363,7 @@ const createReGroup = (patterns: ReadonlySet<string>): string => {
     case 0:
       return '';
     case 1:
-      return patterns.values().next().value;
+      return iteratorFirst(patterns.values()) as string;
     default:
       // Prefer the more compacy [aA] form if we're only matching single
       // characters, produce a non-capturing group otherwise.

--- a/src/ioc-extras.ts
+++ b/src/ioc-extras.ts
@@ -2,6 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import type * as dwf from '@vscode/dwarf-debugging';
 import { promises as fsPromises } from 'fs';
 import { interfaces } from 'inversify';
 import type * as vscode from 'vscode';
@@ -68,6 +69,16 @@ export type FsPromises = typeof fsPromises;
  * Symbol for `@vscode/js-debug-browsers`'s IBrowserFinder.
  */
 export const BrowserFinder = Symbol('IBrowserFinder');
+
+/**
+ * Symbol for the `@vscode/dwarf-debugging` module, in IDwarfDebugging.
+ */
+export const DwarfDebugging = Symbol('DwarfDebugging');
+
+/**
+ * Type for {@link DwarfDebugging}
+ */
+export type DwarfDebugging = () => Promise<typeof dwf | undefined>;
 
 /**
  * Location the extension is running in.

--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -7,20 +7,19 @@ import { extname, resolve } from 'path';
 import { IBreakpointsPredictor } from '../../adapter/breakpointPredictor';
 import { IPortLeaseTracker } from '../../adapter/portLeaseTracker';
 import Cdp from '../../cdp/api';
-import { asArray } from '../../common/arrayUtils';
+import { asArray, iteratorFirst } from '../../common/arrayUtils';
 import { DebugType } from '../../common/contributionUtils';
 import { IFsUtils, LocalFsUtils } from '../../common/fsUtils';
 import { ILogger, LogTag } from '../../common/logging';
 import { fixDriveLetterAndSlashes } from '../../common/pathUtils';
 import { delay } from '../../common/promiseUtil';
-import { ISourceMapMetadata } from '../../common/sourceMaps/sourceMap';
 import { absolutePathToFileUrl, urlToRegex } from '../../common/urlUtils';
 import { AnyLaunchConfiguration, INodeLaunchConfiguration } from '../../configuration';
 import { fixInspectFlags } from '../../ui/configurationUtils';
 import { retryGetNodeEndpoint } from '../browser/spawn/endpoints';
 import { ISourcePathResolverFactory } from '../sourcePathResolverFactory';
 import { CallbackFile } from './callback-file';
-import { getRunScript, hideDebugInfoFromConsole, INodeBinaryProvider } from './nodeBinaryProvider';
+import { INodeBinaryProvider, getRunScript, hideDebugInfoFromConsole } from './nodeBinaryProvider';
 import { IProcessTelemetry, IRunData, NodeLauncherBase } from './nodeLauncherBase';
 import { INodeTargetLifecycleHooks } from './nodeTarget';
 import { IPackageJsonProvider } from './packageJsonProvider';
@@ -305,7 +304,7 @@ export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
 
     // There can be more than one compile file per source file. Just pick
     // whichever one in that case.
-    const entry: ISourceMapMetadata = mapped.values().next().value;
+    const entry = iteratorFirst(mapped.values());
     if (!entry) {
       return targetProgram;
     }

--- a/src/test/breakpoints/breakpoints-user-defined-bp-on-first-line-with-stop-on-entry-on-ts-file-reports-as-breakpoint.txt
+++ b/src/test/breakpoints/breakpoints-user-defined-bp-on-first-line-with-stop-on-entry-on-ts-file-reports-as-breakpoint.txt
@@ -1,7 +1,7 @@
 {
     allThreadsStopped : false
     description : Paused on breakpoint
-    reason : entry
+    reason : breakpoint
     threadId : <number>
 }
 <anonymous> @ ${workspaceFolder}/tsNodeApp/app.ts:1:1

--- a/src/test/sources/sources-sourcemap-error-handling-logs-lazy-parse-errors.txt
+++ b/src/test/sources/sources-sourcemap-error-handling-logs-lazy-parse-errors.txt
@@ -1,10 +1,3 @@
 Evaluating#1: //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZXZhbDEuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJldmFsMVNvdXJjZS5qcyJdLCJtYXBwaW5ncyI6IiMsIyMjIzsifQ==
 
 stderr> Could not read source map for http://localhost:8001/eval1.js: Error parsing mappings (code 4): invalid base 64 character while parsing a VLQ
-{
-    allThreadsStopped : false
-    description : Paused on breakpoint
-    reason : breakpoint
-    threadId : <number>
-}
-<anonymous> @ localhost꞉8001/eval1.js:3:23

--- a/src/test/sources/sourcesTest.ts
+++ b/src/test/sources/sourcesTest.ts
@@ -262,7 +262,6 @@ describe('sources', () => {
         `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${contents}\n`,
       );
       await p.logger.logOutput(await output);
-      await waitForPause(p);
       await ev;
       p.assertLog();
     });

--- a/src/ui/dwarfModuleProviderImpl.ts
+++ b/src/ui/dwarfModuleProviderImpl.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import type * as dwf from '@vscode/dwarf-debugging';
+import * as l10n from '@vscode/l10n';
+import { inject, injectable } from 'inversify';
+import * as vscode from 'vscode';
+import { IDwarfModuleProvider } from '../adapter/dwarf/dwarfModuleProvider';
+import { ExtensionContext } from '../ioc-extras';
+
+const EXT_ID = 'ms-vscode.wasm-dwarf-debugging';
+const NEVER_REMIND = 'dwarf.neverRemind';
+
+@injectable()
+export class DwarfModuleProvider implements IDwarfModuleProvider {
+  private didPromptForSession = this.context.workspaceState.get(NEVER_REMIND, false);
+
+  constructor(@inject(ExtensionContext) private readonly context: vscode.ExtensionContext) {}
+
+  /** @inheritdoc */
+  public async load(): Promise<typeof dwf | undefined> {
+    const ext = vscode.extensions.getExtension<typeof dwf>(EXT_ID);
+    if (!ext) {
+      return undefined;
+    }
+    if (!ext.isActive) {
+      await ext.activate();
+    }
+
+    return ext.exports;
+  }
+
+  /** @inheritdoc */
+  public async prompt() {
+    if (this.didPromptForSession) {
+      return;
+    }
+
+    this.didPromptForSession = true;
+
+    const yes = l10n.t('Yes');
+    const never = l10n.t('Never');
+    const response = await vscode.window.showInformationMessage(
+      l10n.t({
+        message:
+          'VS Code can provide better debugging experience for WebAssembly via "DWARF Debugging" extension. Would you like to install it?',
+        comment: '"DWARF Debugging" is the extension name and should not be localized.',
+      }),
+      yes,
+      l10n.t('Not Now'),
+      never,
+    );
+
+    if (response === yes) {
+      this.install();
+    } else if (response === never) {
+      this.context.workspaceState.update(NEVER_REMIND, true);
+    }
+  }
+
+  private async install() {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: l10n.t('Installing the DWARF debugger...'),
+      },
+      async () => {
+        try {
+          await vscode.commands.executeCommand('workbench.extensions.installExtension', EXT_ID);
+          vscode.window.showInformationMessage(
+            l10n.t(
+              'Installation complete! The extension will be used after you restart your debug session.',
+            ),
+          );
+        } catch (e) {
+          vscode.window.showErrorMessage(e.message || String(e));
+        }
+      },
+    );
+  }
+}

--- a/src/ui/profiling/uiProfileManager.ts
+++ b/src/ui/profiling/uiProfileManager.ts
@@ -7,7 +7,8 @@ import { inject, injectable, multiInject } from 'inversify';
 import { homedir } from 'os';
 import { basename, join } from 'path';
 import * as vscode from 'vscode';
-import { getDefaultProfileName, ProfilerFactory } from '../../adapter/profiling';
+import { ProfilerFactory, getDefaultProfileName } from '../../adapter/profiling';
+import { iteratorFirst } from '../../common/arrayUtils';
 import { Commands, ContextKey, setContextKey } from '../../common/contributionUtils';
 import { DisposableList, IDisposable } from '../../common/disposable';
 import { moveFile } from '../../common/fsUtils';
@@ -260,8 +261,8 @@ export class UiProfileManager implements IDisposable {
 
     setContextKey(vscode.commands, ContextKey.IsProfiling, true);
 
-    if (this.activeSessions.size === 1) {
-      const session: UiProfileSession = this.activeSessions.values().next().value;
+    const session = iteratorFirst(this.activeSessions.values());
+    if (session && this.activeSessions.size === 1) {
       this.statusBarItem.text = session.status
         ? l10n.t('{0} Click to Stop Profiling ({1})', '$(loading~spin)', session.status)
         : l10n.t('{0} Click to Stop Profiling', '$(loading~spin)');

--- a/src/ui/ui-ioc.extensionOnly.ts
+++ b/src/ui/ui-ioc.extensionOnly.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------*/
 
 import { Container } from 'inversify';
+import { IDwarfModuleProvider } from '../adapter/dwarf/dwarfModuleProvider';
 import { IRequestOptionsProvider } from '../adapter/resourceProvider/requestOptionsProvider';
 import { IExtensionContribution, trackDispose, VSCodeApi } from '../ioc-extras';
 import { TerminalNodeLauncher } from '../targets/node/terminalNodeLauncher';
@@ -20,6 +21,7 @@ import { DebugLinkUi } from './debugLinkUI';
 import { DebugSessionTracker } from './debugSessionTracker';
 import { DiagnosticsUI } from './diagnosticsUI';
 import { DisableSourceMapUI } from './disableSourceMapUI';
+import { DwarfModuleProvider } from './dwarfModuleProviderImpl';
 import { EdgeDevToolOpener } from './edgeDevToolOpener';
 import { ExcludedCallersUI } from './excludedCallersUI';
 import { ILinkedBreakpointLocation } from './linkedBreakpointLocation';
@@ -68,6 +70,7 @@ export const registerUiComponents = (container: Container) => {
   container.bind(UiProfileManager).toSelf().inSingletonScope().onActivation(trackDispose);
   container.bind(TerminalLinkHandler).toSelf().inSingletonScope();
   container.bind(DisableSourceMapUI).toSelf().inSingletonScope();
+  container.bind(IDwarfModuleProvider).to(DwarfModuleProvider).inSingletonScope();
 
   container
     .bind(ITerminationConditionFactory)


### PR DESCRIPTION
> This is part 2 in a stacked PR. This will get merged down into a single PR after all of them are reviewed

This commit implements the "variables" view in WebAssembly It introduces new types in the VariableStore that handle WebAssembly (though this is tweaked and cleaned up slightly in a later stack.) The actual call is pretty simple, `listVariablesInScope` on the worker lists variables, and then we can get their properties.

Also, this PR moves the debugger to have a strong preference for setting breakpoints by URL. This makes breakpoints behave better on reload, which is important because there is no instrumentation pause for WebAssembly. Having looked a little in the Chrome debugger, they actually never set breakpoints by script ID any more, so this follows in their footsteps.