### PR TITLE
chore: exclude already-scanned file

### DIFF
--- a/.ci/publish.yml
+++ b/.ci/publish.yml
@@ -24,7 +24,7 @@ extends:
   parameters:
     publishExtension: ${{ parameters.publishExtension }}
     vscePackageArgs: --no-dependencies
-    apiScanExcludes: '**/w32appcontainertokens-xtra77na.node'
+    apiScanExcludes: '**/w32appcontainertokens-*.node'
     cgIgnoreDirectories: 'testdata,demos,.vscode-test,src/test,testWorkspace'
     ${{ if eq(parameters.publishGhRelease, true) }}:
       ghCreateRelease: true

--- a/.ci/publish.yml
+++ b/.ci/publish.yml
@@ -24,6 +24,7 @@ extends:
   parameters:
     publishExtension: ${{ parameters.publishExtension }}
     vscePackageArgs: --no-dependencies
+    apiScanExcludes: '**/w32appcontainertokens-xtra77na.node'
     cgIgnoreDirectories: 'testdata,demos,.vscode-test,src/test,testWorkspace'
     ${{ if eq(parameters.publishGhRelease, true) }}:
       ghCreateRelease: true


### PR DESCRIPTION
I believe APIScan already scans the w32appcontainertokens-xtra77na.node file in the [win32-app-container-tokens pipeline](https://dev.azure.com/monacotools/Monaco/_build?definitionId=449), though I'm not sure why the app container tokens file takes on a longer name in the js-debug VSIX.