### PR TITLE
fix: improve main-thread performance of source map rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
-Nothing, yet
+- fix: improve main-thread performance of source map rename ([vscode#210518](https://github.com/microsoft/vscode/issues/210518))
 
 ## v1.89 (April 2024)
 

--- a/src/common/sourceMaps/renameScopeAndSourceMap.ts
+++ b/src/common/sourceMaps/renameScopeAndSourceMap.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Base0Position } from '../positions';
+import { PositionToOffset } from '../stringUtils';
+import { IRename } from './renameProvider';
+import { ScopeNode, extractScopeRanges } from './renameScopeTree';
+import { SourceMap } from './sourceMap';
+
+enum Constant {
+  SourceMapNameIndex = 4,
+}
+
+/** Very approximate regex for JS identifiers */
+const identifierRe = /[$a-z_][$0-9A-Z_$]*/iy;
+
+export const extractScopeRenames = async (source: string, sourceMap: SourceMap) => {
+  const toOffset = new PositionToOffset(source);
+
+  /**
+   * Parsed mappings to their rename data, or undefined if the rename was
+   * not valid or was already included in a scope.
+   */
+  const usedMappings = new Set<number>();
+  const decodedMappings = sourceMap.decodedMappings();
+  const decodedNames = sourceMap.names();
+
+  const getNameFromMapping = (
+    generatedLineBase0: number,
+    generatedColumnBase0: number,
+    originalName: string,
+  ) => {
+    // keep things as numbers for performance: number in upper bits (until MAX_SAFE_INTEGER),
+    // column in lower 32 bits.
+    const cacheKey = (generatedLineBase0 * 0x7fffffff) | generatedColumnBase0;
+    if (usedMappings.has(cacheKey)) {
+      return undefined;
+    }
+
+    // always say we used this mapping, since trying again would be useless:
+    usedMappings.add(cacheKey);
+
+    const position = new Base0Position(generatedLineBase0, generatedColumnBase0);
+    const start = toOffset.convert(position);
+    identifierRe.lastIndex = start;
+    const match = identifierRe.exec(source);
+    if (!match) {
+      return;
+    }
+
+    const compiled = match[0];
+    if (compiled === originalName) {
+      return; // it happens sometimes 🤷
+    }
+
+    return compiled;
+  };
+
+  const extract = (node: ScopeNode<IRename[]>): IRename[] | undefined => {
+    const start = node.range.begin.base0;
+    const end = node.range.end.base0;
+    let renames: IRename[] | undefined;
+    // Reference: https://github.com/jridgewell/trace-mapping/blob/5a658b10d9b6dea9c614ff545ca9c4df895fee9e/src/trace-mapping.ts#L258-L290
+    for (let i = start.lineNumber; i <= end.lineNumber; i++) {
+      const mappings = decodedMappings[i];
+      if (!mappings) {
+        continue;
+      }
+      for (let k = 0; k < mappings.length; k++) {
+        const mapping: number[] = mappings[k];
+        if (mapping.length <= Constant.SourceMapNameIndex) {
+          continue;
+        }
+
+        const generatedLineBase0 = i;
+        const generatedColumnBase0 = mapping[0];
+        if (
+          generatedLineBase0 === node.range.begin.base0.lineNumber &&
+          node.range.begin.base0.columnNumber > generatedColumnBase0
+        ) {
+          continue;
+        }
+        if (
+          generatedLineBase0 === node.range.end.base0.lineNumber &&
+          node.range.end.base0.columnNumber < generatedColumnBase0
+        ) {
+          continue;
+        }
+
+        const originalName = decodedNames[mapping[4]];
+        const compiledName = getNameFromMapping(
+          generatedLineBase0,
+          generatedColumnBase0,
+          originalName,
+        );
+        if (!compiledName) {
+          continue;
+        }
+
+        renames ??= [];
+
+        // some tools emit name mapping each time the identifier is used, avoid duplicates.
+        if (!renames.some(r => r.compiled == compiledName)) {
+          renames.push({ compiled: compiledName, original: originalName });
+        }
+      }
+    }
+
+    return renames;
+  };
+
+  const scopeTree = await extractScopeRanges(source, extract);
+
+  scopeTree.filterHoist(node => !!node.data);
+
+  return scopeTree;
+};

--- a/src/common/sourceMaps/renameScopeTree.test.ts
+++ b/src/common/sourceMaps/renameScopeTree.test.ts
@@ -42,7 +42,10 @@ describe('extractScopeRanges', () => {
 
   for (const [source, expected] of tcases) {
     it(source, async () => {
-      const actual = calculateActual(source, await extractScopeRanges<void>(source));
+      const actual = calculateActual(
+        source,
+        await extractScopeRanges<void>(source, () => undefined),
+      );
       expect(actual).to.deep.equal(expected);
     });
   }
@@ -60,7 +63,7 @@ describe('extractScopeRanges', () => {
       '}',
     ].join('\n');
 
-    const tree = await extractScopeRanges<void>(src);
+    const tree = await extractScopeRanges<void>(src, () => undefined);
     tree.filterHoist(n => n.range.begin.base0.lineNumber % 2 === 0);
     const actual = calculateActual(src, tree);
     expect(actual).to.deep.equal([
@@ -84,7 +87,7 @@ describe('extractScopeRanges', () => {
       '}',
     ].join('\n');
 
-    const tree = await extractScopeRanges<number>(src);
+    const tree = await extractScopeRanges<number>(src, () => undefined);
     let i = 0;
     tree.forEach(n => (n.data = i++));
 

--- a/src/common/sourceMaps/renameWorker.ts
+++ b/src/common/sourceMaps/renameWorker.ts
@@ -2,23 +2,19 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { Node, SourceLocation } from 'estree';
+import { Node } from 'estree';
 import { isMainThread, parentPort, workerData } from 'worker_threads';
 import { parseProgram, traverse } from '../sourceCodeManipulations';
 import type { FlatTree } from './renameScopeTree';
-
-type TypeWithChildren = { children?: TypeWithChildren[] };
 
 /**
  * Gets ranges of scopes in the source code. It returns ranges where variables
  * declared in those ranges apply to all child scopes. For example,
  * `function(foo) { bar(); }` emits `(foo) { bar(); }` as a range.
  */
-export function extractScopeRangesWithFactory<T extends TypeWithChildren>(
-  source: string,
-  factory: (start: SourceLocation, end: SourceLocation) => T,
-) {
+export function extractScopeRangesWithFactory(source: string): FlatTree {
   const program = parseProgram(source);
+  const output: FlatTree = [];
 
   const push = (
     indexingNode: Node,
@@ -29,22 +25,14 @@ export function extractScopeRangesWithFactory<T extends TypeWithChildren>(
       throw new Error('should include locations');
     }
 
-    const next = factory(start, end);
-    if (stack.length > 0) {
-      const parent = stack[stack.length - 1];
-      parent.scopeNode.children ??= [];
-      parent.scopeNode.children.push(next);
-    }
-
-    stack.push({ node: indexingNode, scopeNode: next });
+    output.push({ start: start.start, end: end.end, depth: stack.length });
+    stack.push(indexingNode);
   };
 
   // nodes ignored because they're already captured in the top
   // level statement, such as the body of `for` loops.
   const coveredBlocks = new Set<Node>();
-
-  const stack: { node: Node; scopeNode: T }[] = [];
-  let programScope: T | undefined;
+  const stack: Node[] = [];
 
   traverse(program, {
     enter: node => {
@@ -58,7 +46,6 @@ export function extractScopeRangesWithFactory<T extends TypeWithChildren>(
         // include the top level program:
         case 'Program':
           push(node);
-          programScope = stack[0].scopeNode;
           break;
         // include the entire loop to handle declarations inside the statement:
         case 'ForStatement':
@@ -76,20 +63,15 @@ export function extractScopeRangesWithFactory<T extends TypeWithChildren>(
       }
     },
     leave: node => {
-      if (node === stack[stack.length - 1].node) {
+      if (node === stack[stack.length - 1]) {
         stack.pop();
       }
     },
   });
 
-  return programScope as T;
+  return output;
 }
 
 if (!isMainThread) {
-  parentPort?.postMessage(
-    extractScopeRangesWithFactory<FlatTree>(workerData, (start, end) => ({
-      start: start.start,
-      end: end.end,
-    })),
-  );
+  parentPort?.postMessage(extractScopeRangesWithFactory(workerData));
 }

--- a/src/common/sourceMaps/sourceMap.ts
+++ b/src/common/sourceMaps/sourceMap.ts
@@ -4,6 +4,7 @@
 
 import {
   allGeneratedPositionsFor,
+  decodedMappings,
   eachMapping,
   EachMapping,
   GeneratedMapping,
@@ -160,6 +161,16 @@ export class SourceMap {
 
   eachMapping(callback: (mapping: EachMapping) => void): void {
     eachMapping(this.original, callback);
+  }
+
+  /** Gets internal decoded mappings from the sourcemap. */
+  decodedMappings() {
+    return decodedMappings(this.original);
+  }
+
+  /** Gets internal decoded names from the sourcemap. */
+  names() {
+    return this.original.names;
   }
 
   private getBestGeneratedForOriginal(


### PR DESCRIPTION
Reduces the extension-host runtime from about 1600ms on my machine to 2ms. We still parse the source asynchronously, but our application of mappings before was not efficient.

Fixes https://github.com/microsoft/vscode-js-debug#nightly-extension