### PR TITLE
Revert the revert of #1464

### DIFF
--- a/src/targets/node/nodeAttacherBase.ts
+++ b/src/targets/node/nodeAttacherBase.ts
@@ -33,7 +33,7 @@ export abstract class NodeAttacherBase<T extends AnyNodeConfiguration> extends N
       '})()' +
       getSourceSuffix();
 
-    for (let retries = 0; retries < 5; retries++) {
+    for (let retries = 0; retries < 200; retries++) {
       const result = await cdp.Runtime.evaluate({
         contextId: 1,
         returnByValue: true,


### PR DESCRIPTION
Restoring the longer timeout which made this the attach subprocesses feature work again for us.

Contributed on behalf of [Swimm](https://swimm.io/)