### PR TITLE
fix: ensure backslash in path when setting breakpoints in windows

### DIFF
--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -6,6 +6,7 @@ import { inject, injectable } from 'inversify';
 import Cdp from '../cdp/api';
 import { ILogger, LogTag } from '../common/logging';
 import { bisectArrayAsync, flatten } from '../common/objUtils';
+import { fixDriveLetterAndSlashes } from '../common/pathUtils';
 import { IPosition } from '../common/positions';
 import { delay } from '../common/promiseUtil';
 import { SourceMap } from '../common/sourceMaps/sourceMap';
@@ -526,7 +527,7 @@ export class BreakpointManager {
     }
 
     const wasEntryBpSet = await this._sourceMapHandlerInstalled?.entryBpSet;
-    params.source.path = urlUtils.platformPathToPreferredCase(params.source.path);
+    params.source.path = fixDriveLetterAndSlashes(params.source.path, true);
     const containedSource = this._sourceContainer.source(params.source);
 
     // Wait until the breakpoint predictor finishes to be sure that we

--- a/src/common/pathUtils.ts
+++ b/src/common/pathUtils.ts
@@ -184,7 +184,18 @@ export function fixDriveLetter(aPath: string, uppercaseDriveLetter = false): str
 /**
  * Ensure lower case drive letter and \ on Windows
  */
-export function fixDriveLetterAndSlashes(aPath: string, uppercaseDriveLetter = false): string {
+export function fixDriveLetterAndSlashes(
+  aPath: string,
+  uppercaseDriveLetter?: boolean,
+): string;
+export function fixDriveLetterAndSlashes(
+  aPath: string | undefined,
+  uppercaseDriveLetter?: boolean,
+): string | undefined;
+export function fixDriveLetterAndSlashes(
+  aPath: string | undefined,
+  uppercaseDriveLetter = false,
+): string | undefined {
   if (!aPath) return aPath;
 
   aPath = fixDriveLetter(aPath, uppercaseDriveLetter);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-js-debug/issues/2183