### PR TITLE
feat: support ModuleConfiguration for `ms-vscode.wasm-dwarf-debugging`

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -51,7 +51,8 @@
 <h5>Default value:</h4><pre><code>true</pre></code><h4>timeout</h4><p>Retry for this number of milliseconds to connect to Node.js. Default is 10000 ms.</p>
 <h5>Default value:</h4><pre><code>10000</pre></code><h4>timeouts</h4><p>Timeouts for several debugger operations.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>trace</h4><p>Configures what diagnostic output is produced.</p>
-<h5>Default value:</h4><pre><code>false</pre></code><h4>websocketAddress</h4><p>Exact websocket address to attach to. If unspecified, it will be discovered from the address and port.</p>
+<h5>Default value:</h4><pre><code>false</pre></code><h4>wasmModuleConfigurations</h4><p>Configuration for locating source files for a given WebAssembly module. If the name is <code>undefined</code>, the configuration is the default configuration, which is chosen if there&#39;s no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the <code>ms-vscode.wasm-dwarf-debugging</code> extension to function.</p>
+<h5>Default value:</h4><pre><code>[]</pre></code><h4>websocketAddress</h4><p>Exact websocket address to attach to. If unspecified, it will be discovered from the address and port.</p>
 <h5>Default value:</h4><pre><code>undefined</pre></code></details>
 
 ### node: launch
@@ -110,7 +111,8 @@
 <h5>Default value:</h4><pre><code>false</pre></code><h4>timeout</h4><p>Retry for this number of milliseconds to connect to Node.js. Default is 10000 ms.</p>
 <h5>Default value:</h4><pre><code>10000</pre></code><h4>timeouts</h4><p>Timeouts for several debugger operations.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>trace</h4><p>Configures what diagnostic output is produced.</p>
-<h5>Default value:</h4><pre><code>false</pre></code></details>
+<h5>Default value:</h4><pre><code>false</pre></code><h4>wasmModuleConfigurations</h4><p>Configuration for locating source files for a given WebAssembly module. If the name is <code>undefined</code>, the configuration is the default configuration, which is chosen if there&#39;s no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the <code>ms-vscode.wasm-dwarf-debugging</code> extension to function.</p>
+<h5>Default value:</h4><pre><code>[]</pre></code></details>
 
 ### node-terminal: launch
 
@@ -159,7 +161,8 @@
 <h5>Default value:</h4><pre><code>true</pre></code><h4>timeout</h4><p>Retry for this number of milliseconds to connect to Node.js. Default is 10000 ms.</p>
 <h5>Default value:</h4><pre><code>10000</pre></code><h4>timeouts</h4><p>Timeouts for several debugger operations.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>trace</h4><p>Configures what diagnostic output is produced.</p>
-<h5>Default value:</h4><pre><code>false</pre></code></details>
+<h5>Default value:</h4><pre><code>false</pre></code><h4>wasmModuleConfigurations</h4><p>Configuration for locating source files for a given WebAssembly module. If the name is <code>undefined</code>, the configuration is the default configuration, which is chosen if there&#39;s no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the <code>ms-vscode.wasm-dwarf-debugging</code> extension to function.</p>
+<h5>Default value:</h4><pre><code>[]</pre></code></details>
 
 ### extensionHost: launch
 
@@ -213,7 +216,8 @@
 <h5>Default value:</h4><pre><code>undefined</pre></code><h4>timeout</h4><p>Retry for this number of milliseconds to connect to Node.js. Default is 10000 ms.</p>
 <h5>Default value:</h4><pre><code>10000</pre></code><h4>timeouts</h4><p>Timeouts for several debugger operations.</p>
 <h5>Default value:</h4><pre><code>{}</pre></code><h4>trace</h4><p>Configures what diagnostic output is produced.</p>
-<h5>Default value:</h4><pre><code>false</pre></code></details>
+<h5>Default value:</h4><pre><code>false</pre></code><h4>wasmModuleConfigurations</h4><p>Configuration for locating source files for a given WebAssembly module. If the name is <code>undefined</code>, the configuration is the default configuration, which is chosen if there&#39;s no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the <code>ms-vscode.wasm-dwarf-debugging</code> extension to function.</p>
+<h5>Default value:</h4><pre><code>[]</pre></code></details>
 
 ### chrome: launch
 
