### PR TITLE
fix: hover evaluation incorrectly showing undefined

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-namespace': 'off',
+    'prefer-const': ['error', { destructuring: 'all' }],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     'header/header': [
       'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
-Nothing, yet
+- fix: hover evaluation incorrectly showing undefined ([vscode#221503](https://github.com/microsoft/vscode/issues/221503))
 
 ## v1.92 (July 2024)
 

--- a/src/adapter/evaluator.test.ts
+++ b/src/adapter/evaluator.test.ts
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import Cdp from '../cdp/api';
 import { stubbedCdpApi, StubCdpApi } from '../cdp/stubbedApi';
+import { Logger } from '../common/logging/logger';
 import { Base01Position, Range } from '../common/positions';
 import { IRename, RenameMapping } from '../common/sourceMaps/renameProvider';
 import { ScopeNode } from '../common/sourceMaps/renameScopeTree';
@@ -25,10 +26,14 @@ describe('Evaluator', () => {
   beforeEach(() => {
     stubCdp = stubbedCdpApi();
     renameMapping = RenameMapping.None;
-    evaluator = new Evaluator(stubCdp.actual, {
-      provideForSource: () => renameMapping,
-      provideOnStackframe: () => renameMapping,
-    });
+    evaluator = new Evaluator(
+      stubCdp.actual,
+      {
+        provideForSource: () => renameMapping,
+        provideOnStackframe: () => renameMapping,
+      },
+      Logger.null,
+    );
   });
 
   it('prepares simple expressions', async () => {


### PR DESCRIPTION
I haven't been quite able to reproduce this, but this is the
explaination I see for https://github.com/microsoft/vscode/issues/221503,
plausibly caused by sourcemap funkiness.

The root cause is that a hover evaluation's scope is being misidentified
as happening in a scope above the one it should actually run in. We then
saw this and thought we should hoist a variable, but don't find a
variable to hoist, and leave the replaced identifier in the expression.
If the scope were not misidentified, then the behavior would have been
identical because the variable would not be defined anyway.

In this PR we replace the identifier back to its original if we don't
find a variable to hoist, and also add logging to help any future
issues.