### PR TITLE
Add Turbopack sourcemap alias

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -977,6 +977,7 @@ export function defaultSourceMapPathOverrides(webRoot: string): { [key: string]:
     'webpack://?:*/*': `${webRoot}/*`,
     'webpack:///([a-z]):/(.+)': '$1:/$2',
     'meteor://💻app/*': `${webRoot}/*`,
+    "turbopack://[project]/*": "${workspaceFolder}/*"
   };
 }
 


### PR DESCRIPTION
## What?

We got an issue report on the Next.js repository about the vscode debugger not automatically working with Turbopack enabled: https://github.com/vercel/next.js/issues/63740.

Turbopack ([website](https://turbo.build/pack)) is the new bundler we've been building, it supports sourcemaps by default and works really well with VS Code's debugger but requires additional configuration compared to using Next.js with webpack because the debugger has built-in handling of webpack paths like `webpack://`.

This PR aims to support Turbopack paths in the same way.

## How?

Updated the `sourceMapPathOverrides` default to include the required path mapping for Turbopack.


## Open questions

Since I'm not familiar with this repository I could use some helping getting this over the line if it's not already good to land.

Specifically what's potentially missing is a test and the docs still need to be updated. It seems `OPTIONS.md` is auto-generated, should I run the script to generate it?


Thanks in advance!


