### PR TITLE
fix: avoid extraneous rename mapping

### DIFF
--- a/src/common/positions.ts
+++ b/src/common/positions.ts
@@ -150,6 +150,13 @@ export class Range {
     return position.compare(this.begin) >= 0 && position.compare(this.end) <= 0;
   }
 
+  /**
+   * Returns if the range contains the given range, inclusive.
+   */
+  public containsRange(range: Range) {
+    return this.contains(range.begin) && this.contains(range.end);
+  }
+
   /** Returns a human-debuggable representation of the range. */
   public toString() {
     const b1 = this.begin.base0;


### PR DESCRIPTION
Previously the entire expression was always renamed, but this caused some issues with names in our clipboard wrapper script being replaced. This commit adds logic such that only the expressions inserted in the evaluation are renamed.

We should ideally have a shadowing model instead... but this is a fix for now.