### PR TITLE
chore(deps): update picomatch to ^2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "micromatch": "^4.0.5",
         "npm-run-all2": "^7.0.1",
         "path-browserify": "^1.0.1",
-        "picomatch": "connor4312/picomatch#2fbe90b12eafa7dde816ff8c16be9e77271b0e0b",
+        "picomatch": "^2.3.2",
         "preact": "^10.19.3",
         "reflect-metadata": "^0.2.1",
         "signale": "^1.4.0",
@@ -12573,9 +12573,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "git+ssh://git@github.com/connor4312/picomatch.git#2fbe90b12eafa7dde816ff8c16be9e77271b0e0b",
-      "integrity": "sha512-NFpH2Othy/6fk2qamg3cjFa4P3RDgDpTNQGqZWT07WL80xef9hoLlIfHNRvWp4VDEOJVIzgChnDOHwvf5KP+jA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -25886,9 +25886,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "git+ssh://git@github.com/connor4312/picomatch.git#2fbe90b12eafa7dde816ff8c16be9e77271b0e0b",
-      "integrity": "sha512-NFpH2Othy/6fk2qamg3cjFa4P3RDgDpTNQGqZWT07WL80xef9hoLlIfHNRvWp4VDEOJVIzgChnDOHwvf5KP+jA==",
-      "from": "picomatch@connor4312/picomatch#2fbe90b12eafa7dde816ff8c16be9e77271b0e0b"
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
     },
     "pidtree": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "micromatch": "^4.0.5",
     "npm-run-all2": "^7.0.1",
     "path-browserify": "^1.0.1",
-    "picomatch": "connor4312/picomatch#2fbe90b12eafa7dde816ff8c16be9e77271b0e0b",
+    "picomatch": "^2.3.2",
     "preact": "^10.19.3",
     "reflect-metadata": "^0.2.1",
     "signale": "^1.4.0",


### PR DESCRIPTION
Upgrade picomatch from 2.3.1 to 2.3.2 to fix CVE-2026-33671.

Also adds 'vscode' to externalModules in gulpfile.js to fix the vsDebugServerBundle build task which fails with 'Could not resolve vscode' since nodeLauncher.ts is now reachable from the vsDebugServer entry point.