### PR TITLE
fix: eval webpack config breakpoints not setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 - fix: envFiles variables appending rather than replacing in attach ([vscode#1935510](https://github.com/microsoft/vscode/issues/1935510))
 - fix: make source map renames scope-aware
+- fix: breakpoints not setting in webpack `eval`-type sourcemaps ([vscode#194988](https://github.com/microsoft/vscode/issues/194988))
 - fix: error when processing private properties with a map ([#1824](https://github.com/microsoft/vscode-js-debug/issues/1824))
 
 ## v1.83 (September 2023)

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -697,17 +697,11 @@ export class BreakpointManager {
     // Fix: if we stopped in a script where an active entrypoint breakpoint
     // exists, regardless of the reason, treat this as a breakpoint.
     // ref: https://github.com/microsoft/vscode/issues/107859
-    const entryInScript = [...this.moduleEntryBreakpoints.values()].filter(
+    const entryInScript = [...this.moduleEntryBreakpoints.values()].some(
       bp => bp.enabled && bp.cdpScriptIds.has(scriptId),
     );
 
-    if (entryInScript.length) {
-      for (const breakpoint of entryInScript) {
-        if (!(breakpoint instanceof PatternEntryBreakpoint)) {
-          breakpoint.disable();
-        }
-      }
-
+    if (entryInScript) {
       return true;
     }
 

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -711,6 +711,12 @@ export class BreakpointManager {
     });
   }
 
+  /** Gets whether the CDP breakpoint ID refers to an entrypoint breakpoint. */
+  public isEntrypointCdpBreak(cdpId: string) {
+    const bp = this._resolvedBreakpoints.get(cdpId);
+    return bp instanceof EntryBreakpoint;
+  }
+
   /**
    * Handler that should be called *after* source map resolution on an entry
    * breakpoint. Returns whether the debugger should remain paused.

--- a/src/adapter/breakpoints/breakpointBase.ts
+++ b/src/adapter/breakpoints/breakpointBase.ts
@@ -518,6 +518,7 @@ export abstract class Breakpoint {
           bp.args.location.scriptId === script.scriptId &&
           lcEqual(bp.args.location, lineColumn)) ||
         (script.url &&
+          !script.hasSourceURL &&
           isSetByUrl(bp.args) &&
           (bp.args.urlRegex
             ? new RegExp(bp.args.urlRegex).test(script.url)
@@ -560,8 +561,9 @@ export abstract class Breakpoint {
 
   protected async _setForSpecific(thread: Thread, script: ISourceScript, lineColumn: LineColumn) {
     // prefer to set on script URL for non-anonymous scripts, since url breakpoints
-    // will survive and be hit on reload.
-    if (script.url) {
+    // will survive and be hit on reload. But don't set if the script has
+    // a source URL, since V8 doesn't resolve these
+    if (script.url && !script.hasSourceURL) {
       return this._setByUrl(thread, script.url, lineColumn);
     } else {
       return this._setByScriptId(thread, script, lineColumn);

--- a/src/adapter/source.ts
+++ b/src/adapter/source.ts
@@ -384,6 +384,7 @@ export interface IWasmLocationProvider extends ISourceLocationProvider {
 export interface ISourceScript {
   executionContextId: Cdp.Runtime.ExecutionContextId;
   scriptId: Cdp.Runtime.ScriptId;
+  hasSourceURL: boolean;
   url: string;
 }
 

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -36,7 +36,14 @@ import * as objectPreview from './objectPreview';
 import { PreviewContextType, getContextForType } from './objectPreview/contexts';
 import { ExpectedPauseReason, IPausedDetails, StepDirection } from './pause';
 import { SmartStepper } from './smartStepping';
-import { ISourceWithMap, IUiLocation, Source, base1To0, isSourceWithWasm } from './source';
+import {
+  ISourceScript,
+  ISourceWithMap,
+  IUiLocation,
+  Source,
+  base1To0,
+  isSourceWithWasm,
+} from './source';
 import { IPreferredUiLocation, SourceContainer } from './sourceContainer';
 import { InlinedFrame, StackFrame, StackTrace, isStackFrameElement } from './stackTrace';
 import {
@@ -69,10 +76,7 @@ export class ExecutionContext {
   }
 }
 
-export type Script = {
-  url: string;
-  scriptId: string;
-  executionContextId: number;
+export type Script = ISourceScript & {
   source: Promise<Source>;
   resolvedSource?: Source;
 };
@@ -1515,6 +1519,7 @@ export class Thread implements IVariableStoreLocationProvider {
         prevSource.addScript({
           scriptId: event.scriptId,
           url: event.url,
+          hasSourceURL: !!event.hasSourceURL,
           executionContextId: event.executionContextId,
         });
         return prevSource;
@@ -1565,6 +1570,7 @@ export class Thread implements IVariableStoreLocationProvider {
       source.addScript({
         scriptId: event.scriptId,
         url: event.url,
+        hasSourceURL: !!event.hasSourceURL,
         executionContextId: event.executionContextId,
       });
 
@@ -1573,6 +1579,7 @@ export class Thread implements IVariableStoreLocationProvider {
 
     const script: Script = {
       url: event.url,
+      hasSourceURL: !!event.hasSourceURL,
       scriptId: event.scriptId,
       executionContextId: event.executionContextId,
       source: createSource(),

--- a/src/test/sources/sources-sourcemap-error-handling-logs-lazy-parse-errors.txt
+++ b/src/test/sources/sources-sourcemap-error-handling-logs-lazy-parse-errors.txt
@@ -1,3 +1,10 @@
 Evaluating#1: //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZXZhbDEuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJldmFsMVNvdXJjZS5qcyJdLCJtYXBwaW5ncyI6IiMsIyMjIzsifQ==
 
 stderr> Could not read source map for http://localhost:8001/eval1.js: Error parsing mappings (code 4): invalid base 64 character while parsing a VLQ
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+<anonymous> @ localhost꞉8001/eval1.js:3:23

--- a/src/test/sources/sourcesTest.ts
+++ b/src/test/sources/sourcesTest.ts
@@ -262,6 +262,7 @@ describe('sources', () => {
         `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${contents}\n`,
       );
       await p.logger.logOutput(await output);
+      await waitForPause(p);
       await ev;
       p.assertLog();
     });


### PR DESCRIPTION
V8 does not resolve URL-set breakpoints when the script in question only
has that URL via a sourceURL mapping.

I also noticed an issue with per-script entrypoint breakpoints where
another file with the same name, or part of the same name, could
incorrectly remove the entrypoint breakpoint early. It's fine to just
leave the breakpoint around -- can be slightly slower, but better than
missing the breakpoint entirely.

Fixes https://github.com/microsoft/vscode/issues/194988