### PR TITLE
Fix formatting of number 0 in remote object when description is not set

### DIFF
--- a/src/adapter/objectPreview/index.ts
+++ b/src/adapter/objectPreview/index.ts
@@ -479,7 +479,7 @@ function formatAsNumber(
       return param.unserializableValue;
     }
 
-    const value = param.value || +param.description;
+    const value = param.value !== undefined ? param.value : +param.description;
     return format?.hex ? value.toString(16) : String(value);
   }
 


### PR DESCRIPTION
Fix for issue reported here: https://github.com/microsoft/vscode-js-debug/issues/1967

Some Javascript Debuggee CDP implementations (Hermes) return the a RemoteObject of `type=number` , `value=0` and the `description` and `unserializableValue` fields unset. This causes RemoteObjects with `type=number` and  `value=0` to be rendered  as NaN due to the logic of formatting numbers here:
https://github.com/microsoft/vscode-js-debug/blob/35c4aea8e08be1ab829bf4e4d585433f7e2b7726/src/adapter/objectPreview/index.ts#L477-L484
