### PR TITLE
chore: remove redundant type definitions for del

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "@types/chai-subset": "^1.3.3",
         "@types/color": "^3.0.3",
         "@types/debug": "^4.1.7",
-        "@types/del": "^4.0.0",
         "@types/diff": "^5.0.2",
         "@types/estraverse": "^5.1.1",
         "@types/estree": "0.0.51",
@@ -1490,16 +1489,6 @@
       "dev": true,
       "dependencies": {
         "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/del": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/del/-/del-4.0.0.tgz",
-      "integrity": "sha512-LDE5atstX5kKnTobWknpmGHC52DH/tp8pIVsD2SSxaOFqW3AQr0EpdzYIfkZ331xe7l9Vn9NlJsBG6viU3mjBA==",
-      "deprecated": "This is a stub types definition. del provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "del": "*"
       }
     },
     "node_modules/@types/diff": {
@@ -16026,15 +16015,6 @@
       "dev": true,
       "requires": {
         "@types/ms": "*"
-      }
-    },
-    "@types/del": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/del/-/del-4.0.0.tgz",
-      "integrity": "sha512-LDE5atstX5kKnTobWknpmGHC52DH/tp8pIVsD2SSxaOFqW3AQr0EpdzYIfkZ331xe7l9Vn9NlJsBG6viU3mjBA==",
-      "dev": true,
-      "requires": {
-        "del": "*"
       }
     },
     "@types/diff": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@types/chai-subset": "^1.3.3",
     "@types/color": "^3.0.3",
     "@types/debug": "^4.1.7",
-    "@types/del": "^4.0.0",
     "@types/diff": "^5.0.2",
     "@types/estraverse": "^5.1.1",
     "@types/estree": "0.0.51",


### PR DESCRIPTION
`del@6.0.0` ships its own types https://github.com/sindresorhus/del/blob/v6.0.0/index.d.ts

Log:
```
npm WARN deprecated @types/del@4.0.0: This is a stub types definition. del provides its own type definitions, so you do not need this installed.
```