### PR TITLE
chore: migrate PR pipeline onto 1ES template

### DIFF
--- a/.ci/common-validation.yml
+++ b/.ci/common-validation.yml
@@ -76,28 +76,3 @@ steps:
   displayName: 'Component Detection'
   inputs:
     ignoreDirectories: 'testdata,demos,.vscode-test'
-
-- ${{ if eq(parameters.name, 'Windows') }}:
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
-    displayName: 'TSA upload to Codebase: vscode-js-debug_master Version: TsaV2'
-    inputs:
-      tsaVersion: TsaV2
-      codebase: NewOrUpdate
-      codeBaseName: 'vscode-js-debug_master'
-      notificationAlias: 'webdiag-extensions@microsoft.com'
-      instanceUrlForTsaV2: DEVDIV
-      projectNameDEVDIV: DevDiv
-      areaPath: 'DevDiv\TypeScript\HTML Experiences\Diagnostics\Debugger'
-      uploadAPIScan: false
-      uploadBinSkim: false
-      uploadFortifySCA: false
-      uploadFxCop: false
-      uploadModernCop: false
-      uploadPoliCheck: false
-      uploadPREfast: false
-      uploadRoslyn: false
-      uploadTSLint: false
-
-- ${{ if eq(parameters.name, 'Windows') }}:
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-    displayName: 'Publish Security Analysis Logs'

--- a/.ci/pipeline.yml
+++ b/.ci/pipeline.yml
@@ -2,37 +2,58 @@ trigger:
   branches:
     include: ['*']
 
-jobs:
-- job: macOS
-  timeoutInMinutes: 20
-  pool:
-    vmImage: 'macos-latest'
-  steps:
-  - template: common-validation.yml
-  variables:
-    node_version: 16.14.2
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
 
-- job: Linux
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - template: common-validation.yml
-  variables:
-    node_version: 16.14.2
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      sourceAnalysisPool: 1es-windows-2022-x64
+      tsa:
+        enabled: false
+    stages:
+      - stage: Build
+        jobs:
+          - job: macOS
+            timeoutInMinutes: 20
+            pool:
+              name: Azure Pipelines
+              vmImage: 'macOS-latest'
+              os: macOS
+            steps:
+            - template: .ci/common-validation.yml@self
+            variables:
+              node_version: 18
 
-- job: LinuxMinspec
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - template: common-validation.yml
-  variables:
-    node_version: 16.14.2
-    only_minspec: true
+          - job: Linux
+            pool:
+              name: '1es-ubuntu-22.04-x64'
+              os: linux
+            steps:
+            - template: .ci/common-validation.yml@self
+            variables:
+              node_version: 18
 
-- job: Windows
-  pool:
-      vmImage: windows-latest
-  steps:
-  - template: common-validation.yml
-  variables:
-    node_version: 16.14.2
+          - job: LinuxMinspec
+            pool:
+              name: '1es-ubuntu-22.04-x64'
+              os: linux
+            steps:
+            - template: .ci/common-validation.yml@self
+            variables:
+              node_version: 18
+              only_minspec: true
+
+          - job: Windows
+            pool:
+              name: windows-latest
+              os: windows
+            steps:
+            - template: .ci/common-validation.yml@self
+            variables:
+              node_version: 18


### PR DESCRIPTION
This PR migrates the pipeline onto the 1ES template and also uses the pools in monacotools.

I would like to merge in this PR, create a new pipeline in monacotools, and then create a new PR for any necessary fixes.