### PR TITLE
Dereferences of undefined at various places

### DIFF
--- a/src/adapter/objectPreview/index.ts
+++ b/src/adapter/objectPreview/index.ts
@@ -174,7 +174,7 @@ function renderObjectPreview(
   format: Dap.ValueFormat | undefined,
 ): string {
   const builder = new BudgetStringBuilder(characterBudget, ' ');
-  if (preview.description !== 'Object') {
+  if (preview.description !== 'Object' && preview.description != null) {
     builder.append(stringUtils.trimEnd(preview.description, builder.budget()));
   }
 

--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -324,7 +324,7 @@ async function getEnhancedName(
       objectId: callFrame.this.objectId,
       returnByValue: true,
     });
-    objName = ret?.result.value;
+    objName = ret?.result?.value;
   }
 
   if (!objName && callFrame.this.description) {

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -548,7 +548,7 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
         return; // shut down
       }
 
-      if (!telemetry || !telemetry.result.value) {
+      if (!telemetry || !telemetry.result || !telemetry.result.value) {
         this.logger.error(LogTag.RuntimeTarget, 'Undefined result getting telemetry');
         return;
       }


### PR DESCRIPTION
There are some places in the code, which lead to the following error: Unable to read a prop from undefined.
There is a `?.` dereference chain which is not complete and so on. The fixes allow the debugger plugin to be used with GraalJS programs as well as with others. 