### PR TITLE
fix: apply sourceMapPathOverrides to Node, too

### DIFF
--- a/src/targets/node/nodeSourcePathResolver.ts
+++ b/src/targets/node/nodeSourcePathResolver.ts
@@ -73,6 +73,11 @@ export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
   public async urlToAbsolutePath({ url, map }: IUrlResolution): Promise<string | undefined> {
     url = this.normalizeSourceMapUrl(url);
 
+    // It's possible the source might be using the `sourceURL`, so apply
+    // any source map overrides now (fixes vscode#204784) and before file
+    // URIs (vscode-dwarf-debugging-ext#7)
+    url = this.sourceMapOverrides.apply(url);
+
     // Allow debugging of externally loaded Node internals
     // [ by building Node with ./configure --node-builtin-modules-path $(pwd) ]
     if (url.startsWith(localNodeInternalsPrefix) && this.options.basePath) {


### PR DESCRIPTION
Matches what we did for https://github.com/microsoft/vscode-dwarf-debugging-ext/issues/7, but for Node too.

Closes #2185