### PR TITLE
fix: don't inject NODE_OPTIONS in Deno

### DIFF
--- a/src/targets/node/nodeAttacherBase.ts
+++ b/src/targets/node/nodeAttacherBase.ts
@@ -21,7 +21,7 @@ const appendVars: readonly string[] = ['NODE_OPTIONS', 'VSCODE_INSPECTOR_OPTIONS
 export abstract class NodeAttacherBase<T extends AnyNodeConfiguration> extends NodeLauncherBase<T> {
   protected async appendEnvironmentVariables(cdp: Cdp.Api, vars: EnvironmentVars) {
     const expression =
-      `typeof process==='undefined'||process.pid===undefined?'process not defined':(()=>{`
+      `typeof process==='undefined'||process.pid===undefined||typeof Deno==='object'?'process not defined':(()=>{`
       + Object.entries(vars.defined())
         .map(([key, value]) => {
           const k = JSON.stringify(key);

--- a/src/targets/node/nodeAttacherBase.ts
+++ b/src/targets/node/nodeAttacherBase.ts
@@ -21,7 +21,7 @@ const appendVars: readonly string[] = ['NODE_OPTIONS', 'VSCODE_INSPECTOR_OPTIONS
 export abstract class NodeAttacherBase<T extends AnyNodeConfiguration> extends NodeLauncherBase<T> {
   protected async appendEnvironmentVariables(cdp: Cdp.Api, vars: EnvironmentVars) {
     const expression =
-      `typeof process==='undefined'||process.pid===undefined||typeof Deno==='object'?'process not defined':(()=>{`
+      `typeof Deno==='object'?'deno':typeof process==='undefined'||process.pid===undefined?'process not defined':(()=>{`
       + Object.entries(vars.defined())
         .map(([key, value]) => {
           const k = JSON.stringify(key);


### PR DESCRIPTION
In Deno 2, Deno has a `process` global. Because of this this extension tries to inject environment variables into the process through the inspector using `process.env`. However when running Deno without I/O permissions (the default), accessing process.env.* will show a permission prompt. This is confusing for users, as their code did not trigger this prompt, but the extensions' injected code did.

Because this code doesn't do anything in Deno anyway (because we do not respect `NODE_OPTIONS`), there is no point in running it in Deno at all. This commit disables this injection code path in Deno through environment detection.