@@ -268,7 +272,8 @@
 <h5>Default value:</h4><pre><code>[
   "${workspaceFolder}/**/*.vue",
   "!**/node_modules/**"
-]</pre></code><h4>webRoot</h4><p>This specifies the workspace absolute path to the webserver root. Used to resolve paths like <code>/app.js</code> to files on disk. Shorthand for a pathMapping for &quot;/&quot;</p>
+]</pre></code><h4>wasmModuleConfigurations</h4><p>Configuration for locating source files for a given WebAssembly module. If the name is <code>undefined</code>, the configuration is the default configuration, which is chosen if there&#39;s no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the <code>ms-vscode.wasm-dwarf-debugging</code> extension to function.</p>
+<h5>Default value:</h4><pre><code>[]</pre></code><h4>webRoot</h4><p>This specifies the workspace absolute path to the webserver root. Used to resolve paths like <code>/app.js</code> to files on disk. Shorthand for a pathMapping for &quot;/&quot;</p>
 <h5>Default value:</h4><pre><code>"${workspaceFolder}"</pre></code></details>
 
 ### chrome: attach
@@ -317,7 +322,8 @@
 <h5>Default value:</h4><pre><code>[
   "${workspaceFolder}/**/*.vue",
   "!**/node_modules/**"
-]</pre></code><h4>webRoot</h4><p>This specifies the workspace absolute path to the webserver root. Used to resolve paths like <code>/app.js</code> to files on disk. Shorthand for a pathMapping for &quot;/&quot;</p>
+]</pre></code><h4>wasmModuleConfigurations</h4><p>Configuration for locating source files for a given WebAssembly module. If the name is <code>undefined</code>, the configuration is the default configuration, which is chosen if there&#39;s no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the <code>ms-vscode.wasm-dwarf-debugging</code> extension to function.</p>
+<h5>Default value:</h4><pre><code>[]</pre></code><h4>webRoot</h4><p>This specifies the workspace absolute path to the webserver root. Used to resolve paths like <code>/app.js</code> to files on disk. Shorthand for a pathMapping for &quot;/&quot;</p>
 <h5>Default value:</h4><pre><code>"${workspaceFolder}"</pre></code></details>
 
 ### msedge: launch
@@ -375,7 +381,8 @@
 <h5>Default value:</h4><pre><code>[
   "${workspaceFolder}/**/*.vue",
   "!**/node_modules/**"
-]</pre></code><h4>webRoot</h4><p>This specifies the workspace absolute path to the webserver root. Used to resolve paths like <code>/app.js</code> to files on disk. Shorthand for a pathMapping for &quot;/&quot;</p>
+]</pre></code><h4>wasmModuleConfigurations</h4><p>Configuration for locating source files for a given WebAssembly module. If the name is <code>undefined</code>, the configuration is the default configuration, which is chosen if there&#39;s no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the <code>ms-vscode.wasm-dwarf-debugging</code> extension to function.</p>
+<h5>Default value:</h4><pre><code>[]</pre></code><h4>webRoot</h4><p>This specifies the workspace absolute path to the webserver root. Used to resolve paths like <code>/app.js</code> to files on disk. Shorthand for a pathMapping for &quot;/&quot;</p>
 <h5>Default value:</h4><pre><code>"${workspaceFolder}"</pre></code></details>
 
 ### msedge: attach
@@ -425,5 +432,6 @@
 <h5>Default value:</h4><pre><code>[
   "${workspaceFolder}/**/*.vue",
   "!**/node_modules/**"
-]</pre></code><h4>webRoot</h4><p>This specifies the workspace absolute path to the webserver root. Used to resolve paths like <code>/app.js</code> to files on disk. Shorthand for a pathMapping for &quot;/&quot;</p>
+]</pre></code><h4>wasmModuleConfigurations</h4><p>Configuration for locating source files for a given WebAssembly module. If the name is <code>undefined</code>, the configuration is the default configuration, which is chosen if there&#39;s no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the <code>ms-vscode.wasm-dwarf-debugging</code> extension to function.</p>
+<h5>Default value:</h4><pre><code>[]</pre></code><h4>webRoot</h4><p>This specifies the workspace absolute path to the webserver root. Used to resolve paths like <code>/app.js</code> to files on disk. Shorthand for a pathMapping for &quot;/&quot;</p>
 <h5>Default value:</h4><pre><code>"${workspaceFolder}"</pre></code></details>

--- a/package.nls.json
+++ b/package.nls.json
@@ -7,6 +7,8 @@
   "attach.node.process": "Attach to Node Process",
   "base.cascadeTerminateToConfigurations.label": "A list of debug sessions which, when this debug session is terminated, will also be stopped.",
   "base.enableDWARF.label": "Toggles whether the debugger will try to read DWARF debug symbols from WebAssembly, which can be resource intensive. Requires the `ms-vscode.wasm-dwarf-debugging` extension to function.",
