### PR TITLE
fix: reuse sources registered during URL resolution

### DIFF
--- a/src/adapter/sourceContainer.test.ts
+++ b/src/adapter/sourceContainer.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { expect } from 'chai';
+import Cdp from '../cdp/api';
+import { ILogger } from '../common/logging';
+import { upcastPartial } from '../common/objUtils';
+import { getDeferred } from '../common/promiseUtil';
+import { ISourceMapFactory } from '../common/sourceMaps/sourceMapFactory';
+import { ISourcePathResolver } from '../common/sourcePathResolver';
+import { AnyLaunchConfiguration } from '../configuration';
+import Dap from '../dap/api';
+import { stubbedDapApi } from '../dap/stubbedApi';
+import { IWasmSymbolProvider } from './dwarf/wasmSymbolProvider';
+import { IResourceProvider } from './resourceProvider';
+import { ScriptSkipper } from './scriptSkipper/implementation';
+import { SourceContainer } from './sourceContainer';
+
+describe('SourceContainer', () => {
+  it('reuses a source registered while its URL was resolving', async () => {
+    const firstResolution = getDeferred<string | undefined>();
+    const secondResolution = getDeferred<string | undefined>();
+    const resolutions = [firstResolution.promise, secondResolution.promise];
+    const sourcePathResolver = upcastPartial<ISourcePathResolver>({
+      urlToAbsolutePath: () => resolutions.shift() ?? Promise.resolve(undefined),
+    });
+    const scriptSkipper = upcastPartial<ScriptSkipper>({
+      setSourceContainer: () => undefined,
+      initializeSkippingValueForSource: () => undefined,
+    });
+    const sourceContainer = new SourceContainer(
+      stubbedDapApi().actual,
+      upcastPartial<ISourceMapFactory>({}),
+      upcastPartial<ILogger>({
+        verbose: () => undefined,
+        assert: <T>(value: T | false | null | undefined): value is T => !!value,
+      }),
+      upcastPartial<AnyLaunchConfiguration>({
+        sourceMaps: true,
+        timeouts: {},
+      }),
+      upcastPartial<Dap.InitializeParams>({}),
+      sourcePathResolver,
+      scriptSkipper,
+      upcastPartial<IResourceProvider>({}),
+      upcastPartial<IWasmSymbolProvider>({}),
+    );
+    const event = (scriptId: string) =>
+      upcastPartial<Cdp.Debugger.ScriptParsedEvent>({
+        scriptId,
+        url: 'file:///shared.js',
+        hash: 'same-content',
+      });
+
+    const firstAdd = sourceContainer.addSource(
+      event('1'),
+      async () => undefined,
+      undefined,
+      undefined,
+      undefined,
+      'same-content',
+    );
+    const secondAdd = sourceContainer.addSource(
+      event('2'),
+      async () => undefined,
+      undefined,
+      undefined,
+      undefined,
+      'same-content',
+    );
+
+    firstResolution.resolve(undefined);
+    const firstSource = await firstAdd;
+    secondResolution.resolve(undefined);
+    const secondSource = await secondAdd;
+
+    expect(secondSource).to.equal(firstSource);
+    expect(sourceContainer.getSourceByOriginalUrl(event('1').url)).to.equal(firstSource);
+  });
+});

--- a/src/adapter/sourceContainer.ts
+++ b/src/adapter/sourceContainer.ts
@@ -626,6 +626,12 @@ export class SourceContainer {
   ): Promise<Source> {
     const absolutePath = await this.sourcePathResolver.urlToAbsolutePath({ url: event.url });
 
+    // Another script event may have registered this source while the URL was resolving.
+    const existingSource = contentHash && this._sourceByOriginalUrl.get(event.url);
+    if (existingSource && existingSource.contentHash === contentHash) {
+      return existingSource;
+    }
+
     this.logger.verbose(LogTag.RuntimeSourceCreate, 'Creating source from url', {
       inputUrl: event.url,
       absolutePath,


### PR DESCRIPTION
## Summary

- recheck the original-URL source registry after asynchronous URL resolution
- reuse a concurrently registered source only when its content hash matches
- add a deterministic regression test for the two-context race

Closes #2342

## Verification

- `npm run test:unit -- --grep SourceContainer` (1 passing)
- `npm run test:types`
- `npm run compile`
- `dprint check src/adapter/sourceContainer.ts src/adapter/sourceContainer.test.ts`
- `eslint --max-warnings=0 src/adapter/sourceContainer.ts src/adapter/sourceContainer.test.ts`
- `git diff --check`

The full unit run completed with 259 passing tests and 8 failures, all in the unchanged `NodeBinaryProvider` Windows PATH fixtures, where the host Node executable is selected instead of the checked-in fixture. Full lint likewise reaches an existing dprint violation in unchanged `src/targets/node/nodeLauncher.ts:318`; the changed files pass both dprint and ESLint directly.