### PR TITLE
chore: experimental networking by default on recent Node versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 - fix: explicitly specify completion ranges ([[vscode#243409](https://github.com/microsoft/vscode/issues/243409)])
 - fix: memory leak between debug sessions ([#2173](https://github.com/microsoft/vscode-js-debug/issues/2173))
 - fix: support `npm.scriptRunner: node`
+- chore: enable experimental networking by default on recent Node versions
 
 ## 1.97 (January 2025)
 

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -174,6 +174,10 @@ export class Binder implements IDisposable {
 
       return {};
     });
+    dap.on('enableNetworking', () => {
+      // handled on a session level
+      return Promise.resolve({});
+    });
   }
 
   private readonly getLaunchers = once(() => {

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -1252,7 +1252,7 @@ const configurationSchema: ConfigurationAttributes<IConfigurationTypes> = {
   },
   [Configuration.EnableNetworkView]: {
     type: 'boolean',
-    default: false,
+    default: true,
     description: refString('configuration.enableNetworkView'),
   },
 };

--- a/src/targets/node/nodeBinaryProvider.ts
+++ b/src/targets/node/nodeBinaryProvider.ts
@@ -132,13 +132,9 @@ export class NodeBinary {
       this.capabilities.add(Capability.UseInspectPublishUid);
     }
 
-    // todo@connor4312: the current API we get in Node.js is pretty tiny and
-    // I don't want to ship it by default in its current version, ref
-    // https://github.com/nodejs/node/pull/53593#issuecomment-2276367389
-    // Users can still turn it on by setting `experimentalNetworking: on`.
-    // if (version.gte(new Semver(22, 6, 0)) && version.lt(new Semver(24, 0, 0))) {
-    //   this.capabilities.add(Capability.UseExperimentalNetworking);
-    // }
+    if (version.gte(new Semver(22, 14, 0)) && version.lt(new Semver(24, 0, 0))) {
+      this.capabilities.add(Capability.UseExperimentalNetworking);
+    }
   }
 
   /**


### PR DESCRIPTION
It's now good enough to be reasonably useful in Node.js, so turn it on by default. Still have a setting to turn it off.