### PR TITLE
feat: improve display of HTML in the debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
+- feat: improve display of HTML elements in the debugger
 - feat: add node tool picker completion for launch.json ([#1997](https://github.com/microsoft/vscode-js-debug/issues/1997))
 - fix: process attachment with `--inspect=:1234` style ([#2063](https://github.com/microsoft/vscode-js-debug/issues/2063))
 

--- a/src/adapter/clientCapabilities.ts
+++ b/src/adapter/clientCapabilities.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { injectable } from 'inversify';
+import Dap from '../dap/api';
+
+export interface IClientCapabilies {
+  value?: Dap.InitializeParams;
+}
+
+export const IClientCapabilies = Symbol('IClientCapabilies');
+
+@injectable()
+export class ClientCapabilities implements IClientCapabilies {
+  value?: Dap.InitializeParams | undefined;
+}

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -24,6 +24,7 @@ import { IShutdownParticipants } from '../ui/shutdownParticipants';
 import { IAsyncStackPolicy } from './asyncStackPolicy';
 import { BreakpointManager } from './breakpoints';
 import { ICdpProxyProvider } from './cdpProxy';
+import { IClientCapabilies } from './clientCapabilities';
 import { ICompletions } from './completions';
 import { IConsole } from './console';
 import { Diagnostics } from './diagnosics';
@@ -250,6 +251,7 @@ export class DebugAdapter implements IDisposable {
   ): Promise<Dap.InitializeResult | Dap.Error> {
     console.assert(params.linesStartAt1);
     console.assert(params.columnsStartAt1);
+    this._services.get<IClientCapabilies>(IClientCapabilies).value = params;
     const capabilities = DebugAdapter.capabilities(true);
     setTimeout(() => this.dap.initialized({}), 0);
     setTimeout(() => this._thread?.dapInitialized(), 0);
@@ -310,6 +312,7 @@ export class DebugAdapter implements IDisposable {
       supportsEvaluationOptions: extended ? true : false,
       supportsDebuggerProperties: extended ? true : false,
       supportsSetSymbolOptions: extended ? true : false,
+      supportsANSIStyling: true,
       // supportsDataBreakpoints: false,
       // supportsDisassembleRequest: false,
     };
@@ -515,6 +518,7 @@ export class DebugAdapter implements IDisposable {
       this._services.get(IExceptionPauseService),
       this._services.get(SmartStepper),
       this._services.get(IShutdownParticipants),
+      this._services.get(IClientCapabilies),
     );
 
     const profile = this._services.get<IProfileController>(IProfileController);

--- a/src/adapter/messageFormat.ts
+++ b/src/adapter/messageFormat.ts
@@ -148,13 +148,13 @@ export function formatCssAsAnsi(style: string): string {
           if (background) escapedSequence += `\x1b[48;5;${background}m`;
           break;
         case 'font-weight':
-          if (match[2] === 'bold') escapedSequence += '\x1b[1m';
+          if (match[2] === 'bold') escapedSequence += AnsiStyles.Bold;
           break;
         case 'font-style':
-          if (match[2] === 'italic') escapedSequence += '\x1b[3m';
+          if (match[2] === 'italic') escapedSequence += AnsiStyles.Italic;
           break;
         case 'text-decoration':
-          if (match[2] === 'underline') escapedSequence += '\x1b[4m';
+          if (match[2] === 'underline') escapedSequence += AnsiStyles.Underline;
           break;
         default:
           // css not mapped, skip
@@ -165,4 +165,32 @@ export function formatCssAsAnsi(style: string): string {
   }
 
   return escapedSequence;
+}
+
+export const enum AnsiStyles {
+  Reset = '\x1b[0m',
+  Bold = '\x1b[1m',
+  Dim = '\x1b[2m',
+  Italic = '\x1b[3m',
+  Underline = '\x1b[4m',
+  Blink = '\x1b[5m',
+  Reverse = '\x1b[7m',
+  Hidden = '\x1b[8m',
+  Strikethrough = '\x1b[9m',
+  Black = '\x1b[30m',
+  Red = '\x1b[31m',
+  Green = '\x1b[32m',
+  Yellow = '\x1b[33m',
+  Blue = '\x1b[34m',
+  Magenta = '\x1b[35m',
+  Cyan = '\x1b[36m',
+  White = '\x1b[37m',
+  BrightBlack = '\x1b[30;1m',
+  BrightRed = '\x1b[31;1m',
+  BrightGreen = '\x1b[32;1m',
+  BrightYellow = '\x1b[33;1m',
+  BrightBlue = '\x1b[34;1m',
+  BrightMagenta = '\x1b[35;1m',
+  BrightCyan = '\x1b[36;1m',
+  BrightWhite = '\x1b[37;1m',
 }

--- a/src/adapter/objectPreview/index.ts
+++ b/src/adapter/objectPreview/index.ts
@@ -314,12 +314,12 @@ function appendKeyValue(
   if (key.length + separator.length > characterBudget) {
     return stringUtils.trimEnd(key, characterBudget);
   }
-  return `${key}${separator}${
+  return escapeAnsiInString(`${key}${separator}${
     stringUtils.trimMiddle(
       value,
       characterBudget - key.length - separator.length,
     )
-  }`; // Keep in sync with characterBudget calculation.
+  }`); // Keep in sync with characterBudget calculation.
 }
 
 function renderPropertyPreview(
@@ -339,6 +339,10 @@ function renderPropertyPreview(
     return appendKeyValue(name, ': ', quoteStringValue(prop.value), characterBudget);
   }
   return appendKeyValue(name, ': ', prop.value ?? 'unknown', characterBudget);
+}
+
+function escapeAnsiInString(value: string) {
+  return value.replaceAll('\x1b', '\\x1b');
 }
 
 function quoteStringValue(value: string) {
@@ -368,7 +372,7 @@ function renderValue(
       quote = false;
     }
     const value = stringUtils.trimMiddle(stringValue, quote ? budget - 2 : budget);
-    return quote ? quoteStringValue(value) : value;
+    return escapeAnsiInString(quote ? quoteStringValue(value) : value);
   }
 
   if (object.type === 'undefined') {

--- a/src/adapter/templates/getNodeChildren.ts
+++ b/src/adapter/templates/getNodeChildren.ts
@@ -18,7 +18,13 @@ export const getNodeChildren = remoteFunction(function(
   const to = count === -1 ? this.childNodes.length : start + count;
   for (let i = from; i < to && i < this.childNodes.length; ++i) {
     const cn = this.childNodes[i];
-    result[i] = cn.nodeName === '#text' ? (cn.textContent || '') : this.childNodes[i];
+    if (cn.nodeName === '#comment') {
+      result[i] = `<!-- ${cn.textContent} -->`;
+    } else if (cn.nodeName === '#text') {
+      result[i] = cn.textContent || '';
+    } else {
+      result[i] = cn;
+    }
   }
 
   return result;

--- a/src/adapter/templates/getNodeChildren.ts
+++ b/src/adapter/templates/getNodeChildren.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { remoteFunction } from '.';
+
+/**
+ * Returns an object containing array property descriptors for the given
+ * range of array indices.
+ */
+export const getNodeChildren = remoteFunction(function(
+  this: Node,
+  start: number,
+  count: number,
+) {
+  const result: Record<number, Node | string> = {};
+  const from = start === -1 ? 0 : start;
+  const to = count === -1 ? this.childNodes.length : start + count;
+  for (let i = from; i < to && i < this.childNodes.length; ++i) {
+    const cn = this.childNodes[i];
+    result[i] = cn.nodeName === '#text' ? (cn.textContent || '') : this.childNodes[i];
+  }
+
+  return result;
+});

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -27,6 +27,7 @@ import { ITarget } from '../targets/targets';
 import { IShutdownParticipants } from '../ui/shutdownParticipants';
 import { BreakpointManager, EntryBreakpointMode } from './breakpoints';
 import { UserDefinedBreakpoint } from './breakpoints/userDefinedBreakpoint';
+import { IClientCapabilies } from './clientCapabilities';
 import { ICompletions } from './completions';
 import { ExceptionMessage, IConsole, QueryObjectsMessage } from './console';
 import { customBreakpoints } from './customBreakpoints';
@@ -221,12 +222,20 @@ export class Thread implements IVariableStoreLocationProvider {
     private readonly exceptionPause: IExceptionPauseService,
     private readonly _smartStepper: SmartStepper,
     private readonly shutdown: IShutdownParticipants,
+    clientCapabilities: IClientCapabilies,
   ) {
     this._dap = new DeferredContainer(dap);
     this._sourceContainer = sourceContainer;
     this._cdp = cdp;
     this.id = Thread._lastThreadId++;
-    this.replVariables = new VariableStore(renameProvider, this._cdp, dap, launchConfig, this);
+    this.replVariables = new VariableStore(
+      renameProvider,
+      this._cdp,
+      dap,
+      launchConfig,
+      clientCapabilities,
+      this,
+    );
     sourceContainer.onSourceMappedSteppingChange(() => this.refreshStackTrace());
     this._initialize();
   }

--- a/src/common/disposable.ts
+++ b/src/common/disposable.ts
@@ -38,7 +38,7 @@ export class RefCounter<T extends IDisposable> {
   public dispose() {
     if (!this.disposed) {
       this.disposed = true;
-      this.value.dispose;
+      this.value.dispose();
     }
   }
 }

--- a/src/dap/api.d.ts
+++ b/src/dap/api.d.ts
@@ -2611,6 +2611,11 @@ export namespace Dap {
      * Client supports the `startDebugging` request.
      */
     supportsStartDebuggingRequest?: boolean;
+
+    /**
+     * The client will interpret ANSI escape sequences in the display of `OutputEvent.output` and `Variable.value` fields when `Capabilities.supportsANSIStyling` is also enabled.
+     */
+    supportsANSIStyling?: boolean;
   }
 
   export interface InitializeResult {
@@ -2820,6 +2825,11 @@ export namespace Dap {
      * Clients may present the first applicable mode in this array as the 'default' mode in gestures that set breakpoints.
      */
     breakpointModes?: (BreakpointMode)[];
+
+    /**
+     * The debug adapter supports ANSI escape sequences in styling of `OutputEvent.output` and `Variable.value` fields.
+     */
+    supportsANSIStyling?: boolean;
   }
 
   export interface InitializedEventParams {
@@ -3092,6 +3102,10 @@ export namespace Dap {
 
     /**
      * The output to report.
+     *
+     * ANSI escape sequences may be used to inflience text color and styling if `supportsANSIStyling` is present in both the adapter's `Capabilities` and the client's `InitializeRequestArguments`. A client may strip any unrecognized ANSI sequences.
+     *
+     * If the `supportsANSIStyling` capabilities are not both true, then the client should display the output literally.
      */
     output: string;
 
@@ -5406,6 +5420,11 @@ export namespace Dap {
      * Clients may present the first applicable mode in this array as the 'default' mode in gestures that set breakpoints.
      */
     breakpointModes?: (BreakpointMode)[];
+
+    /**
+     * The debug adapter supports ANSI escape sequences in styling of `OutputEvent.output` and `Variable.value` fields.
+     */
+    supportsANSIStyling?: boolean;
   }
 
   /**

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -27,6 +27,7 @@ import {
 } from './adapter/breakpoints/conditions';
 import { LogPointCompiler } from './adapter/breakpoints/conditions/logPoint';
 import { CdpProxyProvider, ICdpProxyProvider } from './adapter/cdpProxy';
+import { ClientCapabilities, IClientCapabilies } from './adapter/clientCapabilities';
 import { Completions, ICompletions } from './adapter/completions';
 import { IConsole } from './adapter/console';
 import { Console } from './adapter/console/console';
@@ -163,6 +164,7 @@ export const createTargetContainer = (
   container.bind(ITarget).toConstantValue(target);
   container.bind(ITargetOrigin).toConstantValue(target.targetOrigin());
   container.bind(IResourceProvider).to(StatefulResourceProvider).inSingletonScope();
+  container.bind(IClientCapabilies).to(ClientCapabilities).inSingletonScope();
   container.bind(ISourceMapFactory).to(SourceMapFactory).inSingletonScope();
   container.bind(IBreakpointConditionFactory).to(BreakpointConditionFactory).inSingletonScope();
   container.bind(LogPointCompiler).toSelf().inSingletonScope();

--- a/src/test/console/console-format-nodes.txt
+++ b/src/test/console/console-format-nodes.txt
@@ -1,0 +1,7 @@
+> result: [34m<div [34;1mid[2m=[33m"main"[34m>[2m...[34m</div>[0m
+    0: '\n        Content\n        '
+    > 1: [34m<p[34m>[2m...[34m</p>[0m
+        0: 'Paragaph'
+    2: '\n        More content\n        '
+    > 3: [34m<div[34m></div>[0m
+    4: '\n      '

--- a/src/test/console/console-format-popular-types.txt
+++ b/src/test/console/console-format-popular-types.txt
@@ -318,6 +318,14 @@ Evaluating: 'console.log([true])'
 stdout> (1) [true]
 stdout> > (1) [true]
 
+Evaluating: 'console.log(node)'
+stdout> p#p
+stdout> > [34m<p [34;1mid[2m=[33m"p"[34m></p>[0m
+
+Evaluating: 'console.log([node])'
+stdout> (1) [p#p]
+stdout> > (1) [p#p]
+
 Evaluating: 'console.log(new Boolean(true))'
 stdout> Boolean (true)
 stdout> > Boolean (true)

--- a/src/test/console/consoleFormatTest.ts
+++ b/src/test/console/consoleFormatTest.ts
@@ -151,6 +151,7 @@ describe('console format', () => {
       'boxedStringWithProps',
       'false',
       'true',
+      'node',
       'new Boolean(true)',
       'new Set([1, 2, 3, 4])',
       'new Set([1, 2, 3, 4, 5, 6, 7, 8])',
@@ -458,6 +459,23 @@ describe('console format', () => {
       ],
       { depth: 0 },
     );
+    p.assertLog();
+  });
+
+  itIntegrates('nodes', async ({ r }) => {
+    const p = await r.launchAndLoad(`
+      <div id="main">
+        Content
+        <p>Paragaph</p>
+        More content
+        <div></div>
+      </div>
+    `);
+
+    await p.logger.evaluateAndLog('document.getElementById("main")', {
+      depth: 3,
+      omitProperties: ['Node Attributes', '[[Prototype]]'],
+    });
     p.assertLog();
   });
 

--- a/src/test/evaluate/evaluate-default.txt
+++ b/src/test/evaluate/evaluate-default.txt
@@ -14,6 +14,8 @@ result: 3
 
 <error>: Uncaught ReferenceError: baz is not defined
 
+result: '\x1b[2m'
+
 > result: Uint8Array(3) [1, 2, 3, buffer: ArrayBuffer(3), byteLength: 3, byteOffset: 0, length: 3, Symbol(Symbol.toStringTag): 'Uint8Array']
     0: 1
     1: 2

--- a/src/test/evaluate/evaluate.ts
+++ b/src/test/evaluate/evaluate.ts
@@ -35,6 +35,9 @@ describe('evaluate', () => {
     await p.logger.evaluateAndLog(`baz();`);
     p.log('');
 
+    await p.logger.evaluateAndLog(`'\\x1b[2m'`);
+    p.log('');
+
     await p.logger.evaluateAndLog(`new Uint8Array([1, 2, 3]);`);
     p.log('');
 

--- a/src/test/infra/infra-initialize.txt
+++ b/src/test/infra/infra-initialize.txt
@@ -28,6 +28,7 @@
     supportTerminateDebuggee : true
     supportedChecksumAlgorithms : [
     ]
+    supportsANSIStyling : true
     supportsBreakpointLocationsRequest : true
     supportsClipboardContext : true
     supportsCompletionsRequest : true

--- a/src/test/logger.ts
+++ b/src/test/logger.ts
@@ -10,6 +10,7 @@ interface ILogOptions {
   format?: Dap.ValueFormat;
   params?: Partial<Dap.EvaluateParams>;
   logInternalInfo?: boolean;
+  omitProperties?: string[];
 }
 
 const kOmitProperties = ['[[ArrayBufferData]]'];
@@ -93,8 +94,10 @@ export class Logger {
       this._dap,
       rootVariable,
       (variable, depth) => {
-        if (kOmitProperties.includes(variable.name)) {
-          return depth < (options.depth ?? 1);
+        if (
+          kOmitProperties.includes(variable.name) || options.omitProperties?.includes(variable.name)
+        ) {
+          return false;
         }
 
         const name = variable.name ? `${variable.name}: ` : '';

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -111,6 +111,7 @@ class Session {
         columnsStartAt1: true,
         pathFormat: 'path',
         supportsVariablePaging: true,
+        supportsANSIStyling: true,
       }),
       this.dap.once('initialized'),
     ]);

--- a/src/test/variables/variables-web-tags.txt
+++ b/src/test/variables/variables-web-tags.txt
@@ -1,7 +1,7 @@
 > result: HTMLCollection(2) [meta, title, foo: meta]
-    > 0: meta
-    > 1: title
+    > 0: [34m<meta [34;1mname[2m=[33m"foo" [34;1mcontent[2m=[33m"bar"[34m></meta>[0m
+    > 1: [34m<title[34m>[2m...[34m</title>[0m
     > length: (...)
-    > foo: meta
+    > foo: [34m<meta [34;1mname[2m=[33m"foo" [34;1mcontent[2m=[33m"bar"[34m></meta>[0m
     > [[Prototype]]: HTMLCollection
     > [[Prototype]]: Object


### PR DESCRIPTION
Advertises ANSI styles as proposed in https://github.com/microsoft/debug-adapter-protocol/issues/500,
though it works without them too, just without colors!

Previously the Nodes were displayed as naive objects, so we'd just
list their properties, which was quite useless when trying to get
a handle on the DOM. Now we display their children as the primary
element display, and have "Node Attributes" in a separate section.

![](https://memes.peet.io/img/24-09-9b2b35e1-3874-4e06-825a-5c84abeeb6e4.png)

Refs https://github.com/microsoft/vscode/pull/227729
Closes https://github.com/microsoft/vscode-js-debug/issues/2076