### PR TITLE
fix: avoid forcing attach PID into debug mode with default arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - feat: resolve executables from `node_modules/.bin` automatically ([#1984](https://github.com/microsoft/vscode-js-debug/issues/1984))
+- fix: avoid forcing attach PID into debug mode with default args ([vscode#206683](https://github.com/microsoft/vscode/issues/206683))
 
 ## v1.88 (March 2024)
 

--- a/src/ui/processTree/processTree.ts
+++ b/src/ui/processTree/processTree.ts
@@ -78,9 +78,13 @@ export function analyseArguments(args: string) {
   // match --inspect, --inspect=1234, --inspect-brk, --inspect-brk=1234
   let matches = DEBUG_FLAGS_PATTERN.exec(args);
   if (matches && matches.length >= 1) {
+    port = 9229;
+    address = '127.0.0.1';
+
     if (matches.length >= 5 && matches[4]) {
       address = matches[4];
     }
+
     if (matches.length >= 6 && matches[5]) {
       port = parseInt(matches[5]);
     }
@@ -89,6 +93,7 @@ export function analyseArguments(args: string) {
   // a --inspect-port=1234 overrides the port
   matches = DEBUG_PORT_PATTERN.exec(args);
   if (matches && matches.length === 2) {
+    address = '127.0.0.1';
     port = parseInt(matches[1]);
   }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/206683