### PR TITLE
fix: memory leaks between debug sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 This changelog records changes to stable releases since 1.50.2. "TBA" changes here may be available in the [nightly release](https://github.com/microsoft/vscode-js-debug/#nightly-extension) before they're in stable. Note that the minor version (`v1.X.0`) corresponds to the VS Code version js-debug is shipped in, but the patch version (`v1.50.X`) is not meaningful.
 
-## Nightly (only)
+## 1.99 (March 2025)
 
-Nothing, yet
+- fix: memory leak between debug sessions ([#2173](https://github.com/microsoft/vscode-js-debug/issues/2173))
+- fix: support `npm.scriptRunner: node`
 
 ## 1.97 (January 2025)
 

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -42,7 +42,7 @@ export class Logger implements ILogger, IDisposable {
   /**
    * Log buffer for replaying diagnostics.
    */
-  private readonly logBuffer = new RingBuffer();
+  private readonly logBuffer = new RingBuffer(1);
 
   /**
    * A no-op logger that never logs anything.

--- a/src/ioc-extras.ts
+++ b/src/ioc-extras.ts
@@ -124,6 +124,7 @@ export const trackDispose = <T>(ctx: interfaces.Context, service: T): T => {
  */
 export const disposeContainer = (container: interfaces.Container) => {
   toDispose.get(container)?.forEach(d => d.dispose());
+  toDispose.delete(container);
 };
 
 /**

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -195,7 +195,7 @@ export const createTargetContainer = (
   container.bind(SourceContainer).toSelf().inSingletonScope();
   container.bind(Diagnostics).toSelf().inSingletonScope();
 
-  container.bind(IScriptSkipper).to(ScriptSkipper).inSingletonScope();
+  container.bind(IScriptSkipper).to(ScriptSkipper).inSingletonScope().onActivation(trackDispose);
   container.bind(SmartStepper).toSelf().inSingletonScope();
   container.bind(IExceptionPauseService).to(ExceptionPauseService).inSingletonScope();
   container.bind(ICompletions).to(Completions).inSingletonScope();

--- a/src/telemetry/vscodeExperimentationService.ts
+++ b/src/telemetry/vscodeExperimentationService.ts
@@ -9,6 +9,7 @@ import {
   IExperimentationService,
   TargetPopulation,
 } from 'vscode-tas-client';
+import { IDisposable } from '../common/disposable';
 import { isNightly, packageVersion } from '../configuration';
 import { ExtensionContext } from '../ioc-extras';
 import { DapTelemetryReporter } from './dapTelemetryReporter';
@@ -19,7 +20,7 @@ import {
 import { ITelemetryReporter } from './telemetryReporter';
 
 @injectable()
-export class VSCodeExperimentationService implements IJsDebugExpService {
+export class VSCodeExperimentationService implements IJsDebugExpService, IDisposable {
   private service?: IExperimentationService;
 
   constructor(
@@ -48,6 +49,13 @@ export class VSCodeExperimentationService implements IJsDebugExpService {
         context.globalState,
       );
     }
+  }
+
+  dispose(): void {
+    // See microsoft/tas-client#74
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const polling = (this.service as any).pollingService;
+    polling?.StopPolling();
   }
 
   /**

--- a/src/ui/ui-ioc.extensionOnly.ts
+++ b/src/ui/ui-ioc.extensionOnly.ts
@@ -114,5 +114,6 @@ export const registerTopLevelSessionComponents = (container: Container) => {
   // request options:
   container.bind(IRequestOptionsProvider).to(SettingRequestOptionsProvider).inSingletonScope();
 
-  container.bind(IExperimentationService).to(VSCodeExperimentationService).inSingletonScope();
+  container.bind(IExperimentationService).to(VSCodeExperimentationService).inSingletonScope()
+    .onActivation(trackDispose);
 };


### PR DESCRIPTION
- Fix the global scriptSkipper event retaining event references
- Work around the non-disposable vscode-tas-client leaking references
- Cleanup the disposable container weakmap after deleting (just makes
  heap profiles easier to read)

Fixes #2173, hopefully