### PR TITLE
Bump data-uri-to-buffer to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "acorn-loose": "^8.4.0",
         "astring": "^1.8.6",
         "color": "^4.2.3",
-        "data-uri-to-buffer": "^6.0.1",
+        "data-uri-to-buffer": "^6.0.2",
         "default-browser": "^5.2.1",
         "dotenv": "^16.4.1",
         "eslint-visitor-keys": "^3.4.3",
@@ -5571,9 +5571,10 @@
       }
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.1.tgz",
-      "integrity": "sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -21125,9 +21126,9 @@
       }
     },
     "data-uri-to-buffer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.1.tgz",
-      "integrity": "sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="
     },
     "data-view-buffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "acorn-loose": "^8.4.0",
     "astring": "^1.8.6",
     "color": "^4.2.3",
-    "data-uri-to-buffer": "^6.0.1",
+    "data-uri-to-buffer": "^6.0.2",
     "default-browser": "^5.2.1",
     "dotenv": "^16.4.1",
     "eslint-visitor-keys": "^3.4.3",

--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -315,7 +315,9 @@ export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
       return targetProgram;
     }
 
-    const resolve = this.vscode ? readConfig(this.vscode.workspace, Configuration.ResolveDebugEntrypoint) : true;
+    const resolve = this.vscode
+      ? readConfig(this.vscode.workspace, Configuration.ResolveDebugEntrypoint)
+      : true;
     if (!resolve) {
       return targetProgram;
     }


### PR DESCRIPTION
## Summary

- update `data-uri-to-buffer` from 6.0.1 to 6.0.2
- use the package's Node-specific implementation, which decodes base64 data URIs through the native `Buffer` API and improves handling of large inline source maps
- apply the formatter-required wrapping in `nodeLauncher.ts` so the repository's pre-commit hook passes

Related to #1911.

## Validation

- `npm run test:types`
- `npm run test:unit -- --grep 'resourceProvider|SourceMapFactory'`
- targeted `resourceProvider` data URI tests (2 passing)
- pre-commit `test:lint` and `test:types`
- verified Node resolves `data-uri-to-buffer/dist/node.js`

## Affected Insiders build

- Version: `1.134.0-insider`
- Commit: `0f3c3b53028901b912211a99b23232b76017bcfc`
- Architecture: `arm64`