### PR TITLE
fix: identifier regexp supports unicode identifiers

### DIFF
--- a/src/adapter/completions.ts
+++ b/src/adapter/completions.ts
@@ -282,7 +282,7 @@ export class Completions {
 
     const start = getStart(node.property) - 1;
 
-    // For any properties are aren't valid identifiers, quote them as foo['bar!']
+    // For any properties that aren't valid identifiers, quote them as foo['bar!']
     for (const item of result) {
       if (!validIdentifierRe.test(item.label)) {
         item.text = `[${JSON.stringify(item.label)}]`;

--- a/src/adapter/completions.ts
+++ b/src/adapter/completions.ts
@@ -132,6 +132,8 @@ export interface ICompletions {
   completions(options: ICompletionContext & ICompletionExpression): Promise<Dap.CompletionItem[]>;
 }
 
+const validIdentifierRe = /^[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*$/u;
+
 /**
  * Provides REPL completions for the debug session.
  */
@@ -280,9 +282,7 @@ export class Completions {
 
     const start = getStart(node.property) - 1;
 
-    // For any properties are aren't valid identifiers, (erring on the side of
-    // caution--not checking unicode and such), quote them as foo['bar!']
-    const validIdentifierRe = /^[$a-z_][0-9a-z_$]*$/i;
+    // For any properties are aren't valid identifiers, quote them as foo['bar!']
     for (const item of result) {
       if (!validIdentifierRe.test(item.label)) {
         item.text = `[${JSON.stringify(item.label)}]`;

--- a/src/adapter/variableStore.ts
+++ b/src/adapter/variableStore.ts
@@ -88,7 +88,7 @@ const enum SortOrder {
 const customStringReprMaxLength = 1024;
 
 const identifierRe = /^[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*$/u;
-const privatePropertyRe = /^#[$_\u200C\u200D\p{ID_Continue}]*$/u;
+const privatePropertyRe = /^#[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*$/u;
 
 type AnyPropertyDescriptor = Cdp.Runtime.PropertyDescriptor | Cdp.Runtime.PrivatePropertyDescriptor;
 

--- a/src/adapter/variableStore.ts
+++ b/src/adapter/variableStore.ts
@@ -87,8 +87,8 @@ const enum SortOrder {
 
 const customStringReprMaxLength = 1024;
 
-const identifierRe = /^[$a-z_][0-9a-z_$]*$/i;
-const privatePropertyRe = /^#[0-9a-z_$]+$/i;
+const identifierRe = /^[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*$/u;
+const privatePropertyRe = /^#[$_\u200C\u200D\p{ID_Continue}]*$/u;
 
 type AnyPropertyDescriptor = Cdp.Runtime.PropertyDescriptor | Cdp.Runtime.PrivatePropertyDescriptor;
 

--- a/src/common/sourceMaps/renameScopeAndSourceMap.ts
+++ b/src/common/sourceMaps/renameScopeAndSourceMap.ts
@@ -12,8 +12,7 @@ enum Constant {
   SourceMapNameIndex = 4,
 }
 
-/** Very approximate regex for JS identifiers */
-const identifierRe = /[$a-z_][$0-9A-Z_$]*/iy;
+const identifierRe = /[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*/uy;
 
 export const extractScopeRenames = async (source: string, sourceMap: SourceMap) => {
   const toOffset = new PositionToOffset(source);

--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -315,7 +315,9 @@ export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
       return targetProgram;
     }
 
-    const resolve = this.vscode ? readConfig(this.vscode.workspace, Configuration.ResolveDebugEntrypoint) : true;
+    const resolve = this.vscode
+      ? readConfig(this.vscode.workspace, Configuration.ResolveDebugEntrypoint)
+      : true;
     if (!resolve) {
       return targetProgram;
     }


### PR DESCRIPTION
Fixes #2391

The new regular expression supports all JavaScript identifiers. It was taken from the following article: https://v8.dev/features/regexp-match-indices