### PR TITLE
fix: label module scopes as expensive

### DIFF
--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -523,7 +523,7 @@ export class StackFrame implements IStackFrameElement {
         const dap: Dap.Scope = {
           name,
           presentationHint,
-          expensive: scope.type === 'global',
+          expensive: scope.type === 'global' || scope.type === 'module',
           variablesReference: variable.id,
         };
         if (scope.startLocation) {


### PR DESCRIPTION
In some environments (e.g., Cloudflare Workers), module scopes can contain thousands of variables, making them expensive. Therefore, we should label them as such.