### PR TITLE
fix: rare race that could show breakpoints as unverified

### DIFF
--- a/src/adapter/breakpoints/userDefinedBreakpoint.ts
+++ b/src/adapter/breakpoints/userDefinedBreakpoint.ts
@@ -141,6 +141,7 @@ export class UserDefinedBreakpoint extends Breakpoint {
    * used for statistics and notifying the UI.
    */
   private async notifyResolved(): Promise<void> {
-    await this._manager.notifyBreakpointChange(this, this.completedSet.hasSettled());
+    await this.completedSet.promise;
+    await this._manager.notifyBreakpointChange(this, true);
   }
 }


### PR DESCRIPTION
- When a breakpoint is set, we call `.toDap()` on an unverified BP
- In the meantime, the debugger resolves the breakpoint
- `toDap()` resolves and then we `.markSetCompleted()`
- But we never notify the UI because we assume it was captured in `toDap()`.

Instead of omitting the resolve during set, just wait in `notifyResolved`.
This could lead to some duplicate updates in the UI, but there should be
no ill effects from them.