### PR TITLE
fix: allow hitting breakpoints early in webassembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
+- fix: allow hitting breakpoints early in webassembly ([vscode#230875](https://github.com/microsoft/vscode/issues/230875))
 - fix: only autofill "debug link" input if the hostname resolves ([vscode#228950](https://github.com/microsoft/vscode/issues/228950))
 - fix: support ANSI colorization in stdout logged strings ([vscode#230441](https://github.com/microsoft/vscode/issues/230441))
 - fix: disable entrypoint breakpoint at first pause in script ([vscode#230201](https://github.com/microsoft/vscode/issues/230201))

--- a/src/adapter/templates/breakOnWasm.ts
+++ b/src/adapter/templates/breakOnWasm.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { makeInternalSourceUrl, templateFunction } from '.';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export const breakOnWasmSourceUrl = makeInternalSourceUrl(); // randomized
+
+export const breakOnWasmInit = templateFunction(function() {
+  const fns = [
+    'instantiate',
+    'instantiateStreaming',
+    'compile',
+    'compileStreaming',
+  ] satisfies (keyof typeof WebAssembly)[];
+  for (const fn of fns) {
+    const original = (WebAssembly as any)[fn];
+    WebAssembly[fn] = function(...args) {
+      return original.apply(this, args).then((r: unknown) => {
+        debugger;
+        return r as any;
+      });
+    };
+  }
+}, breakOnWasmSourceUrl);

--- a/src/test/wasm/webassembly-dwarf-can-break-immediately.txt
+++ b/src/test/wasm/webassembly-dwarf-can-break-immediately.txt
@@ -1,0 +1,42 @@
+{
+    allThreadsStopped : false
+    description : Paused on breakpoint
+    reason : breakpoint
+    threadId : <number>
+}
+
+fib @ ${workspaceFolder}/web/dwarf/fibonacci.c:6:9
+  > scope #0: Locals
+      a: 0
+      b: 0
+      c: 1
+      i: 1
+  scope #1: Parameters [expensive]
+
+main @ ${workspaceFolder}/web/dwarf/fibonacci.c:14:11
+  > scope #0: Locals
+      a: 0
+      b: 0
+
+Window.$main @ localhost꞉8001/dwarf/fibonacci.wat:230:1
+
+<anonymous> @ ${workspaceFolder}/web/dwarf/fibonacci.js:723:14
+
+Window.callMain @ ${workspaceFolder}/web/dwarf/fibonacci.js:1580:15
+
+Window.doRun @ ${workspaceFolder}/web/dwarf/fibonacci.js:1630:23
+
+<anonymous> @ ${workspaceFolder}/web/dwarf/fibonacci.js:1641:7
+
+----setTimeout----
+run @ ${workspaceFolder}/web/dwarf/fibonacci.js:1637:5
+runCaller @ ${workspaceFolder}/web/dwarf/fibonacci.js:1565:19
+removeRunDependency @ ${workspaceFolder}/web/dwarf/fibonacci.js:641:7
+receiveInstance @ ${workspaceFolder}/web/dwarf/fibonacci.js:860:5
+receiveInstantiationResult @ ${workspaceFolder}/web/dwarf/fibonacci.js:878:5
+----Promise.then----
+<anonymous> @ ${workspaceFolder}/web/dwarf/fibonacci.js:813:21
+----Promise.then----
+instantiateAsync @ ${workspaceFolder}/web/dwarf/fibonacci.js:805:62
+createWasm @ ${workspaceFolder}/web/dwarf/fibonacci.js:897:3
+<anonymous> @ ${workspaceFolder}/web/dwarf/fibonacci.js:1253:19


### PR DESCRIPTION
V8 doesn't give us instrumentation breakpoints for WASM, so take a
primitive approach of overwriting WebAssembly compile/instantiate
methods with one that includes a `debugger;` statement after they're
done, and handle those as instrumentation.

Closes https://github.com/microsoft/vscode/issues/230875