### PR TITLE
Support usenode as npm script runner

### DIFF
--- a/src/ui/configuration/nodeDebugConfigurationProvider.ts
+++ b/src/ui/configuration/nodeDebugConfigurationProvider.ts
@@ -17,7 +17,7 @@ import {
   ResolvingTerminalConfiguration,
 } from '../../configuration';
 import { findScripts } from '../debugNpmScript';
-import { getPackageManager } from '../getRunScriptCommand';
+import { getScriptRunner } from '../getRunScriptCommand';
 import { BaseConfigurationProvider } from './baseConfigurationProvider';
 import { createLaunchConfigFromContext } from './nodeDebugConfigurationResolver';
 
@@ -98,7 +98,7 @@ export class NodeDynamicDebugConfigurationProvider extends BaseConfigurationProv
       return [openTerminal];
     }
 
-    const packageManager = await getPackageManager(folder);
+    const packageManager = await getScriptRunner(folder);
     return scripts
       .map<DynamicConfig>(script => ({
         type: getPreferredOrDebugType(DebugType.Terminal),

--- a/src/ui/getRunScriptCommand.ts
+++ b/src/ui/getRunScriptCommand.ts
@@ -7,11 +7,15 @@ import { commands, WorkspaceFolder } from 'vscode';
 /**
  * Gets the package manager the user configured in the folder.
  */
-export const getPackageManager = async (folder: WorkspaceFolder | undefined) => {
+export const getScriptRunner = async (folder: WorkspaceFolder | undefined) => {
   try {
-    return await commands.executeCommand('npm.packageManager', folder?.uri);
+    return await commands.executeCommand('npm.scriptRunner', folder?.uri);
   } catch {
-    return 'npm';
+    try {
+      return await commands.executeCommand('npm.packageManager', folder?.uri);
+    } catch {
+      return 'npm';
+    }
   }
 };
 
@@ -19,4 +23,4 @@ export const getPackageManager = async (folder: WorkspaceFolder | undefined) => 
  * Gets a command to run a script
  */
 export const getRunScriptCommand = async (name: string, folder?: WorkspaceFolder) =>
-  `${await getPackageManager(folder)} run ${name}`;
+  `${await getScriptRunner(folder)} run ${name}`;

--- a/src/ui/getRunScriptCommand.ts
+++ b/src/ui/getRunScriptCommand.ts
@@ -22,5 +22,7 @@ export const getScriptRunner = async (folder: WorkspaceFolder | undefined) => {
 /**
  * Gets a command to run a script
  */
-export const getRunScriptCommand = async (name: string, folder?: WorkspaceFolder) =>
-  `${await getScriptRunner(folder)} run ${name}`;
+export const getRunScriptCommand = async (name: string, folder?: WorkspaceFolder) => {
+  const scriptRunner = await getScriptRunner(folder);
+  return `${scriptRunner} ${scriptRunner === 'node' ? '--run' : 'run'} ${name}`;
+};


### PR DESCRIPTION
This PR add remaining required changes to support use node as npm script runner in VSCode. See microsoft/vscode#234468