### PR TITLE
Fix bug where the WasmWorker instance is disposed but never re-spawned on page reloads + writeMemory when WASM memory is SharedArrayBuffer

### DIFF
--- a/src/adapter/dwarf/wasmSymbolProvider.ts
+++ b/src/adapter/dwarf/wasmSymbolProvider.ts
@@ -103,6 +103,10 @@ export class WasmWorkerFactory implements IWasmWorkerFactory {
       getStopId: id => `${cdpId}:${id}`,
       dispose: () => {
         this.cdp.delete(cdpId);
+        if (this.cdp.size > 0) {
+          return Promise.resolve();
+        }
+        this.worker = undefined;
         return worker.dispose();
       },
     };

--- a/src/adapter/templates/writeMemory.ts
+++ b/src/adapter/templates/writeMemory.ts
@@ -14,7 +14,8 @@ export const writeMemory = remoteFunction(function(
 ) {
   const bytes = decodeHex(data);
 
-  const { buffer, byteLength, byteOffset } = this instanceof ArrayBuffer
+  const { buffer, byteLength, byteOffset } = (this instanceof ArrayBuffer
+      || (typeof SharedArrayBuffer !== 'undefined' && this instanceof SharedArrayBuffer))
     ? new DataView(this)
     : this instanceof WebAssembly.Memory
     ? new DataView(this.buffer)


### PR DESCRIPTION
The `WasmWorkerFactory` instance caches a single `IWasmWorker` instance but the `dispose` method on the `IWasmWorker` instance still terminates the underlying worker. The effect is that the worker in the `@vscode/dwarf-debugging` terminates on browser page reloads and never re-spawns again until debugging is restarted.

This PR addresses this issue by still caching a single `IWasmWorker` instance but re-spawning it if the previous call to `dispose` caused the _"ref count"_ to reach zero.

Possible related to https://github.com/microsoft/vscode-dwarf-debugging/issues/6

Also fixes `writeMemory` when WASM memory is `SharedArrayBuffer`.
