### PR TITLE
fix: show the subsession name before the root prefix

### DIFF
--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -81,7 +81,7 @@ export class Session<TSessionImpl extends IDebugSessionLike> implements IDisposa
     const substate = this.sessionStates.get(this.debugSession.id);
     let name = target.name();
     if (this.parent instanceof RootSession) {
-      name = `${this.parent.debugSession.name}: ${name}`;
+      name = `${name} « ${this.parent.debugSession.name}`;
     }
 
     this.debugSession.name = substate ? `${name} (${substate})` : name;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/229100