### PR TITLE
fix: don't use approximate matching for file uris in browsers

### DIFF
--- a/src/targets/browser/browserPathResolver.ts
+++ b/src/targets/browser/browserPathResolver.ts
@@ -113,6 +113,8 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
       if (await this.fsUtils.exists(net)) {
         return net;
       }
+
+      return abs;
     }
 
     let pathname: string;


### PR DESCRIPTION
This was causing issues in WASM debugging where files are included from compilation that may not exist on disk. File URIs are absolute, so don't try to use approximate matching even if the absolute path doesn't exist; it's never going to be right.