### PR TITLE
extension: require VS Code 1.112

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
       },
       "engines": {
         "node": ">=10",
-        "vscode": "^1.80.0"
+        "vscode": "^1.112.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "description": "An extension for debugging Node.js programs and Chrome.",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.80.0",
+    "vscode": "^1.112.0",
     "node": ">=10"
   },
   "icon": "resources/logo.png",


### PR DESCRIPTION
## Summary

- require VS Code 1.112 or newer, the first shipped stable product that authorizes the `browser` proposal for `ms-vscode.js-debug`
- update the root lockfile metadata to match the source manifest
- cover stable and nightly packages, whose generated manifests both inherit the source engine range

## Compatibility evidence

- shipped VS Code 1.111.0 does not authorize `browser` for either `ms-vscode.js-debug` or `ms-vscode.js-debug-nightly`
- shipped VS Code 1.112.0 authorizes `browser` for both extension IDs
- the pending mandatory compatibility gate rejects the old `^1.80.0` range and accepts both rebuilt VSIXes with `^1.112.0` across 35 admitted released stable products through VS Code 1.135.0

## Validation

- `npm run compile -- package:prepare`
- `npm run compile -- package:prepare --nightly`
- proposed-API compatibility validation for both generated VSIXes
- `npm run test:types`
- `git diff --check`

## Tracking

- Mandatory proposal compatibility gate: microsoft/vscode-engineering#3705
- Related proposed-API compatibility incident: microsoft/vscode-remote-release#11815