### PR TITLE
Fixes source code resolution problem in `extensionHost` debugging

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -886,12 +886,16 @@ export const extensionHostConfigDefaults: IExtensionHostLaunchConfiguration = {
   name: 'Debug Extension',
   request: 'launch',
   args: ['--extensionDevelopmentPath=${workspaceFolder}'],
-  env: {VSCODE_EXTENSION_DEVELOPMENT_PATH: '${workspaceFolder}'},
+  env: { VSCODE_EXTENSION_DEVELOPMENT_PATH: '${workspaceFolder}' },
   outFiles: ['${workspaceFolder}/out/**/*.js'],
   resolveSourceMapLocations: ['${workspaceFolder}/**', '!**/node_modules/**'],
   rendererDebugOptions: {},
   runtimeExecutable: '${execPath}',
-  skipFiles: ['<node_internals>/**', '${execInstallFolder}/**', '${workspaceFolder}/**/node_modules/**'],
+  skipFiles: [
+    '<node_internals>/**',
+    '${execInstallFolder}/**',
+    '${workspaceFolder}/**/node_modules/**'
+  ],
   autoAttachChildProcesses: false,
   debugWebviews: false,
   debugWebWorkerHost: false,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/145473

Add `skipFiles` in `extensionHostConfigDefaults` to correctly resolve source line addresses emitting messages in `DEBUG CONSOLE`.

Add a new environment variable `VSCODE_EXTENSION_DEVELOPMENT_PATH` for https://github.com/microsoft/vscode/pull/238469