### PR TITLE
fix: debug targets orphaned when a detached child starts after a parent exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 ## Nightly (only)
 
 - fix: breakpoints at unmapped locations setting in wrong locations ([vscode#219031](https://github.com/microsoft/vscode/issues/219031))
+- fix: debug targets orphaned when a detached child starts after a parent exits ([vscode#219673](https://github.com/microsoft/vscode/issues/219673))
 
 ## v1.91 (June 2024)
 

--- a/src/ui/debugTerminalUI.ts
+++ b/src/ui/debugTerminalUI.ts
@@ -94,19 +94,19 @@ export const launchVirtualTerminalParent = (
       // Skip targets the consumer asked to filter out.
       if (!filterTarget(target)) {
         target.detach();
-        return;
+        continue;
       }
 
       // Check that we didn't detach from the parent session.
       if (target.targetInfo.openerId && !target.parent()) {
         target.detach();
-        return;
+        continue;
       }
 
       // Detach from targets if workspace trust was not granted
       if (!trusted) {
         target.detach();
-        return;
+        continue;
       }
 
       if (!target.parent()) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/219673