### PR TITLE
fix: keep directory separators visible when filtering npm scripts

### DIFF
--- a/src/ui/debugNpmScript.ts
+++ b/src/ui/debugNpmScript.ts
@@ -49,6 +49,10 @@ export async function debugNpmScript(inFolder?: vscode.WorkspaceFolder | string)
   // directory name so the user knows where it's coming from.
   const multiDir = scripts.some(s => s.directory !== scripts[0].directory);
   const quickPick = vscode.window.createQuickPick<ScriptPickItem>();
+  // Keep the original order while filtering so directory separators stay attached to their
+  // groups; sorting by match would reorder across groups and drop them. (sortByLabel is
+  // proposed API microsoft/vscode#73904, safe at runtime — cast to avoid the dependency.)
+  (quickPick as { sortByLabel?: boolean }).sortByLabel = !multiDir;
 
   let lastDir: string | undefined;
   const items: ScriptPickItem[] = [];


### PR DESCRIPTION
## Problem

The **Debug npm Script** picker (`extension.js-debug.npmScript`) groups scripts by directory using `QuickPickItemKind.Separator` when scripts come from multiple directories (multi-root / monorepo workspaces). While filtering, the quick pick sorts items by match position (VS Code's default), which reorders items across groups and drops the separators. As soon as you type a filter, you can no longer tell which package each script belongs to.

- Unfiltered: scripts grouped with the directory name shown on the right ✔️
- Filtered (before): directory labels disappear ❌
- Filtered (after): directory labels stay attached to their groups ✔️

## Fix

Disable match sorting **only** when scripts span multiple directories (`multiDir`), so the separators stay attached while filtering. Single-directory pickers keep the default match sorting and are unchanged.

```diff
   const quickPick = vscode.window.createQuickPick<ScriptPickItem>();
+  (quickPick as { sortByLabel?: boolean }).sortByLabel = !multiDir;
```

`sortByLabel` is a proposed API (microsoft/vscode#73904) but is safe to set at runtime (the setter has no proposal guard). The change uses a typed cast to avoid taking a proposed-API dependency, matching the existing cast style in the codebase (e.g. `objectPreview/index.ts`).

<img width="1056" height="224" alt="Screenshot 2026-06-07 070414" src="https://github.com/user-attachments/assets/f7b9cb04-a2d0-401f-b1de-78ba3613ad56" />
<img width="1033" height="191" alt="Screenshot 2026-06-07 081932" src="https://github.com/user-attachments/assets/c7db98ad-5075-48fb-8b43-86e51faf4c57" />
