### PR TITLE
Revert "Migrate package TypeScript settings to ESM"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
             only_minspec: false
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    env:
-      # TODO: Re-enable lint checks after current lint baseline failures are resolved.
-      DISABLE_LINT_FOR_NOW: 'true'
     permissions:
       contents: read
 
@@ -66,5 +63,5 @@ jobs:
         run: npm run test:types
 
       - name: Lint checking
-        if: ${{ env.DISABLE_LINT_FOR_NOW != 'true' && !matrix.only_minspec }}
+        if: ${{ !matrix.only_minspec }}
         run: npm run test:lint

--- a/src/adapter/cdpProxy.ts
+++ b/src/adapter/cdpProxy.ts
@@ -4,7 +4,7 @@
 
 import { randomBytes } from 'crypto';
 import { inject, injectable } from 'inversify';
-import WebSocket, { type RawData, type WebSocketServer } from 'ws';
+import WebSocket from 'ws';
 import { Cdp } from '../cdp/api';
 import { ICdpApi, ProtocolError } from '../cdp/connection';
 import { CdpProtocol } from '../cdp/protocol';
@@ -162,7 +162,7 @@ export const ICdpProxyProvider = Symbol('ICdpProxyProvider');
  */
 @injectable()
 export class CdpProxyProvider implements ICdpProxyProvider {
-  private server?: Promise<{ server: WebSocketServer; path: string }>;
+  private server?: Promise<{ server: WebSocket.Server; path: string }>;
   private readonly disposables = new DisposableList();
   private readonly replay = new DomainReplays();
 
@@ -241,7 +241,7 @@ export class CdpProxyProvider implements ICdpProxyProvider {
 
     this.logger.info(LogTag.ProxyActivity, 'activated cdp proxy');
 
-    server.on('connection', (client: WebSocket) => {
+    server.on('connection', client => {
       const clientHandle = new ClientHandle(client, this.logger);
       this.logger.info(LogTag.ProxyActivity, 'accepted proxy connection', {
         id: clientHandle.id,
@@ -254,7 +254,7 @@ export class CdpProxyProvider implements ICdpProxyProvider {
         this.disposables.disposeObject(clientHandle);
       });
 
-      client.on('message', async (d: RawData) => {
+      client.on('message', async d => {
         let message: CdpProtocol.ICommand;
         try {
           message = JSON.parse(d.toString());

--- a/src/adapter/portLeaseTracker.ts
+++ b/src/adapter/portLeaseTracker.ts
@@ -5,7 +5,7 @@
 import { inject, injectable } from 'inversify';
 import * as net from 'net';
 import { CancellationToken } from 'vscode';
-import { type ServerOptions } from 'ws';
+import * as WebSocket from 'ws';
 import { cancellableRace, NeverCancelled } from '../common/cancellation';
 import { IDisposable } from '../common/disposable';
 import { EventEmitter } from '../common/events';
@@ -43,7 +43,7 @@ export const acquireTrackedServer = async (
  */
 export const acquireTrackedWebSocketServer = async (
   tracker: IPortLeaseTracker,
-  options?: ServerOptions,
+  options?: WebSocket.ServerOptions,
   ct?: CancellationToken,
 ) => {
   const server = await findOpenPort({ tester: makeAcquireWebSocketServer(options) }, ct);

--- a/src/build/documentReadme.ts
+++ b/src/build/documentReadme.ts
@@ -9,8 +9,6 @@ import strings from '../../package.nls.json';
 import { getPreferredOrDebugType } from '../common/contributionUtils';
 import { debuggers, DescribedAttribute } from './generate-contributions.js';
 
-const nlsStrings = strings as Record<string, string | { message: string }>;
-
 (async () => {
   let out = `# Options\n\n`;
   for (const dbg of debuggers) {
@@ -29,11 +27,7 @@ const nlsStrings = strings as Record<string, string | { message: string }>;
       }
 
       const descriptionKey = descriptionKeyRaw.slice(1, -1);
-      const localized = nlsStrings[descriptionKey];
-      const description = (typeof localized === 'string' ? localized : localized?.message)?.replace(
-        /\n/g,
-        '<br>',
-      );
+      const description = strings[descriptionKey].replace(/\n/g, '<br>');
       if (!description) {
         continue;
       }

--- a/src/common/findOpenPort.ts
+++ b/src/common/findOpenPort.ts
@@ -4,7 +4,7 @@
 
 import * as net from 'net';
 import type { CancellationToken } from 'vscode';
-import { WebSocketServer, type ServerOptions } from 'ws';
+import * as WebSocket from 'ws';
 import { NeverCancelled, TaskCancelledError } from './cancellation';
 import { IDisposable } from './disposable';
 import { randomInRange } from './random';
@@ -112,9 +112,9 @@ export const makeAcquireTcpServer =
  * @returns the listening server
  */
 export const makeAcquireWebSocketServer =
-  (options?: ServerOptions): PortTesterFn<WebSocketServer> => (port, ct) =>
+  (options?: WebSocket.ServerOptions): PortTesterFn<WebSocket.Server> => (port, ct) =>
     waitForServerToListen(
-      new WebSocketServer({ host: '127.0.0.1', ...options, port }),
+      new WebSocket.WebSocketServer({ host: '127.0.0.1', ...options, port }),
       ct,
     );
 

--- a/src/test/common/cdpTransport.test.ts
+++ b/src/test/common/cdpTransport.test.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 import { randomBytes } from 'crypto';
 import { stub } from 'sinon';
 import { PassThrough } from 'stream';
-import { AddressInfo, WebSocketServer } from 'ws';
+import { AddressInfo, Server as WebSocketServer } from 'ws';
 import { RawPipeTransport } from '../../cdp/rawPipeTransport';
 import { ITransport } from '../../cdp/transport';
 import { WebSocketTransport } from '../../cdp/webSocketTransport';
@@ -41,7 +41,7 @@ describe('cdp transport', () => {
         const address = server.address() as AddressInfo;
         const a = WebSocketTransport.create(`ws://127.0.0.1:${address.port}`, NeverCancelled);
         const b = new Promise<WebSocketTransport>((resolve, reject) => {
-          server.on('connection', (cnx: import('ws').WebSocket) => resolve(new WebSocketTransport(cnx)));
+          server.on('connection', cnx => resolve(new WebSocketTransport(cnx)));
           server.on('error', reject);
         });
 

--- a/src/test/reporters/goldenTextReporter.ts
+++ b/src/test/reporters/goldenTextReporter.ts
@@ -32,4 +32,5 @@ class GoldenTextReporter extends mocha.reporters.Spec {
   }
 }
 
-export default GoldenTextReporter;
+// Must be default export
+export = GoldenTextReporter;

--- a/src/test/reporters/logTestReporter.ts
+++ b/src/test/reporters/logTestReporter.ts
@@ -30,4 +30,5 @@ class LoggingReporter extends mocha.reporters.Spec {
   }
 }
 
-export default LoggingReporter;
+// Must be default export
+export = LoggingReporter;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "ES2022",
+    "module": "commonjs",
     "target": "ES2021",
     "lib": ["ES2022"],
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitThis": true,
     "sourceMap": true,


### PR DESCRIPTION
Reverts microsoft/vscode-js-debug#2355 because it fails lint checks that were not caught until those checks were re-enabled.