### PR TITLE
feat: Add named pipes entrypoint for Visual Studio

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -338,6 +338,12 @@ gulp.task('vsDebugServerBundle:webpack-bundle', async () => {
   return compileTs({ packages, sourcemap: isDebug, minify: !isDebug });
 });
 
+/** Run webpack to bundle into the VS debug server with named pipes */
+gulp.task('vsDebugPipeServerBundle:webpack-bundle', async () => {
+  const packages = [{ entry: `${srcDir}/vsDebugPipeServer.ts`, library: true }];
+  return compileTs({ packages, sourcemap: isDebug, minify: !isDebug });
+});
+
 const vsceUrls = {
   baseContentUrl: 'https://github.com/microsoft/vscode-js-debug/blob/main',
   baseImagesUrl: 'https://github.com/microsoft/vscode-js-debug/raw/main',
@@ -423,6 +429,11 @@ gulp.task(
 gulp.task(
   'vsDebugServerBundle',
   gulp.series('clean', 'compile', 'vsDebugServerBundle:webpack-bundle', 'l10n:bundle-download'),
+);
+
+gulp.task(
+  'vsDebugPipeServerBundle',
+  gulp.series('clean', 'compile', 'vsDebugPipeServerBundle:webpack-bundle', 'l10n:bundle-download'),
 );
 
 /** Publishes the build extension to the marketplace */

--- a/src/vsDebugPipeServer.ts
+++ b/src/vsDebugPipeServer.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+require('source-map-support').install(); // Enable TypeScript stack traces translation
+import * as l10n from '@vscode/l10n';
+import * as fs from 'fs';
+/**
+ * This script launches vscode-js-debug in server mode for Visual Studio
+ */
+import * as os from 'os';
+import * as path from 'path';
+import 'reflect-metadata';
+import { DebugConfiguration } from 'vscode';
+import { DebugType } from './common/contributionUtils';
+import { getDeferred, IDeferred } from './common/promiseUtil';
+import { IPseudoAttachConfiguration } from './configuration';
+import DapConnection from './dap/connection';
+import { createGlobalContainer } from './ioc';
+import { ServerSessionManager } from './serverSessionManager';
+import { IDebugSessionLike, ISessionLauncher, Session } from './sessionManager';
+import { ITarget } from './targets/targets';
+
+const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-js-debug-'));
+
+if (process.env.L10N_FSPATH_TO_BUNDLE) {
+  l10n.config({ fsPath: process.env.L10N_FSPATH_TO_BUNDLE });
+}
+
+export class VSDebugSession implements IDebugSessionLike {
+  constructor(
+    public id: string,
+    name: string,
+    private readonly childConnection: Promise<DapConnection>,
+    public readonly configuration: DebugConfiguration,
+  ) {
+    this._name = name;
+  }
+
+  private _name: string;
+  set name(newName: string) {
+    this._name = newName;
+    this.childConnection
+      .then(conn => conn.initializedBlocker)
+      .then(conn => conn.dap().process({ name: newName }));
+  }
+  get name() {
+    return this._name;
+  }
+}
+
+class VsDebugPipeServer implements ISessionLauncher<VSDebugSession> {
+  private readonly sessionServer: ServerSessionManager<VSDebugSession>;
+
+  constructor() {
+    const services = createGlobalContainer({ storagePath, isVsCode: false });
+    this.sessionServer = new ServerSessionManager(services, this);
+
+    const deferredConnection: IDeferred<DapConnection> = getDeferred();
+    const rootSession = new VSDebugSession(
+      'root',
+      l10n.t('JavaScript debug adapter'),
+      deferredConnection.promise,
+      { type: DebugType.Chrome, name: 'root', request: 'launch' },
+    );
+
+    this.launchRoot(deferredConnection, rootSession);
+  }
+
+  async launchRoot(deferredConnection: IDeferred<DapConnection>, session: VSDebugSession) {
+    const result = await this.sessionServer.createRootDebugServer(session);
+    result.connectionPromise.then(x => deferredConnection.resolve(x));
+    console.log(result.server.address());
+  }
+
+  public launch(
+    parentSession: Session<VSDebugSession>,
+    target: ITarget,
+    config: IPseudoAttachConfiguration,
+  ): void {
+    const childAttachConfig = { ...config, sessionId: target.id, __jsDebugChildServer: '' };
+    const deferredConnection: IDeferred<DapConnection> = getDeferred();
+    const session = new VSDebugSession(
+      target.id(),
+      target.name(),
+      deferredConnection.promise,
+      childAttachConfig,
+    );
+
+    this.sessionServer.createChildDebugServer(session).then(({ server, connectionPromise }) => {
+      connectionPromise.then(x => deferredConnection.resolve(x));
+      const address = server.address()?.toString();
+      if (address === undefined) {
+        throw new Error('Server address is undefined');
+      }
+      childAttachConfig.__jsDebugChildServer = address;
+
+      // Custom message currently not part of DAP
+      parentSession.connection._send({
+        seq: 0,
+        command: 'attachedChildSession',
+        type: 'request',
+        arguments: {
+          config: childAttachConfig,
+        },
+      });
+    });
+  }
+}
+
+new VsDebugPipeServer();


### PR DESCRIPTION
Adding an entrypoint for external users (e.g. Visual Studio) which uses named pipes instead of TCP sockets.