### PR TITLE
update doc for IChromiumLaunchConfiguration.runtimeExecutable

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -599,7 +599,7 @@ export interface IChromiumLaunchConfiguration extends IChromiumBaseConfiguration
   runtimeArgs: ReadonlyArray<string> | null;
 
   /**
-   * Either 'canary', 'stable', 'custom' or path to the browser executable.
+   * Either 'canary', 'stable', 'beta', 'dev', 'custom' or path to the browser executable.
    * Custom means a custom wrapper, custom build or CHROME_PATH
    * environment variable.
    */


### PR DESCRIPTION
I've added `'beta'` and `'dev'` to the doc for `IChromiumLaunchConfiguration.runtimeExecutable` as they were missing.

Reference: https://github.com/microsoft/vscode-js-debug-browsers/blob/2c118eff8f9116a85a03b8ebc2c770ac633c4ca6/src/index.ts#L20-L26