### PR TITLE
fix: auto-attach/debug terminal not working in nightly

### DIFF
--- a/src/build/esbuildPlugins.js
+++ b/src/build/esbuildPlugins.js
@@ -27,6 +27,7 @@ exports.hackyVendorBundle = vendors => ({
       args => ({
         path: vendors.get(args.path),
         external: true,
+        sideEffects: false,
       }),
     );
   },


### PR DESCRIPTION
The plugin didn't mark acorn as side-effect-free, so the watchdog bundle was trying to import it