### PR TITLE
chore: cleanup custom breakpoint ui

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-  "add.eventListener.breakpoint": "Add Event Listener Breakpoint",
+  "add.eventListener.breakpoint": "Toggle Event Listener Breakpoints",
   "attach.node.process": "Attach to Node Process",
   "base.cascadeTerminateToConfigurations.label": "A list of debug sessions which, when this debug session is terminated, will also be stopped.",
   "base.enableDWARF.label": "Toggles whether the debugger will try to read DWARF debug symbols from WebAssembly, which can be resource intensive. Requires the `ms-vscode.wasm-dwarf-debugging` extension to function.",

--- a/src/build/dapCustom.ts
+++ b/src/build/dapCustom.ts
@@ -81,27 +81,14 @@ const makeRequest = (
 
 const dapCustom: JSONSchema4 = {
   definitions: {
-    ...makeRequest('enableCustomBreakpoints', 'Enable custom breakpoints.', {
+    ...makeRequest('setCustomBreakpoints', 'Sets the enabled custom breakpoints.', {
       properties: {
         ids: {
           type: 'array',
           items: {
             type: 'string',
           },
-          description: 'Id of breakpoints to enable.',
-        },
-      },
-      required: ['ids'],
-    }),
-
-    ...makeRequest('disableCustomBreakpoints', 'Disable custom breakpoints.', {
-      properties: {
-        ids: {
-          type: 'array',
-          items: {
-            type: 'string',
-          },
-          description: 'Id of breakpoints to enable.',
+          description: 'Id of breakpoints that should be enabled.',
         },
       },
       required: ['ids'],

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -1213,14 +1213,9 @@ const commands: ReadonlyArray<{
     category: 'Debug',
   },
   {
-    command: Commands.AddCustomBreakpoints,
+    command: Commands.ToggleCustomBreakpoints,
     title: refString('add.eventListener.breakpoint'),
     icon: '$(add)',
-  },
-  {
-    command: Commands.RemoveCustomBreakpoints,
-    title: refString('remove.eventListener.breakpoint'),
-    icon: '$(remove)',
   },
   {
     command: Commands.RemoveAllCustomBreakpoints,
@@ -1437,7 +1432,7 @@ const menus: Menus = {
   ],
   'view/title': [
     {
-      command: Commands.AddCustomBreakpoints,
+      command: Commands.ToggleCustomBreakpoints,
       when: `view == ${CustomViews.EventListenerBreakpoints}`,
       group: 'navigation',
     },

--- a/src/cdp/api.d.ts
+++ b/src/cdp/api.d.ts
@@ -23859,6 +23859,28 @@ export namespace Cdp {
       | 'PageSupportNeeded'
       | 'Circumstantial';
 
+    export interface BackForwardCacheBlockingDetails {
+      /**
+       * Url of the file where blockage happened. Optional because of tests.
+       */
+      url?: string;
+
+      /**
+       * Function name where blockage happened. Optional because of anonymous functions and tests.
+       */
+      function?: string;
+
+      /**
+       * Line number in the script (0-based).
+       */
+      lineNumber: integer;
+
+      /**
+       * Column number in the script (0-based).
+       */
+      columnNumber: integer;
+    }
+
     export interface BackForwardCacheNotRestoredExplanation {
       /**
        * Type of the reason
@@ -23876,6 +23898,8 @@ export namespace Cdp {
        * - EmbedderExtensionSentMessageToCachedFrame: the extension ID.
        */
       context?: string;
+
+      details?: BackForwardCacheBlockingDetails[];
     }
 
     export interface BackForwardCacheNotRestoredExplanationTree {
@@ -28676,6 +28700,8 @@ export namespace Cdp {
       ends: integer[];
     }
 
+    export type AttributionReportingTriggerDataMatching = 'exact' | 'modulus';
+
     export interface AttributionReportingSourceRegistration {
       time: Network.TimeSinceEpoch;
 
@@ -28708,6 +28734,8 @@ export namespace Cdp {
       aggregationKeys: AttributionReportingAggregationKeysEntry[];
 
       debugKey?: UnsignedInt64AsBase10;
+
+      triggerDataMatching: AttributionReportingTriggerDataMatching;
     }
 
     export type AttributionReportingSourceRegistrationResult =

--- a/src/common/contributionUtils.ts
+++ b/src/common/contributionUtils.ts
@@ -25,7 +25,7 @@ export const enum CustomViews {
 }
 
 export const enum Commands {
-  AddCustomBreakpoints = 'extension.js-debug.addCustomBreakpoints',
+  ToggleCustomBreakpoints = 'extension.js-debug.addCustomBreakpoints',
   AttachProcess = 'extension.pwa-node-debug.attachNodeProcess',
   AutoAttachClearVariables = 'extension.js-debug.clearAutoAttachVariables',
   AutoAttachSetVariables = 'extension.js-debug.setAutoAttachVariables',
@@ -38,7 +38,6 @@ export const enum Commands {
   PickProcess = 'extension.js-debug.pickNodeProcess',
   PrettyPrint = 'extension.js-debug.prettyPrint',
   RemoveAllCustomBreakpoints = 'extension.js-debug.removeAllCustomBreakpoints',
-  RemoveCustomBreakpoints = 'extension.js-debug.removeCustomBreakpoint',
   RevealPage = 'extension.js-debug.revealPage',
   RequestCDPProxy = 'extension.js-debug.requestCDPProxy',
   /** Use node-debug's command so existing keybindings work */
@@ -86,7 +85,7 @@ const debugTypes: { [K in DebugType]: null } = {
 };
 
 const commandsObj: { [K in Commands]: null } = {
-  [Commands.AddCustomBreakpoints]: null,
+  [Commands.ToggleCustomBreakpoints]: null,
   [Commands.AttachProcess]: null,
   [Commands.AutoAttachClearVariables]: null,
   [Commands.AutoAttachSetVariables]: null,
@@ -99,7 +98,6 @@ const commandsObj: { [K in Commands]: null } = {
   [Commands.PickProcess]: null,
   [Commands.PrettyPrint]: null,
   [Commands.RemoveAllCustomBreakpoints]: null,
-  [Commands.RemoveCustomBreakpoints]: null,
   [Commands.RevealPage]: null,
   [Commands.StartProfile]: null,
   [Commands.StopProfile]: null,

--- a/src/common/objUtils.ts
+++ b/src/common/objUtils.ts
@@ -340,7 +340,7 @@ export function trailingEdgeThrottle(
  */
 export async function bisectArrayAsync<T>(
   items: ReadonlyArray<T>,
-  predicate: (item: T) => Promise<boolean>,
+  predicate: (item: T) => Promise<boolean> | boolean,
 ): Promise<[T[], T[]]> {
   const a: T[] = [];
   const b: T[] = [];

--- a/src/dap/api.d.ts
+++ b/src/dap/api.d.ts
@@ -824,66 +824,18 @@ export namespace Dap {
     disassembleRequest(params: DisassembleParams): Promise<DisassembleResult>;
 
     /**
-     * Enable custom breakpoints.
+     * Sets the enabled custom breakpoints.
      */
     on(
-      request: 'enableCustomBreakpoints',
-      handler: (
-        params: EnableCustomBreakpointsParams,
-      ) => Promise<EnableCustomBreakpointsResult | Error>,
+      request: 'setCustomBreakpoints',
+      handler: (params: SetCustomBreakpointsParams) => Promise<SetCustomBreakpointsResult | Error>,
     ): () => void;
     /**
-     * Enable custom breakpoints.
+     * Sets the enabled custom breakpoints.
      */
-    enableCustomBreakpointsRequest(
-      params: EnableCustomBreakpointsParams,
-    ): Promise<EnableCustomBreakpointsResult>;
-
-    /**
-     * Disable custom breakpoints.
-     */
-    on(
-      request: 'disableCustomBreakpoints',
-      handler: (
-        params: DisableCustomBreakpointsParams,
-      ) => Promise<DisableCustomBreakpointsResult | Error>,
-    ): () => void;
-    /**
-     * Disable custom breakpoints.
-     */
-    disableCustomBreakpointsRequest(
-      params: DisableCustomBreakpointsParams,
-    ): Promise<DisableCustomBreakpointsResult>;
-
-    /**
-     * Enable XHR/fetch breakpoints.
-     */
-    on(
-      request: 'enableXHRBreakpoints',
-      handler: (params: EnableXHRBreakpointsParams) => Promise<EnableXHRBreakpointsResult | Error>,
-    ): () => void;
-    /**
-     * Enable XHR/fetch breakpoints.
-     */
-    enableXHRBreakpointsRequest(
-      params: EnableXHRBreakpointsParams,
-    ): Promise<EnableXHRBreakpointsResult>;
-
-    /**
-     * Disable XHR/fetch breakpoints.
-     */
-    on(
-      request: 'disableXHRBreakpoints',
-      handler: (
-        params: DisableXHRBreakpointsParams,
-      ) => Promise<DisableXHRBreakpointsResult | Error>,
-    ): () => void;
-    /**
-     * Disable XHR/fetch breakpoints.
-     */
-    disableXHRBreakpointsRequest(
-      params: DisableXHRBreakpointsParams,
-    ): Promise<DisableXHRBreakpointsResult>;
+    setCustomBreakpointsRequest(
+      params: SetCustomBreakpointsParams,
+    ): Promise<SetCustomBreakpointsResult>;
 
     /**
      * Pretty prints source for debugging.
@@ -1700,30 +1652,9 @@ export namespace Dap {
     disassemble(params: DisassembleParams): Promise<DisassembleResult>;
 
     /**
-     * Enable custom breakpoints.
+     * Sets the enabled custom breakpoints.
      */
-    enableCustomBreakpoints(
-      params: EnableCustomBreakpointsParams,
-    ): Promise<EnableCustomBreakpointsResult>;
-
-    /**
-     * Disable custom breakpoints.
-     */
-    disableCustomBreakpoints(
-      params: DisableCustomBreakpointsParams,
-    ): Promise<DisableCustomBreakpointsResult>;
-
-    /**
-     * Enable XHR/fetch breakpoints.
-     */
-    enableXHRBreakpoints(params: EnableXHRBreakpointsParams): Promise<EnableXHRBreakpointsResult>;
-
-    /**
-     * Disable XHR/fetch breakpoints.
-     */
-    disableXHRBreakpoints(
-      params: DisableXHRBreakpointsParams,
-    ): Promise<DisableXHRBreakpointsResult>;
+    setCustomBreakpoints(params: SetCustomBreakpointsParams): Promise<SetCustomBreakpointsResult>;
 
     /**
      * Pretty prints source for debugging.
@@ -2184,15 +2115,6 @@ export namespace Dap {
     canPersist?: boolean;
   }
 
-  export interface DisableCustomBreakpointsParams {
-    /**
-     * Id of breakpoints to enable.
-     */
-    ids: string[];
-  }
-
-  export interface DisableCustomBreakpointsResult {}
-
   export interface DisableSourcemapParams {
     /**
      * Source to be pretty printed.
@@ -2201,15 +2123,6 @@ export namespace Dap {
   }
 
   export interface DisableSourcemapResult {}
-
-  export interface DisableXHRBreakpointsParams {
-    /**
-     * Id of breakpoints to enable.
-     */
-    ids: string[];
-  }
-
-  export interface DisableXHRBreakpointsResult {}
 
   export interface DisassembleParams {
     /**
@@ -2268,24 +2181,6 @@ export namespace Dap {
   }
 
   export interface DisconnectResult {}
-
-  export interface EnableCustomBreakpointsParams {
-    /**
-     * Id of breakpoints to enable.
-     */
-    ids: string[];
-  }
-
-  export interface EnableCustomBreakpointsResult {}
-
-  export interface EnableXHRBreakpointsParams {
-    /**
-     * Id of breakpoints to enable.
-     */
-    ids: string[];
-  }
-
-  export interface EnableXHRBreakpointsResult {}
 
   export interface EvaluateParams {
     /**
@@ -3327,6 +3222,15 @@ export namespace Dap {
      */
     breakpoints: Breakpoint[];
   }
+
+  export interface SetCustomBreakpointsParams {
+    /**
+     * Id of breakpoints that should be enabled.
+     */
+    ids: string[];
+  }
+
+  export interface SetCustomBreakpointsResult {}
 
   export interface SetDataBreakpointsParams {
     /**

--- a/src/dap/telemetryClassification.d.ts
+++ b/src/dap/telemetryClassification.d.ts
@@ -94,14 +94,8 @@ interface IDAPOperationClassification {
   '!writememory.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
   disassemble: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
   '!disassemble.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-  enablecustombreakpoints: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
-  '!enablecustombreakpoints.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-  disablecustombreakpoints: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
-  '!disablecustombreakpoints.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-  enablexhrbreakpoints: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
-  '!enablexhrbreakpoints.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-  disablexhrbreakpoints: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
-  '!disablexhrbreakpoints.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
+  setcustombreakpoints: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
+  '!setcustombreakpoints.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
   prettyprintsource: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
   '!prettyprintsource.errors': { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
   toggleskipfilestatus: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };

--- a/src/dapDebugServer.ts
+++ b/src/dapDebugServer.ts
@@ -13,7 +13,7 @@ import { DebugAdapter } from './adapter/debugAdapter';
 import { Binder, IBinderDelegate } from './binder';
 import { ILogger } from './common/logging';
 import { ProxyLogger } from './common/logging/proxyLogger';
-import { getDeferred, IDeferred } from './common/promiseUtil';
+import { IDeferred, getDeferred } from './common/promiseUtil';
 import { AnyResolvingConfiguration } from './configuration';
 import Dap from './dap/api';
 import DapConnection from './dap/connection';
@@ -71,13 +71,9 @@ function collectInitialize(dap: Dap.Api) {
     return {};
   });
 
-  dap.on('enableCustomBreakpoints', async params => {
+  dap.on('setCustomBreakpoints', async params => {
+    customBreakpoints.clear();
     for (const id of params.ids) customBreakpoints.add(id);
-    return {};
-  });
-
-  dap.on('disableCustomBreakpoints', async params => {
-    for (const id of params.ids) customBreakpoints.delete(id);
     return {};
   });
 
@@ -189,7 +185,7 @@ class DapSessionManager implements IBinderDelegate {
       await adapter.setExceptionBreakpoints(init.setExceptionBreakpointsParams);
     for (const { params, ids } of init.setBreakpointsParams)
       await adapter.breakpointManager.setBreakpoints(params, ids);
-    await adapter.enableCustomBreakpoints({ ids: Array.from(init.customBreakpoints) });
+    await adapter.setCustomBreakpoints({ ids: Array.from(init.customBreakpoints) });
     await adapter.onInitialize(init.initializeParams);
     await adapter.configurationDone();
 

--- a/src/debugServer.ts
+++ b/src/debugServer.ts
@@ -22,7 +22,7 @@ const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-js-debug-'));
 class Configurator {
   private _setExceptionBreakpointsParams?: Dap.SetExceptionBreakpointsParams;
   private _setBreakpointsParams: { params: Dap.SetBreakpointsParams; ids: number[] }[];
-  private _customBreakpoints = new Set<string>();
+  private _customBreakpoints: string[] = [];
   private lastBreakpointId = 0;
 
   constructor(dap: Dap.Api) {
@@ -47,13 +47,8 @@ class Configurator {
       return {};
     });
 
-    dap.on('enableCustomBreakpoints', async params => {
-      for (const id of params.ids) this._customBreakpoints.add(id);
-      return {};
-    });
-
-    dap.on('disableCustomBreakpoints', async params => {
-      for (const id of params.ids) this._customBreakpoints.delete(id);
+    dap.on('setCustomBreakpoints', async params => {
+      this._customBreakpoints = params.ids;
       return {};
     });
 
@@ -75,7 +70,7 @@ class Configurator {
       await adapter.setExceptionBreakpoints(this._setExceptionBreakpointsParams);
     for (const { params, ids } of this._setBreakpointsParams)
       await adapter.breakpointManager.setBreakpoints(params, ids);
-    await adapter.enableCustomBreakpoints({ ids: Array.from(this._customBreakpoints) });
+    await adapter.setCustomBreakpoints({ ids: Array.from(this._customBreakpoints) });
     await adapter.configurationDone();
   }
 }

--- a/src/test/breakpoints/breakpointsTest.ts
+++ b/src/test/breakpoints/breakpointsTest.ts
@@ -642,7 +642,7 @@ describe('breakpoints', () => {
       await p.evaluate(`document.querySelector('div').innerHTML = 'foo';`);
 
       p.log('Pausing on innerHTML');
-      await p.dap.enableCustomBreakpoints({ ids: ['instrumentation:Element.setInnerHTML'] });
+      await p.dap.setCustomBreakpoints({ ids: ['instrumentation:Element.setInnerHTML'] });
       p.evaluate(`document.querySelector('div').innerHTML = 'bar';`);
       const event = p.log(await p.dap.once('stopped'));
       p.log(await p.dap.continue({ threadId: event.threadId }));


### PR DESCRIPTION
Uses a manually controlled checkbox list, fixes some state erros. Also
handle the recently-deprecated DOMDebugger.setInstrumentationBreakpoint API.