### PR TITLE
chore: fix publish pipeline

### DIFF
--- a/.ci/publish.yml
+++ b/.ci/publish.yml
@@ -48,7 +48,7 @@ extends:
           sbomBuildDropPath: $(Build.ArtifactStagingDirectory)/sbom-dap-server
           sbomEnabled: ${{ eq(parameters.publishExtension, true) }}
           targetPath: $(Build.ArtifactStagingDirectory)/dap-server
-        artifact: Publish DAP Debug Server Bundle
+        displayName: Publish DAP Debug Server Bundle
 
       - script: npm run compile -- package:hoist
         displayName: Package Stable

--- a/.ci/publish.yml
+++ b/.ci/publish.yml
@@ -24,7 +24,7 @@ extends:
   parameters:
     publishExtension: ${{ parameters.publishExtension }}
     vscePackageArgs: --no-dependencies
-    cgIgnoreDirectories: "testdata,demos,.vscode-test,src/test,testWorkspace"
+    cgIgnoreDirectories: 'testdata,demos,.vscode-test,src/test,testWorkspace'
     ${{ if eq(parameters.publishGhRelease, true) }}:
       ghCreateRelease: true
       ghReleaseAddChangeLog: true
@@ -41,7 +41,13 @@ extends:
       - script: node src/build/archiveDapBundle $(Build.ArtifactStagingDirectory)/dap-server
         displayName: Package DAP Debug Server Bundle
 
-      - publish: $(Build.ArtifactStagingDirectory)/dap-server
+      - task: 1ES.PublishPipelineArtifact@1
+        inputs:
+          artifactName: 'Publish DAP Debug Server Bundle'
+          sbomBuildComponentPath: $(Build.SourcesDirectory)/dist
+          sbomBuildDropPath: $(Build.ArtifactStagingDirectory)/sbom-dap-server
+          sbomEnabled: ${{ eq(parameters.publishExtension, true) }}
+          targetPath: $(Build.ArtifactStagingDirectory)/dap-server
         artifact: Publish DAP Debug Server Bundle
 
       - script: npm run compile -- package:hoist
@@ -49,6 +55,6 @@ extends:
     tsa:
       config:
         areaPath: 'Visual Studio Code Debugging Extensions'
-        serviceTreeID: "053e3ba6-924d-456c-ace0-67812c5ccc52"
+        serviceTreeID: '053e3ba6-924d-456c-ace0-67812c5ccc52'
       enabled: true
-    apiScanSoftwareVersion: "1"
+    apiScanSoftwareVersion: '1'


### PR DESCRIPTION
Replaces the publish task with a 1ES-compliant one.

Verification run: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=263214&view=results