### PR TITLE
chore: Fix default url for turbopack

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -984,6 +984,7 @@ export function defaultSourceMapPathOverrides(webRoot: string): { [key: string]:
     'webpack://?:*/*': `${webRoot}/*`,
     'webpack:///([a-z]):/(.+)': '$1:/$2',
     'meteor://💻app/*': `${webRoot}/*`,
+    'turbopack://[project]/*': '${workspaceFolder}/*',
     'turbopack:///[project]/*': '${workspaceFolder}/*',
   };
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -984,7 +984,7 @@ export function defaultSourceMapPathOverrides(webRoot: string): { [key: string]:
     'webpack://?:*/*': `${webRoot}/*`,
     'webpack:///([a-z]):/(.+)': '$1:/$2',
     'meteor://💻app/*': `${webRoot}/*`,
-    'turbopack://[project]/*': '${workspaceFolder}/*',
+    'turbopack:///[project]/*': '${workspaceFolder}/*',
   };
 }
 


### PR DESCRIPTION
Fix the default URL of turbopack to match the content of https://github.com/vercel/next.js/pull/76075.

x-ref: https://github.com/vercel/next.js/issues/77670#issuecomment-2873760418