### PR TITLE
feat: use `remoteHostHeader` option when looking up websocket address

### DIFF
--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -74,6 +74,7 @@ export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
               ? CancellationTokenSource.withTimeout(runData.params.timeout).token
               : runData.context.cancellationToken,
             this.logger,
+            runData.params.remoteHostHeader,
           );
         }
       } catch (e) {


### PR DESCRIPTION
Implementation of #2107 

This updates the `nodeAttacher` to use the `remoteHostHeader` configuration option for the initial HTTP requests to retrieve the debugger's websocket URL. 