+  "base.wasmModuleConfigurations.description": "Configuration for locating source files for a given WebAssembly module. If the name is `undefined`, the configuration is the default configuration, which is chosen if there's no named configuration matching the basename of the WebAssembly module file. The name can be a wildcard pattern, and global match will be used to match the name against the URL of the WebAssembly module file. Requires the `ms-vscode.wasm-dwarf-debugging` extension to function.",
+  "base.wasmModuleConfigurations.pathSubstitutions.description": "A path substitution specifies a string prefix pattern to be replaced with a new string. This is the pendant of the `set substitute-path old new` feature that is found in GDB and `settings set target.source-map old new` feature that is found in LLDB.",
   "browser.address.description": "IP address or hostname the debugged browser is listening on.",
   "browser.attach.port.description": "Port to use to remote debugging the browser, given as `--remote-debugging-port` when launching the browser.",
   "browser.baseUrl.description": "Base URL to resolve paths baseUrl. baseURL is trimmed when mapping URLs to the files on disk. Defaults to the launch URL domain.",
@@ -86,7 +88,9 @@
   "debug.terminal.toggleAuto": "Toggle Terminal Node.js Auto Attach",
   "debug.terminal.welcome": {
     "message": "[JavaScript Debug Terminal](command:extension.js-debug.createDebuggerTerminal)\n\nYou can use the JavaScript Debug Terminal to debug Node.js processes run on the command line.",
-    "comment": ["{Locked='](command:extension.js-debug.createDebuggerTerminal)'}"]
+    "comment": [
+      "{Locked='](command:extension.js-debug.createDebuggerTerminal)'}"
+    ]
   },
   "debug.terminal.welcomeWithLink": {
     "message": "[JavaScript Debug Terminal](command:extension.js-debug.createDebuggerTerminal)\n\nYou can use the JavaScript Debug Terminal to debug Node.js processes run on the command line.\n\n[Debug URL](command:extension.js-debug.debugLink)",

--- a/src/adapter/dwarf/wasmSymbolProvider.ts
+++ b/src/adapter/dwarf/wasmSymbolProvider.ts
@@ -85,7 +85,7 @@ export class WasmWorkerFactory implements IWasmWorkerFactory {
           ).then((v: number[]) => new Uint8Array(v).buffer),
       });
 
-      worker.rpc.sendMessage('hello', [], false);
+      worker.rpc.sendMessage('hello', this.launchConfig.wasmModuleConfigurations, false);
 
       return worker;
     });

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -311,6 +311,30 @@ const baseConfigurationAttributes: ConfigurationAttributes<IBaseConfiguration> =
     default: true,
     markdownDescription: refString('base.enableDWARF.label'),
   },
+  wasmModuleConfigurations: {
+    type: 'array',
+    default: [],
+    markdownDescription: refString('base.wasmModuleConfigurations.description'),
+    items: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        pathSubstitutions: {
+          type: 'array',
+          description: refString('base.wasmModuleConfigurations.pathSubstitutions.description'),
+          items: {
+            type: 'object',
+            properties: {
+              from: { type: 'string' },
+              to: { type: 'string' },
+            },
+            required: ['from', 'to'],
+          },
+        },
+      },
+      required: ['pathSubstitutions'],
+    },
+  },
 };
 
 /**

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,6 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { type ModuleConfigurations } from '@vscode/dwarf-debugging/chrome-cxx/mnt/extension/ModuleConfiguration';
 import { homedir } from 'os';
 import { SourceMapTimeouts } from './adapter/sourceContainer';
 import { DebugType } from './common/contributionUtils';
@@ -166,6 +167,17 @@ export interface IBaseConfiguration extends IMandatedConfiguration {
    * `ms-vscode.wasm-dwarf-debugging` extension to function.
    */
   enableDWARF: boolean;
+
+  /**
+   * Configuration for locating source files for a given WebAssembly module.
+   * If the name is `undefined`, the configuration is the default configuration,
+   * which is chosen if there's no named configuration matching the basename of
+   * the WebAssembly module file.
+   * The name can be a wildcard pattern, and global match will be used to
+   * match the name against the URL of the WebAssembly module file.
+   * Requires the `ms-vscode.wasm-dwarf-debugging` extension to function.
+   */
+  wasmModuleConfigurations: ModuleConfigurations;
 
   /**
    * The value of the ${workspaceFolder} variable
@@ -840,6 +852,7 @@ export const baseDefaults: IBaseConfiguration = {
   enableContentValidation: true,
   cascadeTerminateToConfigurations: [],
   enableDWARF: true,
+  wasmModuleConfigurations: [],
   // Should always be determined upstream;
   __workspaceFolder: '',
   __remoteFilePrefix: undefined,


### PR DESCRIPTION
Issue https://github.com/microsoft/vscode-dwarf-debugging-ext/issues/7 gives a solution of path substitutions in browser. But it doesn't work when debugging webassembly in nodejs. I wonder why we cannot directly add a configuration. Here it is.

Docs and descriptions come from the jsdocs in `@vscode/dwarf-debugging/chrome-cxx/mnt/extension/ModuleConfiguration`