### PR TITLE
fix: removed support for logpoints 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-debug",
-  "version": "1.86.0",
+  "version": "1.86.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-debug",
-      "version": "1.86.0",
+      "version": "1.86.1",
       "license": "MIT",
       "dependencies": {
         "@c4312/chromehash": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "js-debug",
   "displayName": "JavaScript Debugger",
-  "version": "1.86.0",
+  "version": "1.86.1",
   "publisher": "ms-vscode",
   "author": {
     "name": "Microsoft Corporation"

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -252,7 +252,7 @@ export class DebugAdapter implements IDisposable {
       supportTerminateDebuggee: true,
       supportsDelayedStackTraceLoading: true,
       supportsLoadedSourcesRequest: true,
-      supportsLogPoints: false,
+      supportsLogPoints: true,
       supportsTerminateThreadsRequest: false,
       supportsSetExpression: true,
       supportsTerminateRequest: false,


### PR DESCRIPTION
I think I turned this off for verification, and it was still in my workspace when I bumped the last js-debug version