### PR TITLE
fix: fixed issue #2344

### DIFF
--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -105,9 +105,7 @@ export default class Connection {
     if (!session) {
       const disposedDate = this._disposedSessions.get(object.sessionId);
       if (!disposedDate) {
-        throw new Error(
-          `Unknown session id: ${object.sessionId} while processing: ${object.method}`,
-        );
+        this.logger.warn(LogTag.Internal,`Unknown session id: ${object.sessionId} while processing: ${object.method}`,);
       } else {
         const secondsAgo = (Date.now() - disposedDate.getTime()) / 1000.0;
         this.logger.warn(
@@ -122,7 +120,7 @@ export default class Connection {
     const eventName = object.method;
     let error: Error | undefined;
     try {
-      session._onMessage(object);
+      session?._onMessage(object);
     } catch (e) {
       error = e;
     }

--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -105,7 +105,7 @@ export default class Connection {
     if (!session) {
       const disposedDate = this._disposedSessions.get(object.sessionId);
       if (!disposedDate) {
-        this.logger.warn(LogTag.Internal,`Unknown session id: ${object.sessionId} while processing: ${object.method}`,);
+        this.logger.warn(LogTag.Internal,`Unknown session id: ${object.sessionId} while processing: ${object.method}`);
       } else {
         const secondsAgo = (Date.now() - disposedDate.getTime()) / 1000.0;
         this.logger.warn(

--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -105,7 +105,7 @@ export default class Connection {
     if (!session) {
       const disposedDate = this._disposedSessions.get(object.sessionId);
       if (!disposedDate) {
-        this.logger.warn(LogTag.Internal,`Unknown session id: ${object.sessionId} while processing: ${object.method}`);
+        this.logger.error(LogTag.Internal,`Unknown session id: ${object.sessionId} while processing: ${object.method}`);
       } else {
         const secondsAgo = (Date.now() - disposedDate.getTime()) / 1000.0;
         this.logger.warn(


### PR DESCRIPTION
At the end of a debugging session, it may not be cleaned up properly due to various reasons, or the session may be occupied. This frequently occurs in attach mode. The error "Unknown session id" is thrown, causing the attach to be terminated before completion, which in turn freezes the target browser page and leaves the session state abnormal within VS Code.

Changing the error message to a warning is the minimal change. It does not affect the existing debugging workflow and allows the target page to be attached successfully. This resolves the issue where a second attach attempt fails due to detection errors, thereby preventing debugging from being blocked.