### PR TITLE
chore: prep v1.117.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This changelog records changes to stable releases since 1.50.2. "TBA" changes he
 
 Nothing, yet
 
+## 1.117 (April 2026)
+
+- feat: add debug configuration provider for integrated browser ([#2347](https://github.com/microsoft/vscode-js-debug/pull/2347))
+- fix: capture early breakpoints when launching integrated browser ([#2347](https://github.com/microsoft/vscode-js-debug/pull/2347))
+- fix: prevent duplicate worker attachments in integrated browser ([#2347](https://github.com/microsoft/vscode-js-debug/pull/2347))
+
 ## 1.112 (March 2026)
 
 - feat: support debugging integrated browser ([#2329](https://github.com/microsoft/vscode-js-debug/pull/2329))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-debug",
-  "version": "1.112.0",
+  "version": "1.117.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-debug",
-      "version": "1.112.0",
+      "version": "1.117.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "js-debug",
   "displayName": "JavaScript Debugger",
-  "version": "1.112.0",
+  "version": "1.117.0",
   "publisher": "ms-vscode",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Release prep for v1.117.0.

## Changes
- feat: add debug configuration provider for integrated browser (#2347)
- fix: capture early breakpoints when launching integrated browser (#2347)
- fix: correctly filter page targets in integrated browser attacher (#2347)