### PR TITLE
fix: apply sourceMapPathOverrides to file URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 ## Nightly (only)
 
+- fix: apply sourceMapPathOverrides to file URIs ([vscode-dwarf-debugging-ext#7](https://github.com/microsoft/vscode-dwarf-debugging-ext/issues/7))
 - fix: allow hitting breakpoints early in webassembly ([vscode#230875](https://github.com/microsoft/vscode/issues/230875))
 - fix: only autofill "debug link" input if the hostname resolves ([vscode#228950](https://github.com/microsoft/vscode/issues/228950))
 - fix: support ANSI colorization in stdout logged strings ([vscode#230441](https://github.com/microsoft/vscode/issues/230441))

--- a/src/targets/browser/browserPathResolver.ts
+++ b/src/targets/browser/browserPathResolver.ts
@@ -103,6 +103,11 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
       return;
     }
 
+    // It's possible the source might be using the `sourceURL`, so apply
+    // any source map overrides now (fixes vscode#204784) and before file
+    // URIs (vscode-dwarf-debugging-ext#7)
+    url = this.sourceMapOverrides.apply(url);
+
     // If we have a file URL, we know it's absolute already and points
     // to a location on disk.
     if (utils.isFileUrl(url)) {
@@ -118,10 +123,6 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
 
       return abs;
     }
-
-    // It's possible the source might be using the `sourceURL`, so apply
-    // any source map overrides now (fixes vscode#204784)
-    url = this.sourceMapOverrides.apply(url);
 
     let pathname: string;
     try {


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-dwarf-debugging-ext/issues/7