### PR TITLE
fix: don't let a listener exception wedge EventEmitter

### DIFF
--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -105,9 +105,12 @@ export default class Connection {
     if (!session) {
       const disposedDate = this._disposedSessions.get(object.sessionId);
       if (!disposedDate) {
-        throw new Error(
-          `Unknown session id: ${object.sessionId} while processing: ${object.method}`,
+        this.logger.warn(
+          LogTag.Internal,
+          'Got message for an unknown session',
+          { sessionId: object.sessionId, method: object.method },
         );
+        return; // We just ignore messages for unknown sessions
       } else {
         const secondsAgo = (Date.now() - disposedDate.getTime()) / 1000.0;
         this.logger.warn(

--- a/src/common/events.test.ts
+++ b/src/common/events.test.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { expect } from 'chai';
+import { EventEmitter } from './events';
+
+describe('EventEmitter', () => {
+  it('keeps delivering events after a listener throws', () => {
+    const emitter = new EventEmitter<string>();
+    const delivered: string[] = [];
+
+    emitter.event(event => {
+      if (event === 'throws') {
+        throw new Error('listener error');
+      }
+
+      delivered.push(event);
+    });
+
+    emitter.fire('before');
+    expect(() => emitter.fire('throws')).to.throw('listener error');
+    emitter.fire('after');
+
+    expect(delivered).to.deep.equal(['before', 'after']);
+  });
+});

--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -57,11 +57,14 @@ export class EventEmitter<T> implements IDisposable {
     if (!this._deliveryQueue) this._deliveryQueue = [];
     for (const data of this._listeners) this._deliveryQueue.push({ data, event });
     if (!dispatch) return;
-    for (let index = 0; index < this._deliveryQueue.length; index++) {
-      const { data, event } = this._deliveryQueue[index];
-      data.listener.call(data.thisArg, event);
+    try {
+      for (let index = 0; index < this._deliveryQueue.length; index++) {
+        const { data, event } = this._deliveryQueue[index];
+        data.listener.call(data.thisArg, event);
+      }
+    } finally {
+      this._deliveryQueue = undefined;
     }
-    this._deliveryQueue = undefined;
   }
 
   dispose() {


### PR DESCRIPTION
> **Authored by GitHub Copilot** on behalf of @jruales.

Fixes #2401

## Problem

`EventEmitter.fire` leaves `_deliveryQueue` populated when a listener throws:

```ts
if (!dispatch) return;
for (let index = 0; index < this._deliveryQueue.length; index++) {
  const { data, event } = this._deliveryQueue[index];
  data.listener.call(data.thisArg, event);   // throws
}
this._deliveryQueue = undefined;             // never reached
```

Because the queue is never cleared, every later `fire` computes `dispatch === false`, enqueues, and returns without dispatching. **One listener exception permanently stops all delivery on that emitter.**

`Connection` reads its transport through `this._transport.onMessage(...)`, so this silently kills the CDP message pump for the whole connection. The debuggee is then never sent `Runtime.runIfWaitingForDebugger` and stays paused at startup — the window paints but accepts no input.

The exception comes from `Connection._onMessage`, which ignores messages for *disposed* sessions but throws for *unknown* ones. `Inspector.workerScriptLoaded` (a Blink event fired when a web worker finishes evaluating) is never handled by js-debug and can arrive before the worker's session is registered, since `targetCreated` is queued through `enqueueLifecycleFn`:

```
Error: Unknown session id: B9878282765DBAAB165E4A5851627507 while processing: Inspector.workerScriptLoaded
    at ut._onMessage (.../src/extension.js:58:8166)
    at U.fire        (.../src/extension.js:39:11654)
```

## Changes

- **`src/common/events.ts`** — restore `_deliveryQueue` in a `finally` block so one bad listener can't wedge the emitter. This is the load-bearing fix and is independent of the CDP specifics.
- **`src/cdp/connection.ts`** — treat unknown sessions the way disposed sessions are already treated (warn and ignore) instead of throwing.
- **`src/common/events.test.ts`** — regression test.

## Validation

- New test fails without the `events.ts` change (`expected [ 'before' ] to deeply equal [ 'before', 'after' ]`) and passes with it.
- `npm run test:unit` — **268 passing**. `tsc --noEmit` and `gulp lint` clean.
- End-to-end A/B: this extension built both ways, loaded into a real VS Code Insiders window via `--extensionDevelopmentPath`; same machine, repository (`microsoft/vscode`, Electron 42.8.1), isolated profile and launch compound, only this diff varying.

| Build | Outcome |
|---|---|
| Unpatched | Workbench freezes. Reproduced. |
| Patched | Works every time, across repeated runs. |

Happy to split the `connection.ts` change into a separate PR if you'd prefer to evaluate the two independently.
